### PR TITLE
Add macOS CI, quarantine workaround, and org URL migration

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,42 @@
+name: Build macOS AU + VST3
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:  # Manual trigger
+
+jobs:
+  build-macos:
+    name: macOS arm64 AU + VST3
+    runs-on: macos-14  # Apple Silicon runner
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive  # JUCE is a git submodule
+
+      - name: Configure CMake
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64 -DBUILD_OSD_TESTS=OFF
+
+      - name: Build Release
+        run: cmake --build build --config Release
+
+      - name: Remove quarantine flags
+        run: |
+          xattr -cr build/OpenSpatialDelay_artefacts/Release/AU/ 2>/dev/null || true
+          xattr -cr build/OpenSpatialDelay_artefacts/Release/VST3/ 2>/dev/null || true
+
+      - name: Upload macOS AU
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenSpatialDelay-macOS-AU
+          path: build/OpenSpatialDelay_artefacts/Release/AU/
+          retention-days: 90
+
+      - name: Upload macOS VST3
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenSpatialDelay-macOS-VST3
+          path: build/OpenSpatialDelay_artefacts/Release/VST3/
+          retention-days: 90

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -26,8 +26,25 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Upload Windows VST3
+        id: upload
         uses: actions/upload-artifact@v4
         with:
           name: OpenSpatialDelay-Windows-VST3
           path: build/OpenSpatialDelay_artefacts/Release/VST3/
           retention-days: 90
+
+      # ---------------------------------------------------------------
+      # SignPath code signing (free for open-source projects)
+      # Uncomment after applying at: https://signpath.io/solutions/open-source-community
+      # Requires SIGNPATH_API_TOKEN secret and SignPath project/policy configured.
+      # ---------------------------------------------------------------
+      # - name: Sign with SignPath
+      #   uses: signpath/github-action-submit-signing-request@v1
+      #   with:
+      #     api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+      #     organization-id: '<your-org-id>'
+      #     project-slug: 'open-spatial-delay'
+      #     signing-policy-slug: 'release-signing'
+      #     artifact-configuration-slug: 'vst3'
+      #     github-artifact-id: '${{ steps.upload.outputs.artifact-id }}'
+      #     wait-for-completion: true

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/AndrewRahman/OpenSpatialDelay/releases">Download</a> &middot;
+  <a href="https://github.com/Spatial-Media-Lab/OpenSpatialDelay/releases">Download</a> &middot;
   <a href="https://spatialmedialab.org">Spatial Media Lab</a> &middot;
   <a href="docs/OpenSpatialDelay_Manual_v1.0.pdf">User Manual</a>
 </p>
@@ -60,9 +60,9 @@ OpenSpatialDelay is the first plugin in the **Spatial Media Library** — an ope
 
 ### Download (recommended)
 
-Grab the latest release from the [Releases page](https://github.com/AndrewRahman/OpenSpatialDelay/releases).
+Grab the latest release from the [Releases page](https://github.com/Spatial-Media-Lab/OpenSpatialDelay/releases).
 
-- **macOS:** Download the AU and VST3 plugins and copy them to `~/Library/Audio/Plug-Ins/Components/` (AU) and `~/Library/Audio/Plug-Ins/VST3/` (VST3).
+- **macOS:** Download the AU and VST3 plugins and copy them to `~/Library/Audio/Plug-Ins/Components/` (AU) and `~/Library/Audio/Plug-Ins/VST3/` (VST3). Then remove the macOS quarantine flag — see [macOS security note](#macos-security-note) below.
 - **Windows:** Download the VST3 plugin and copy it to `C:\Program Files\Common Files\VST3\`.
 
 ### Build from source
@@ -70,7 +70,7 @@ Grab the latest release from the [Releases page](https://github.com/AndrewRahman
 Requires CMake 3.22+, a C++17 compiler, and zlib.
 
 ```bash
-git clone --recursive https://github.com/AndrewRahman/OpenSpatialDelay.git
+git clone --recursive https://github.com/Spatial-Media-Lab/OpenSpatialDelay.git
 cd OpenSpatialDelay
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build --config Release
@@ -82,6 +82,17 @@ On macOS, the post-build script automatically copies the AU and VST3 plugins to 
 - [JUCE 8](https://juce.com/) (git submodule)
 - [libmysofa](https://github.com/hoene/libmysofa) v1.3.2 (CMake FetchContent)
 - zlib (system on macOS, [vcpkg](https://vcpkg.io/) on Windows)
+
+### macOS security note
+
+OpenSpatialDelay is not yet notarized with Apple. macOS will block the plugin on first launch with a "cannot be verified" warning. To fix this, open Terminal and run:
+
+```bash
+xattr -cr ~/Library/Audio/Plug-Ins/VST3/OpenSpatialDelay*.vst3
+xattr -cr ~/Library/Audio/Plug-Ins/Components/OpenSpatialDelay*.component
+```
+
+Then restart your DAW. You only need to do this once per download.
 
 ## Quick start
 
@@ -116,7 +127,7 @@ OpenSpatialDelay is open source and contributions are welcome. If you'd like to 
 2. Create a feature branch
 3. Submit a pull request
 
-For bug reports and feature requests, please [open an issue](https://github.com/AndrewRahman/OpenSpatialDelay/issues).
+For bug reports and feature requests, please [open an issue](https://github.com/Spatial-Media-Lab/OpenSpatialDelay/issues).
 
 ## License
 

--- a/scripts/install_plugins.sh
+++ b/scripts/install_plugins.sh
@@ -14,6 +14,7 @@ if [ -d "$AU_SRC" ]; then
     mkdir -p "$HOME/Library/Audio/Plug-Ins/Components"
     rm -rf "$AU_DEST"
     cp -R "$AU_SRC" "$AU_DEST"
+    xattr -cr "$AU_DEST" 2>/dev/null
     echo "AU installed to $AU_DEST"
 fi
 
@@ -23,6 +24,7 @@ if [ -d "$VST3_SRC" ]; then
     if [ -w "$VST3_DIR" ]; then
         rm -rf "$VST3_DEST"
         cp -R "$VST3_SRC" "$VST3_DEST"
+        xattr -cr "$VST3_DEST" 2>/dev/null
         echo "VST3 installed to $VST3_DEST"
     else
         echo "WARNING: VST3 dir not writable. Run once:"


### PR DESCRIPTION
## Summary
- Add `build-macos.yml` GitHub Actions workflow for arm64 AU + VST3 builds on macos-14 runner
- Add `xattr -cr` quarantine removal to `install_plugins.sh` and CI post-build step so macOS doesn't block the unsigned plugin
- Add macOS security note to README explaining the quarantine workaround for downloaded builds
- Migrate all GitHub URLs from `AndrewRahman/` to `Spatial-Media-Lab/` org
- Add commented-out SignPath code signing placeholder to Windows workflow for future use

## Test plan
- [x] All 162 Catch2 tests pass (1255 assertions)
- [x] macOS Release build succeeds
- [ ] Verify GitHub Actions runs both `build-macos` and `build-windows` workflows after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)