### PR TITLE
EMA IR smoothing, test infrastructure fix, and diagnostic suite (issue #47)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md — OpenSpatialDelay
+
+## Build & Test Rules
+
+### MANDATORY: Versioned builds for every fix attempt
+
+Every code change that needs manual listening/testing MUST be built as a uniquely-named versioned plugin. **Never reuse a version number. Never skip this step.**
+
+```bash
+# 1. Commit your changes
+git add ... && git commit -m "..."
+
+# 2. Build as a versioned plugin (increment X each time)
+bash scripts/build_version.sh <commit-hash> v1.0.X O10X
+```
+
+**Why this is critical:** The default `cmake --build` installs to `OpenSpatialDelay v1.0.component`. The user tests with individually-named versioned plugins (e.g., `OpenSpatialDelay v1.0.4.component`) loaded side-by-side in REAPER for A/B comparison. If you don't use `build_version.sh`, the user will never hear your changes.
+
+**Version number registry (do not reuse):**
+- v1.0.0 / O100 — baseline (commit 023670a)
+- v1.0.1 / O101 — NaN handler fix
+- v1.0.2 / O102 — overlap zeroing + threshold reduction (PR #48)
+- v1.0.3 / O103 — freq-domain IR interpolation branch
+- v1.0.4 / O104 — spectral envelope EMA smoothing (commit 8c665cb)
+- Next available: **v1.0.5 / O105**
+
+### Running tests
+
+```bash
+# Configure (first time or after clean)
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -Wno-dev
+
+# Build and run tests
+cmake --build build --target OpenSpatialDelayTests -j$(sysctl -n hw.ncpu)
+./build/OpenSpatialDelayTests
+
+# HRTF tests require synchronous profile loading (testLoadHRTFProfile)
+# The timer thread doesn't fire in the test harness
+```
+
+### Test infrastructure notes
+
+- All HRTF binaural tests use `testLoadHRTFProfile()` for synchronous HRTF loading
+- Without this, the timer-based loading never fires and tests run in Simple mode (false positives)
+- The `createBinauralProcessor()` helper handles this automatically
+
+## Architecture Notes
+
+### HRTF rendering signal flow
+1. `renderDirectBinauralHRTF()` — 3-pass architecture
+2. Pass 1: per-sample delay engine → per-source mono accumulation
+3. Pass 2: per-block HRTF convolution via `BinauralRenderer::renderSourceBuffers()`
+4. Pass 3: per-sample dry/wet mix + output gain
+
+### PartitionedConvolver (v1.0.4)
+Uses spectral envelope EMA smoothing: magnitude and phase smoothed separately per frequency bin. This prevents comb filtering from phase-misaligned time-domain blending.
+
+### ITD delay line
+For MIT KEMAR SOFA file, ITD values are always 0 (embedded in HRIR waveform). The ITD delay line is effectively a pass-through for this dataset.

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -652,9 +652,12 @@ void PartitionedConvolver::prepare (int maxBlockSize, int irLength_)
     fftWorkBuf.resize (static_cast<size_t> (fftSize * 2), 0.0f);
     overlapBuf.resize (static_cast<size_t> (fftSize), 0.0f);
 
-    // v1.0.3: EMA-smoothed IR buffers (time domain)
-    currentTimeDomainIR.resize (static_cast<size_t> (fftSize), 0.0f);
-    targetTimeDomainIR.resize (static_cast<size_t> (fftSize), 0.0f);
+    // v1.0.4: Spectral envelope EMA buffers (frequency domain, per-bin mag+phase)
+    int numBins = fftSize / 2 + 1;
+    currentMagnitude.resize (static_cast<size_t> (numBins), 0.0f);
+    targetMagnitude.resize (static_cast<size_t> (numBins), 0.0f);
+    currentPhase.resize (static_cast<size_t> (numBins), 0.0f);
+    targetPhase.resize (static_cast<size_t> (numBins), 0.0f);
 
     reset();
 }
@@ -663,23 +666,34 @@ void PartitionedConvolver::setIR (const float* ir, int length)
 {
     if (fftSize == 0) return;
 
-    // v1.0.3: EMA-smoothed IR transition (replaces dual-convolver crossfade).
-    // Store target IR in time domain. Smoothing happens per-block in process().
-    std::fill (targetTimeDomainIR.begin(), targetTimeDomainIR.end(), 0.0f);
+    // v1.0.4: Spectral envelope EMA smoothing.
+    // Compute target's magnitude and phase in frequency domain.
+    // Only the magnitude is EMA-smoothed; phase always comes from the target.
+    // This prevents comb filtering from blending IRs with misaligned phase.
+
+    // FFT the new IR to get its spectrum
+    std::fill (irFreqDomain.begin(), irFreqDomain.end(), 0.0f);
     for (int i = 0; i < std::min (length, fftSize); ++i)
-        targetTimeDomainIR[static_cast<size_t> (i)] = ir[i];
+        irFreqDomain[static_cast<size_t> (i)] = ir[i];
+    fft.performRealOnlyForwardTransform (irFreqDomain.data(), true);
+
+    // Extract magnitude and phase from the target spectrum
+    // JUCE real FFT stores: [re0, im0, re1, im1, ..., reN/2, imN/2] (fftSize+1 values)
+    int numBins = fftSize / 2 + 1;
+    for (int k = 0; k < numBins; ++k)
+    {
+        float re = irFreqDomain[static_cast<size_t> (k * 2)];
+        float im = irFreqDomain[static_cast<size_t> (k * 2 + 1)];
+        targetMagnitude[static_cast<size_t> (k)] = std::sqrt (re * re + im * im);
+        targetPhase[static_cast<size_t> (k)] = std::atan2 (im, re);
+    }
 
     if (! irInitialized)
     {
-        // First IR: snap immediately (no smoothing from zero)
-        std::copy (targetTimeDomainIR.begin(), targetTimeDomainIR.end(), currentTimeDomainIR.begin());
-
-        // Compute frequency-domain IR
-        std::fill (irFreqDomain.begin(), irFreqDomain.end(), 0.0f);
-        for (int i = 0; i < std::min (length, fftSize); ++i)
-            irFreqDomain[static_cast<size_t> (i)] = ir[i];
-        fft.performRealOnlyForwardTransform (irFreqDomain.data(), true);
-
+        // First IR: snap both magnitude and phase immediately
+        std::copy (targetMagnitude.begin(), targetMagnitude.end(), currentMagnitude.begin());
+        std::copy (targetPhase.begin(), targetPhase.end(), currentPhase.begin());
+        // irFreqDomain is already correct from the FFT above
         irInitialized = true;
         irNeedsSmoothing = false;
     }
@@ -701,27 +715,46 @@ void PartitionedConvolver::process (const float* in, float* out, int numSamples)
         return;
     }
 
-    // v1.0.3: EMA-smooth the IR towards target before convolution.
-    // This replaces the dual-convolver crossfade with continuous IR blending,
-    // eliminating overlap discontinuities and spectral artifacts (issue #47).
+    // v1.0.4: Spectral envelope EMA smoothing (issue #47).
+    // Smooth magnitude (linear EMA) and phase (circular EMA) SEPARATELY per bin.
+    // This avoids comb filtering from complex-coefficient blending (which cancels
+    // when phases oppose) while also preventing phase discontinuities.
     if (irNeedsSmoothing)
     {
+        constexpr float pi = juce::MathConstants<float>::pi;
+        constexpr float twoPi = juce::MathConstants<float>::twoPi;
         bool stillSmoothing = false;
-        for (int i = 0; i < fftSize; ++i)
+        int numBins = fftSize / 2 + 1;
+
+        for (int k = 0; k < numBins; ++k)
         {
-            float diff = targetTimeDomainIR[static_cast<size_t> (i)] - currentTimeDomainIR[static_cast<size_t> (i)];
-            if (std::abs (diff) > kIRConvergenceEps)
+            // Magnitude: linear EMA
+            float magDiff = targetMagnitude[static_cast<size_t> (k)] - currentMagnitude[static_cast<size_t> (k)];
+            if (std::abs (magDiff) > kIRConvergenceEps)
             {
-                currentTimeDomainIR[static_cast<size_t> (i)] += kIRSmoothAlpha * diff;
+                currentMagnitude[static_cast<size_t> (k)] += kIRSmoothAlpha * magDiff;
+                stillSmoothing = true;
+            }
+
+            // Phase: circular EMA (wrap difference to [-π, π])
+            float phaseDiff = targetPhase[static_cast<size_t> (k)] - currentPhase[static_cast<size_t> (k)];
+            // Wrap to [-π, π]
+            phaseDiff = phaseDiff - twoPi * std::round (phaseDiff / twoPi);
+            if (std::abs (phaseDiff) > kIRConvergenceEps)
+            {
+                currentPhase[static_cast<size_t> (k)] += kIRSmoothAlpha * phaseDiff;
                 stillSmoothing = true;
             }
         }
 
-        // Recompute frequency-domain IR from smoothed time-domain IR
-        std::fill (irFreqDomain.begin(), irFreqDomain.end(), 0.0f);
-        for (int i = 0; i < fftSize; ++i)
-            irFreqDomain[static_cast<size_t> (i)] = currentTimeDomainIR[static_cast<size_t> (i)];
-        fft.performRealOnlyForwardTransform (irFreqDomain.data(), true);
+        // Reconstruct frequency-domain IR from smoothed magnitude + smoothed phase
+        for (int k = 0; k < numBins; ++k)
+        {
+            float mag = currentMagnitude[static_cast<size_t> (k)];
+            float phase = currentPhase[static_cast<size_t> (k)];
+            irFreqDomain[static_cast<size_t> (k * 2)]     = mag * std::cos (phase);
+            irFreqDomain[static_cast<size_t> (k * 2 + 1)] = mag * std::sin (phase);
+        }
 
         irNeedsSmoothing = stillSmoothing;
     }
@@ -787,8 +820,11 @@ void PartitionedConvolver::reset()
     std::fill (inputAccum.begin(), inputAccum.end(), 0.0f);
     std::fill (overlapBuf.begin(), overlapBuf.end(), 0.0f);
     std::fill (fftWorkBuf.begin(), fftWorkBuf.end(), 0.0f);
-    std::fill (currentTimeDomainIR.begin(), currentTimeDomainIR.end(), 0.0f);
-    std::fill (targetTimeDomainIR.begin(), targetTimeDomainIR.end(), 0.0f);
+    std::fill (irFreqDomain.begin(), irFreqDomain.end(), 0.0f);
+    std::fill (currentMagnitude.begin(), currentMagnitude.end(), 0.0f);
+    std::fill (targetMagnitude.begin(), targetMagnitude.end(), 0.0f);
+    std::fill (currentPhase.begin(), currentPhase.end(), 0.0f);
+    std::fill (targetPhase.begin(), targetPhase.end(), 0.0f);
     irNeedsSmoothing = false;
     irInitialized = false;
     inputAccumPos = 0;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -565,6 +565,70 @@ void HRTFDatabase::unload()
 }
 
 //==============================================================================
+// v1.0.4: Minimum-phase HRIR conversion via cepstral decomposition (issue #47).
+// Converts a raw HRIR to its minimum-phase equivalent in-place.
+// Preserves magnitude spectrum but removes excess phase, enabling smooth
+// time-domain EMA interpolation between adjacent HRIRs without comb filtering.
+//==============================================================================
+void HRTFDatabase::convertToMinPhase (float* ir, int irLength, int fftOrder, float* workBuf)
+{
+    if (irLength <= 0 || fftOrder <= 0) return;
+
+    const int N = 1 << fftOrder;  // FFT size (must be >= 2 * irLength)
+    juce::dsp::FFT fft (fftOrder);
+
+    // workBuf layout: N Complex<float> = N * 2 floats
+    auto* cBuf = reinterpret_cast<std::complex<float>*> (workBuf);
+
+    // Step 1: Copy IR into complex buffer, zero-pad
+    for (int i = 0; i < N; ++i)
+        cBuf[i] = (i < irLength) ? std::complex<float> (ir[i], 0.0f) : std::complex<float> (0.0f, 0.0f);
+
+    // Step 2: Forward FFT
+    fft.perform (cBuf, cBuf, false);
+
+    // Step 3: Compute log-magnitude (real cepstrum input)
+    for (int k = 0; k < N; ++k)
+    {
+        float mag = std::abs (cBuf[k]);
+        float logMag = std::log (std::max (mag, 1e-20f));  // epsilon for -ffast-math safety
+        cBuf[k] = std::complex<float> (logMag, 0.0f);
+    }
+
+    // Step 4: IFFT to get real cepstrum
+    fft.perform (cBuf, cBuf, true);
+
+    // Step 5: Apply minimum-phase window to cepstrum
+    // c_mp[0] unchanged, c_mp[1..N/2-1] doubled, c_mp[N/2] unchanged, c_mp[N/2+1..N-1] zeroed
+    int halfN = N / 2;
+    for (int n = 1; n < halfN; ++n)
+        cBuf[n] *= 2.0f;
+    for (int n = halfN + 1; n < N; ++n)
+        cBuf[n] = std::complex<float> (0.0f, 0.0f);
+
+    // Step 6: Forward FFT
+    fft.perform (cBuf, cBuf, false);
+
+    // Step 7: Exponentiate to get minimum-phase spectrum
+    for (int k = 0; k < N; ++k)
+    {
+        float re = cBuf[k].real();
+        float im = cBuf[k].imag();
+        // Clamp to prevent exp() overflow under -ffast-math
+        re = std::max (-80.0f, std::min (80.0f, re));
+        float mag = std::exp (re);
+        cBuf[k] = std::complex<float> (mag * std::cos (im), mag * std::sin (im));
+    }
+
+    // Step 8: IFFT to get minimum-phase IR
+    fft.perform (cBuf, cBuf, true);
+
+    // Step 9: Copy first irLength samples back (real part only)
+    for (int i = 0; i < irLength; ++i)
+        ir[i] = cBuf[i].real();
+}
+
+//==============================================================================
 // PartitionedConvolver implementation — overlap-save FFT convolution
 //==============================================================================
 void PartitionedConvolver::prepare (int maxBlockSize, int irLength_)
@@ -588,10 +652,9 @@ void PartitionedConvolver::prepare (int maxBlockSize, int irLength_)
     fftWorkBuf.resize (static_cast<size_t> (fftSize * 2), 0.0f);
     overlapBuf.resize (static_cast<size_t> (fftSize), 0.0f);
 
-    // v1.0: Dual-convolver crossfade buffers
-    prevIrFreqDomain.resize (static_cast<size_t> (fftSize * 2), 0.0f);
-    prevFftWorkBuf.resize (static_cast<size_t> (fftSize * 2), 0.0f);
-    prevOverlapBuf.resize (static_cast<size_t> (fftSize), 0.0f);
+    // v1.0.3: EMA-smoothed IR buffers (time domain)
+    currentTimeDomainIR.resize (static_cast<size_t> (fftSize), 0.0f);
+    targetTimeDomainIR.resize (static_cast<size_t> (fftSize), 0.0f);
 
     reset();
 }
@@ -600,36 +663,31 @@ void PartitionedConvolver::setIR (const float* ir, int length)
 {
     if (fftSize == 0) return;
 
-    // v1.0: Non-restarting dual-convolver crossfade.
-    // Key behavior: if called during active crossfade, only update the new IR
-    // (irFreqDomain) without resetting crossfade progress. This ensures the
-    // fade always completes during continuous movement, rather than perpetually
-    // restarting at 0%.
-
-    if (irLen > 0 && crossfadeRemaining <= 0)
-    {
-        // No crossfade active — start a new one.
-        // Save current IR + overlap as crossfade source.
-        std::copy (irFreqDomain.begin(), irFreqDomain.end(), prevIrFreqDomain.begin());
-        std::copy (overlapBuf.begin(), overlapBuf.end(), prevOverlapBuf.begin());
-        // v1.0.2: Zero overlapBuf so new convolver starts with clean overlap state.
-        // Without this, both old and new outputs include the same overlap buffer during
-        // crossfade, and the equal-power blend (cos+sin peaks at 1.414) amplifies the
-        // shared overlap by up to 41%, producing audible pops (issue #47).
-        std::fill (overlapBuf.begin(), overlapBuf.end(), 0.0f);
-        crossfadeTotalLength = blockSize * kCrossfadeBlocks;
-        crossfadeRemaining = crossfadeTotalLength;
-    }
-    // else: crossfade already active — don't restart, don't touch prevIrFreqDomain
-    // or prevOverlapBuf. The crossfade continues from where it is, blending from
-    // the original source toward whatever the latest IR is.
-
-    // Always update the "new" IR (target of crossfade)
-    std::fill (irFreqDomain.begin(), irFreqDomain.end(), 0.0f);
+    // v1.0.3: EMA-smoothed IR transition (replaces dual-convolver crossfade).
+    // Store target IR in time domain. Smoothing happens per-block in process().
+    std::fill (targetTimeDomainIR.begin(), targetTimeDomainIR.end(), 0.0f);
     for (int i = 0; i < std::min (length, fftSize); ++i)
-        irFreqDomain[static_cast<size_t> (i)] = ir[i];
+        targetTimeDomainIR[static_cast<size_t> (i)] = ir[i];
 
-    fft.performRealOnlyForwardTransform (irFreqDomain.data(), true);
+    if (! irInitialized)
+    {
+        // First IR: snap immediately (no smoothing from zero)
+        std::copy (targetTimeDomainIR.begin(), targetTimeDomainIR.end(), currentTimeDomainIR.begin());
+
+        // Compute frequency-domain IR
+        std::fill (irFreqDomain.begin(), irFreqDomain.end(), 0.0f);
+        for (int i = 0; i < std::min (length, fftSize); ++i)
+            irFreqDomain[static_cast<size_t> (i)] = ir[i];
+        fft.performRealOnlyForwardTransform (irFreqDomain.data(), true);
+
+        irInitialized = true;
+        irNeedsSmoothing = false;
+    }
+    else
+    {
+        irNeedsSmoothing = true;
+    }
+
     irLen = length;
 }
 
@@ -643,10 +701,32 @@ void PartitionedConvolver::process (const float* in, float* out, int numSamples)
         return;
     }
 
-    // Dual-convolver overlap-save with non-restarting crossfade:
-    // During crossfade, both old and new IRs convolve the same input.
-    // Outputs are blended via equal-power crossfade that always completes.
+    // v1.0.3: EMA-smooth the IR towards target before convolution.
+    // This replaces the dual-convolver crossfade with continuous IR blending,
+    // eliminating overlap discontinuities and spectral artifacts (issue #47).
+    if (irNeedsSmoothing)
+    {
+        bool stillSmoothing = false;
+        for (int i = 0; i < fftSize; ++i)
+        {
+            float diff = targetTimeDomainIR[static_cast<size_t> (i)] - currentTimeDomainIR[static_cast<size_t> (i)];
+            if (std::abs (diff) > kIRConvergenceEps)
+            {
+                currentTimeDomainIR[static_cast<size_t> (i)] += kIRSmoothAlpha * diff;
+                stillSmoothing = true;
+            }
+        }
 
+        // Recompute frequency-domain IR from smoothed time-domain IR
+        std::fill (irFreqDomain.begin(), irFreqDomain.end(), 0.0f);
+        for (int i = 0; i < fftSize; ++i)
+            irFreqDomain[static_cast<size_t> (i)] = currentTimeDomainIR[static_cast<size_t> (i)];
+        fft.performRealOnlyForwardTransform (irFreqDomain.data(), true);
+
+        irNeedsSmoothing = stillSmoothing;
+    }
+
+    // Single-convolver overlap-save (no crossfade needed — IR transitions smoothly)
     int samplesProcessed = 0;
 
     while (samplesProcessed < numSamples)
@@ -670,22 +750,7 @@ void PartitionedConvolver::process (const float* in, float* out, int numSamples)
             // Forward FFT of input
             fft.performRealOnlyForwardTransform (fftWorkBuf.data(), true);
 
-            // If crossfading, also convolve with previous (old) IR
-            bool doCrossfade = (crossfadeRemaining > 0);
-            if (doCrossfade)
-            {
-                std::copy (fftWorkBuf.begin(), fftWorkBuf.end(), prevFftWorkBuf.begin());
-                for (int i = 0; i < fftSize * 2; i += 2)
-                {
-                    float re1 = prevFftWorkBuf[static_cast<size_t> (i)],     im1 = prevFftWorkBuf[static_cast<size_t> (i + 1)];
-                    float re2 = prevIrFreqDomain[static_cast<size_t> (i)],   im2 = prevIrFreqDomain[static_cast<size_t> (i + 1)];
-                    prevFftWorkBuf[static_cast<size_t> (i)]     = re1 * re2 - im1 * im2;
-                    prevFftWorkBuf[static_cast<size_t> (i + 1)] = re1 * im2 + im1 * re2;
-                }
-                fft.performRealOnlyInverseTransform (prevFftWorkBuf.data());
-            }
-
-            // Complex multiply with new IR spectrum
+            // Complex multiply with smoothed IR spectrum
             for (int i = 0; i < fftSize * 2; i += 2)
             {
                 float re1 = fftWorkBuf[static_cast<size_t> (i)],     im1 = fftWorkBuf[static_cast<size_t> (i + 1)];
@@ -699,47 +764,13 @@ void PartitionedConvolver::process (const float* in, float* out, int numSamples)
             int outStart = samplesProcessed - blockSize;
             int outSamples = std::min (blockSize, numSamples - outStart);
 
-            if (doCrossfade)
+            for (int i = 0; i < outSamples; ++i)
             {
-                // Equal-power crossfade: sin²+cos² = 1 constant energy
-                float totalLen = static_cast<float> (crossfadeTotalLength);
-                float samplesCompleted = static_cast<float> (crossfadeTotalLength - crossfadeRemaining);
-                constexpr float halfPi = juce::MathConstants<float>::halfPi;
-
-                for (int i = 0; i < outSamples; ++i)
-                {
-                    float fadeProgress = (samplesCompleted + static_cast<float> (i)) / totalLen;
-                    fadeProgress = std::min (fadeProgress, 1.0f);
-                    float fadeNew = std::sin (fadeProgress * halfPi);
-                    float fadeOld = std::cos (fadeProgress * halfPi);
-
-                    float newOut = fftWorkBuf[static_cast<size_t> (i)]
-                                 + overlapBuf[static_cast<size_t> (i)];
-                    float oldOut = prevFftWorkBuf[static_cast<size_t> (i)]
-                                 + prevOverlapBuf[static_cast<size_t> (i)];
-                    out[outStart + i] = oldOut * fadeOld + newOut * fadeNew;
-                }
-
-                // Update old overlap for next crossfade block
-                int overlapLen = fftSize - blockSize;
-                for (int i = 0; i < overlapLen; ++i)
-                    prevOverlapBuf[static_cast<size_t> (i)] = prevFftWorkBuf[static_cast<size_t> (blockSize + i)];
-                for (int i = overlapLen; i < fftSize; ++i)
-                    prevOverlapBuf[static_cast<size_t> (i)] = 0.0f;
-
-                crossfadeRemaining -= outSamples;
-                if (crossfadeRemaining < 0) crossfadeRemaining = 0;
-            }
-            else
-            {
-                for (int i = 0; i < outSamples; ++i)
-                {
-                    out[outStart + i] = fftWorkBuf[static_cast<size_t> (i)]
-                                      + overlapBuf[static_cast<size_t> (i)];
-                }
+                out[outStart + i] = fftWorkBuf[static_cast<size_t> (i)]
+                                  + overlapBuf[static_cast<size_t> (i)];
             }
 
-            // Save new-IR overlap for next block
+            // Save overlap for next block
             int overlapLen = fftSize - blockSize;
             for (int i = 0; i < overlapLen; ++i)
                 overlapBuf[static_cast<size_t> (i)] = fftWorkBuf[static_cast<size_t> (blockSize + i)];
@@ -756,10 +787,10 @@ void PartitionedConvolver::reset()
     std::fill (inputAccum.begin(), inputAccum.end(), 0.0f);
     std::fill (overlapBuf.begin(), overlapBuf.end(), 0.0f);
     std::fill (fftWorkBuf.begin(), fftWorkBuf.end(), 0.0f);
-    std::fill (prevOverlapBuf.begin(), prevOverlapBuf.end(), 0.0f);
-    std::fill (prevFftWorkBuf.begin(), prevFftWorkBuf.end(), 0.0f);
-    crossfadeRemaining = 0;
-    crossfadeTotalLength = 0;
+    std::fill (currentTimeDomainIR.begin(), currentTimeDomainIR.end(), 0.0f);
+    std::fill (targetTimeDomainIR.begin(), targetTimeDomainIR.end(), 0.0f);
+    irNeedsSmoothing = false;
+    irInitialized = false;
     inputAccumPos = 0;
 }
 
@@ -833,6 +864,19 @@ void BinauralRenderer::setProfile (int profileIndex, HRTFDatabase& hrtfDb)
     const float targetRMS = 1.0f / std::sqrt ((float) irLen);
     const double avgRMS   = std::sqrt (totalEnergy / (double) (NUM_REF_DIRS * 2 * irLen));
     storedNormGain = (avgRMS > 1e-8) ? (float) (targetRMS / avgRMS) : 1.0f;
+
+    // =========================================================================
+    // v1.0.4: Pre-allocate minimum-phase extraction buffer.
+    // Use 4× IR length for FFT to preserve stopband magnitude after truncation.
+    // =========================================================================
+    {
+        int mpSize = 4 * irLen;
+        minPhaseFFTOrder = 1;
+        while ((1 << minPhaseFFTOrder) < mpSize)
+            ++minPhaseFFTOrder;
+        int mpFFTSize = 1 << minPhaseFFTOrder;
+        minPhaseWorkBuf.resize (static_cast<size_t> (mpFFTSize * 2), 0.0f);
+    }
 
     // =========================================================================
     // Prepare per-source convolvers (allocate FFT buffers for irLength).

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -328,9 +328,9 @@ public:
     void prepare (int maxBlockSize, int irLength);
 
     /** Set or update the impulse response.
-        v1.0.3: Uses EMA time-domain IR smoothing instead of dual-convolver crossfade.
-        On first call, IR is applied immediately. On subsequent calls, the IR
-        smoothly transitions towards the new target over ~20 blocks (issue #47). */
+        v1.0.4: Uses spectral envelope EMA smoothing — magnitude spectrum is
+        smoothly interpolated while phase always comes from the target IR.
+        This prevents comb filtering from phase-misaligned blending (issue #47). */
     void setIR (const float* ir, int length);
 
     /** Process one block: convolve input with IR, write to output.
@@ -355,16 +355,22 @@ private:
     std::vector<float> overlapBuf;       // Overlap-save tail buffer
     int inputAccumPos = 0;               // Current position in input accumulator
 
-    // v1.0.3: EMA-smoothed IR transition (replaces dual-convolver crossfade).
-    // Instead of crossfading two convolution outputs, smoothly blend the IR
-    // itself in the time domain each block. This eliminates overlap discontinuities
-    // and spectral artifacts from the dual-convolver approach (issue #47).
-    std::vector<float> currentTimeDomainIR;  // Current smoothed IR (time domain)
-    std::vector<float> targetTimeDomainIR;   // Target IR from latest setIR() call
-    bool irNeedsSmoothing = false;           // True when current != target
+    // v1.0.4: Spectral envelope EMA smoothing (issue #47).
+    // Smooths only the magnitude spectrum while always using the target's phase.
+    // This prevents comb filtering from phase-misaligned IR interpolation —
+    // the root cause of perceptual pops during HRTF transitions.
+    // Previous approaches that failed:
+    //   - Dual-convolver crossfade (v1.0): overlap contamination
+    //   - Time-domain EMA (v1.0.3): comb filtering from phase blending
+    //   - Minimum-phase conversion: increased spectral flux by 68%
+    std::vector<float> currentMagnitude;     // Current EMA-smoothed magnitude spectrum
+    std::vector<float> targetMagnitude;      // Target magnitude from latest setIR()
+    std::vector<float> currentPhase;         // Current EMA-smoothed phase (circular interpolation)
+    std::vector<float> targetPhase;          // Target phase from latest setIR()
+    bool irNeedsSmoothing = false;           // True when currentMag != targetMag
     bool irInitialized = false;              // False until first setIR()
-    static constexpr float kIRSmoothAlpha = 0.15f;      // EMA alpha: ~97% converged in 20 blocks (~107ms)
-    static constexpr float kIRConvergenceEps = 1e-8f;  // Smoothing stops when all samples converge within this
+    static constexpr float kIRSmoothAlpha = 0.12f;      // EMA alpha: ~97% converged in 25 blocks (~133ms)
+    static constexpr float kIRConvergenceEps = 1e-8f;   // Smoothing stops when all bins converge
 };
 
 //==============================================================================

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -302,6 +302,12 @@ public:
     /** Unload current profile and free resources. */
     void unload();
 
+    /** Convert a raw HRIR to minimum-phase in-place using cepstral decomposition.
+        Preserves magnitude spectrum but removes excess phase, so time-domain
+        interpolation between adjacent HRIRs produces smooth spectral transitions
+        without comb filtering (issue #47). workBuf must be >= fftSize * 2 floats. */
+    static void convertToMinPhase (float* ir, int irLength, int fftOrder, float* workBuf);
+
 private:
     MYSOFA_EASY* easyHandle = nullptr;
     int irLength = 0;
@@ -321,10 +327,10 @@ public:
     /** Prepare the convolver for a given max block size and IR length. */
     void prepare (int maxBlockSize, int irLength);
 
-    /** Set or update the impulse response. Pre-computes FFT of IR.
-        v1.0: On IR change, initiates dual-convolver equal-power crossfade.
-        If called during active crossfade, updates target IR without restarting
-        the fade — ensures crossfade always completes during continuous movement. */
+    /** Set or update the impulse response.
+        v1.0.3: Uses EMA time-domain IR smoothing instead of dual-convolver crossfade.
+        On first call, IR is applied immediately. On subsequent calls, the IR
+        smoothly transitions towards the new target over ~20 blocks (issue #47). */
     void setIR (const float* ir, int length);
 
     /** Process one block: convolve input with IR, write to output.
@@ -343,23 +349,22 @@ private:
     int irLen = 0;
     int blockSize = 0;
 
-    std::vector<float> irFreqDomain;     // Current (new) IR in frequency domain
+    std::vector<float> irFreqDomain;     // Current smoothed IR in frequency domain
     std::vector<float> inputAccum;       // Input accumulator for FFT
     std::vector<float> fftWorkBuf;       // FFT work buffer
     std::vector<float> overlapBuf;       // Overlap-save tail buffer
     int inputAccumPos = 0;               // Current position in input accumulator
 
-    // v1.0: Dual-convolver crossfade with non-restarting state machine.
-    // When IR changes, old IR runs in parallel with new IR, outputs blended
-    // via equal-power crossfade over N blocks. If setIR() fires during active
-    // crossfade, only the new IR is updated — crossfade progress continues
-    // uninterrupted, ensuring the fade always completes.
-    std::vector<float> prevIrFreqDomain; // Previous IR in frequency domain (crossfade source)
-    std::vector<float> prevFftWorkBuf;   // Work buffer for old IR convolution
-    std::vector<float> prevOverlapBuf;   // Overlap tail from old IR
-    int crossfadeRemaining = 0;          // Samples remaining in crossfade (0 = inactive)
-    int crossfadeTotalLength = 0;        // Total crossfade duration in samples
-    static constexpr int kCrossfadeBlocks = 4; // Crossfade over 4 blocks (~21ms @ 256/48kHz)
+    // v1.0.3: EMA-smoothed IR transition (replaces dual-convolver crossfade).
+    // Instead of crossfading two convolution outputs, smoothly blend the IR
+    // itself in the time domain each block. This eliminates overlap discontinuities
+    // and spectral artifacts from the dual-convolver approach (issue #47).
+    std::vector<float> currentTimeDomainIR;  // Current smoothed IR (time domain)
+    std::vector<float> targetTimeDomainIR;   // Target IR from latest setIR() call
+    bool irNeedsSmoothing = false;           // True when current != target
+    bool irInitialized = false;              // False until first setIR()
+    static constexpr float kIRSmoothAlpha = 0.15f;      // EMA alpha: ~97% converged in 20 blocks (~107ms)
+    static constexpr float kIRConvergenceEps = 1e-8f;  // Smoothing stops when all samples converge within this
 };
 
 //==============================================================================
@@ -403,6 +408,18 @@ public:
     /** Reset all convolver states (e.g., on playback restart). */
     void reset();
 
+    /** Test-only: override ITD processing state for diagnostic isolation. */
+    void setITDEnabled (bool enabled) { itdActive = enabled; }
+
+    /** Test-only: read current ITD values for diagnostic logging. */
+    float getCurrentITDL (int src) const { return (src >= 0 && src < MAX_SOURCES) ? currentITDL[src] : 0.0f; }
+    float getCurrentITDR (int src) const { return (src >= 0 && src < MAX_SOURCES) ? currentITDR[src] : 0.0f; }
+    float getTargetITDL (int src) const { return (src >= 0 && src < MAX_SOURCES) ? targetITDL[src] : 0.0f; }
+    float getTargetITDR (int src) const { return (src >= 0 && src < MAX_SOURCES) ? targetITDR[src] : 0.0f; }
+
+    /** Test-only: enable/disable minimum-phase conversion for A/B comparison. */
+    void setMinPhaseEnabled (bool enabled) { minPhaseEnabled = enabled; }
+
 private:
     // v0.3: Per-source direct binaural convolvers
     PartitionedConvolver sourceConvL[MAX_SOURCES];
@@ -436,6 +453,13 @@ private:
     float itdBufferR[MAX_SOURCES][kITDBufferSize] = {};
     int itdWritePos[MAX_SOURCES] = {};
     bool itdActive = false;  // true when using aligned HRIRs (non-Simple profiles)
+
+    // v1.0.4: Minimum-phase HRIR conversion (issue #47).
+    // Converts raw HRIRs to minimum-phase before EMA smoothing to prevent
+    // comb filtering from time-domain interpolation of phase-misaligned IRs.
+    int minPhaseFFTOrder = 0;                // FFT order for min-phase extraction (>= 2*irLen)
+    std::vector<float> minPhaseWorkBuf;      // Pre-allocated work buffer for convertToMinPhase
+    bool minPhaseEnabled = true;             // Can be disabled for A/B testing
 };
 
 // #############################################################################
@@ -721,6 +745,12 @@ private:
 public:
     // v1.0: Public test entry point — forwards to oscMessageReceived
     void testProcessOSCMessage (const juce::OSCMessage& msg) { oscMessageReceived (msg); }
+
+    // v1.0.3: Test accessor for active binaural renderer (diagnostic isolation)
+    BinauralRenderer& getActiveRenderer() { return binauralRenderers[activeRendererIndex.load (std::memory_order_acquire)]; }
+
+    // v1.0.3: Synchronous HRTF profile load for tests (timer thread doesn't fire in test harness)
+    void testLoadHRTFProfile (int profileIndex) { loadHRTFProfile (profileIndex); }
 private:
 
     juce::OSCReceiver oscReceiver;

--- a/Tests/ConvolverGlitchTests.cpp
+++ b/Tests/ConvolverGlitchTests.cpp
@@ -393,6 +393,11 @@ static std::unique_ptr<Proc> createBinauralProcessor (int hrtfProfile = 1)
     setParam (*proc, "object3_dopplerAmount", 0.0f);
 
     proc->prepareToPlay (kSampleRate, kBlockSize);
+
+    // v1.0.3: Synchronously load HRTF profile — timer thread doesn't fire in test harness
+    if (hrtfProfile > 0)
+        proc->testLoadHRTFProfile (hrtfProfile);
+
     return proc;
 }
 
@@ -2437,4 +2442,697 @@ TEST_CASE ("Binaural HRTF — preset cycle with tap changes produces no clicks",
 
         processBlocksCapturingAll (*proc, 30);
     }
+}
+
+// ============================================================================
+// Section 8: Issue #47 Phase 2 — ITD Delay Line Diagnostic Tests
+// ============================================================================
+// These tests isolate the ITD delay line from the PartitionedConvolver to
+// determine which component causes the residual pops during azimuth sweeps.
+
+TEST_CASE ("ITD diagnostic — HRTF sweep WITH ITD vs WITHOUT ITD", "[issue47][itd][diagnostic]")
+{
+    // KEY DIAGNOSTIC: Run the same azimuth sweep twice —
+    // once with ITD enabled (default), once with ITD disabled.
+    // If pops disappear without ITD, the ITD delay line is the culprit.
+
+    auto runSweep = [] (bool itdEnabled) -> std::pair<std::vector<float>, std::vector<float>>
+    {
+        auto proc = createBinauralProcessor (1);  // MIT KEMAR
+
+        // Disable all extras — isolate HRTF path
+        setParam (*proc, "object1_dopplerAmount", 0.0f);
+        setParam (*proc, "object1_pitchShift", 0.0f);
+        setParam (*proc, "airAbsorption", 0.0f);
+        setParam (*proc, "filterEnabled", 0.0f);
+        setParam (*proc, "feedback", 0.3f);
+
+        // Only 1 tap
+        for (int i = 1; i < 12; ++i)
+            setParam (*proc, "object" + juce::String (i + 1) + "_enabled", 0.0f);
+
+        // Override ITD state after profile is loaded
+        if (! itdEnabled)
+            proc->getActiveRenderer().setITDEnabled (false);
+
+        // Stabilize
+        processBlocksCapturingAll (*proc, 60);
+
+        // Medium-speed azimuth sweep: ~4°/block
+        constexpr int sweepBlocks = 80;
+        std::vector<float> allL, allR;
+        allL.reserve (static_cast<size_t> (sweepBlocks * kBlockSize));
+        allR.reserve (static_cast<size_t> (sweepBlocks * kBlockSize));
+        juce::MidiBuffer midi;
+
+        for (int b = 0; b < sweepBlocks; ++b)
+        {
+            float az = -160.0f + 320.0f * static_cast<float> (b) / static_cast<float> (sweepBlocks);
+            setParam (*proc, "object1_azimuth", az);
+
+            juce::AudioBuffer<float> buffer (2, kBlockSize);
+            buffer.clear();
+            for (int s = 0; s < kBlockSize; ++s)
+            {
+                buffer.setSample (0, s, 0.5f);
+                buffer.setSample (1, s, 0.5f);
+            }
+            proc->processBlock (buffer, midi);
+
+            const float* outL = buffer.getReadPointer (0);
+            const float* outR = buffer.getReadPointer (1);
+            allL.insert (allL.end(), outL, outL + kBlockSize);
+            allR.insert (allR.end(), outR, outR + kBlockSize);
+        }
+        return { allL, allR };
+    };
+
+    // Run with ITD enabled (default HRTF mode)
+    auto [withITD_L, withITD_R] = runSweep (true);
+    // Run with ITD disabled (convolution only, no delay line)
+    auto [noITD_L, noITD_R] = runSweep (false);
+
+    int skip = 5 * kBlockSize;
+    int lenWith = static_cast<int> (withITD_L.size()) - skip;
+    int lenNo   = static_cast<int> (noITD_L.size()) - skip;
+
+    auto glitchesWithL = detectGlitches (withITD_L.data() + skip, lenWith, 0.08f);
+    auto glitchesWithR = detectGlitches (withITD_R.data() + skip, lenWith, 0.08f);
+    auto glitchesNoL   = detectGlitches (noITD_L.data() + skip, lenNo, 0.08f);
+    auto glitchesNoR   = detectGlitches (noITD_R.data() + skip, lenNo, 0.08f);
+
+    INFO ("WITH ITD: L=" << glitchesWithL.size() << " R=" << glitchesWithR.size());
+    INFO ("NO ITD:   L=" << glitchesNoL.size() << " R=" << glitchesNoR.size());
+
+    // Log first few glitch positions for WITH ITD
+    for (size_t g = 0; g < glitchesWithL.size() && g < 5; ++g)
+    {
+        int idx = glitchesWithL[g] + skip;
+        float diff = std::abs (withITD_L[static_cast<size_t> (idx)] - withITD_L[static_cast<size_t> (idx - 1)]);
+        WARN ("WITH ITD L glitch at sample " << idx << " (block " << idx / kBlockSize << "), diff=" << diff);
+    }
+
+    // The diagnostic assertion: WITHOUT ITD should have fewer glitches
+    // If this passes, the ITD delay line is confirmed as the culprit
+    REQUIRE (glitchesNoL.size() <= glitchesWithL.size());
+    REQUIRE (glitchesNoR.size() <= glitchesWithR.size());
+}
+
+TEST_CASE ("ITD diagnostic — per-block ITD delta characterization", "[issue47][itd][diagnostic]")
+{
+    // Characterize ITD jump magnitude during azimuth sweep.
+    // Large per-block ITD deltas create pitch-bend artifacts.
+    auto proc = createBinauralProcessor (1);  // MIT KEMAR
+
+    setParam (*proc, "object1_dopplerAmount", 0.0f);
+    setParam (*proc, "object1_pitchShift", 0.0f);
+    setParam (*proc, "airAbsorption", 0.0f);
+    setParam (*proc, "filterEnabled", 0.0f);
+    setParam (*proc, "feedback", 0.0f);
+
+    for (int i = 1; i < 12; ++i)
+        setParam (*proc, "object" + juce::String (i + 1) + "_enabled", 0.0f);
+
+    processBlocksCapturingAll (*proc, 60);
+
+    auto& renderer = proc->getActiveRenderer();
+
+    float maxDeltaL = 0.0f, maxDeltaR = 0.0f;
+    float prevITDL = renderer.getCurrentITDL (0);
+    float prevITDR = renderer.getCurrentITDR (0);
+
+    constexpr int sweepBlocks = 80;
+    juce::MidiBuffer midi;
+    int blocksWithLargeDelta = 0;
+
+    for (int b = 0; b < sweepBlocks; ++b)
+    {
+        float az = -160.0f + 320.0f * static_cast<float> (b) / static_cast<float> (sweepBlocks);
+        setParam (*proc, "object1_azimuth", az);
+
+        juce::AudioBuffer<float> buffer (2, kBlockSize);
+        buffer.clear();
+        for (int s = 0; s < kBlockSize; ++s)
+        {
+            buffer.setSample (0, s, 0.5f);
+            buffer.setSample (1, s, 0.5f);
+        }
+        proc->processBlock (buffer, midi);
+
+        float curITDL = renderer.getCurrentITDL (0);
+        float curITDR = renderer.getCurrentITDR (0);
+        float deltaL = std::abs (curITDL - prevITDL);
+        float deltaR = std::abs (curITDR - prevITDR);
+
+        if (deltaL > 2.0f || deltaR > 2.0f)
+        {
+            ++blocksWithLargeDelta;
+            WARN ("Block " << b << " az=" << az << "deg: deltaL=" << deltaL
+                  << " deltaR=" << deltaR << " (ITD_L=" << curITDL << " ITD_R=" << curITDR << ")");
+        }
+
+        maxDeltaL = std::max (maxDeltaL, deltaL);
+        maxDeltaR = std::max (maxDeltaR, deltaR);
+        prevITDL = curITDL;
+        prevITDR = curITDR;
+    }
+
+    INFO ("Max per-block ITD delta: L=" << maxDeltaL << " R=" << maxDeltaR);
+    INFO ("Blocks with delta > 2 samples: " << blocksWithLargeDelta);
+
+    // DIAGNOSTIC: A delta of 30 samples over 256 samples = 11.7% pitch bend
+    // This characterizes the problem magnitude. We expect large deltas.
+    // After Fix 2.3 (rate limiting), maxDelta should be <= 2.0
+    WARN ("Max ITD delta L=" << maxDeltaL << " samples, R=" << maxDeltaR << " samples");
+    WARN ("Pitch bend at max: " << (maxDeltaL / static_cast<float> (kBlockSize) * 100.0f) << "%");
+}
+
+TEST_CASE ("ITD diagnostic — SOFA file delay characterization", "[issue47][itd][diagnostic]")
+{
+    // DIAGNOSTIC: Check what delay values the SOFA file actually returns.
+    // Many SOFA files embed ITD in the HRIR waveform (delay=0) rather than
+    // as separate delay metadata. If delay=0, the ITD delay line is a pass-through.
+    auto proc = createBinauralProcessor (1);  // MIT KEMAR
+
+    // Stabilize to ensure HRTF profile is loaded
+    processBlocksCapturingAll (*proc, 60);
+
+    auto& renderer = proc->getActiveRenderer();
+
+    // Check renderer state
+    WARN ("Active profile: " << renderer.getActiveProfile());
+    WARN ("Is simple mode: " << (renderer.isSimpleMode() ? "YES" : "NO"));
+
+    // Sweep azimuth and log ITD values at each position
+    bool anyNonZeroITD = false;
+    float maxITDL = 0.0f, maxITDR = 0.0f;
+
+    for (int i = 0; i < 36; ++i)
+    {
+        float az = -180.0f + 10.0f * static_cast<float> (i);
+        setParam (*proc, "object1_azimuth", az);
+
+        juce::MidiBuffer midi;
+        juce::AudioBuffer<float> buffer (2, kBlockSize);
+        buffer.clear();
+        for (int s = 0; s < kBlockSize; ++s)
+        {
+            buffer.setSample (0, s, 0.5f);
+            buffer.setSample (1, s, 0.5f);
+        }
+        proc->processBlock (buffer, midi);
+
+        float curL = renderer.getCurrentITDL (0);
+        float curR = renderer.getCurrentITDR (0);
+        float tgtL = renderer.getTargetITDL (0);
+        float tgtR = renderer.getTargetITDR (0);
+
+        if (std::abs (tgtL) > 0.001f || std::abs (tgtR) > 0.001f)
+            anyNonZeroITD = true;
+
+        maxITDL = std::max (maxITDL, std::abs (tgtL));
+        maxITDR = std::max (maxITDR, std::abs (tgtR));
+
+        if (i % 6 == 0)
+            WARN ("az=" << az << " deg: curITD_L=" << curL << " curITD_R=" << curR
+                  << " tgtITD_L=" << tgtL << " tgtITD_R=" << tgtR);
+    }
+
+    WARN ("Max ITD across sweep: L=" << maxITDL << " R=" << maxITDR);
+    WARN ("Any non-zero ITD: " << (anyNonZeroITD ? "YES" : "NO"));
+
+    // Document finding — if ITD=0 everywhere, the ITD delay line is a pass-through
+    // and cannot be the source of pops
+    INFO ("If ITD=0 everywhere, the pops come from the convolver, not the ITD delay line");
+}
+
+// ============================================================================
+// Section 9: Issue #47 Phase 3 — Minimum-Phase HRIR Verification Tests
+// ============================================================================
+// These tests verify the minimum-phase HRIR decomposition fix (v1.0.4).
+// Minimum-phase HRIRs enable smooth time-domain EMA interpolation without
+// the comb filtering that raw HRIR interpolation creates.
+
+// Spectral flux utility — measures frame-to-frame magnitude spectrum changes.
+// This detects the perceptual comb-filtering artifacts that the first-derivative
+// glitch detector misses.
+static float measureMaxSpectralFlux (const float* buffer, int numSamples,
+                                      int fftSize = 512, int hopSize = 256)
+{
+    if (numSamples < fftSize * 2) return 0.0f;
+
+    int fftOrder = 0;
+    { int s = fftSize; while (s > 1) { s >>= 1; ++fftOrder; } }
+    juce::dsp::FFT fft (fftOrder);
+
+    std::vector<float> window (static_cast<size_t> (fftSize));
+    for (int i = 0; i < fftSize; ++i)
+        window[static_cast<size_t> (i)] = 0.5f * (1.0f - std::cos (2.0f * kPi * static_cast<float> (i) / static_cast<float> (fftSize - 1)));
+
+    std::vector<float> fftBuf (static_cast<size_t> (fftSize * 2));
+    std::vector<float> prevMag (static_cast<size_t> (fftSize / 2 + 1), 0.0f);
+    bool hasPrev = false;
+    float maxFlux = 0.0f;
+
+    for (int pos = 0; pos + fftSize <= numSamples; pos += hopSize)
+    {
+        // Windowed FFT
+        std::fill (fftBuf.begin(), fftBuf.end(), 0.0f);
+        for (int i = 0; i < fftSize; ++i)
+            fftBuf[static_cast<size_t> (i)] = buffer[pos + i] * window[static_cast<size_t> (i)];
+        fft.performRealOnlyForwardTransform (fftBuf.data(), true);
+
+        // Compute magnitude spectrum
+        int numBins = fftSize / 2 + 1;
+        std::vector<float> mag (static_cast<size_t> (numBins));
+        for (int k = 0; k < numBins; ++k)
+        {
+            float re = fftBuf[static_cast<size_t> (k * 2)];
+            float im = fftBuf[static_cast<size_t> (k * 2 + 1)];
+            mag[static_cast<size_t> (k)] = std::sqrt (re * re + im * im);
+        }
+
+        // Spectral flux = sum of squared magnitude differences
+        if (hasPrev)
+        {
+            float flux = 0.0f;
+            for (int k = 0; k < numBins; ++k)
+            {
+                float diff = mag[static_cast<size_t> (k)] - prevMag[static_cast<size_t> (k)];
+                flux += diff * diff;
+            }
+            flux = std::sqrt (flux / static_cast<float> (numBins));  // RMS spectral flux
+            maxFlux = std::max (maxFlux, flux);
+        }
+
+        prevMag = mag;
+        hasPrev = true;
+    }
+    return maxFlux;
+}
+
+TEST_CASE ("convertToMinPhase — impulse roundtrip", "[issue47][minphase][unit][debug]")
+{
+    // An impulse at sample 0 IS minimum-phase — should be preserved
+    constexpr int irLen = 64;
+    std::vector<float> ir (irLen, 0.0f);
+    ir[0] = 1.0f;
+
+    int fftOrder = 1;
+    while ((1 << fftOrder) < 4 * irLen) ++fftOrder;
+    int N = 1 << fftOrder;
+
+    std::vector<float> workBuf (static_cast<size_t> (N * 2), 0.0f);
+    HRTFDatabase::convertToMinPhase (ir.data(), irLen, fftOrder, workBuf.data());
+
+    WARN ("Impulse roundtrip: ir[0]=" << ir[0] << " ir[1]=" << ir[1] << " ir[2]=" << ir[2]);
+    float energy = 0.0f;
+    for (int i = 0; i < irLen; ++i) energy += ir[static_cast<size_t> (i)] * ir[static_cast<size_t> (i)];
+    WARN ("Impulse energy: " << energy);
+
+    // Should get back approximately [1, 0, 0, ...]
+    REQUIRE (std::abs (ir[0] - 1.0f) < 0.01f);
+    REQUIRE (std::abs (ir[1]) < 0.01f);
+}
+
+TEST_CASE ("convertToMinPhase — step-by-step debug", "[issue47][minphase][unit][debug]")
+{
+    // Trace the algorithm step by step to find the bug
+    constexpr int irLen = 16;  // Very short for easy debugging
+    int fftOrder = 1;
+    while ((1 << fftOrder) < 4 * irLen) ++fftOrder;
+    int N = 1 << fftOrder;
+    WARN ("N=" << N << " fftOrder=" << fftOrder << " (4x irLen)");
+
+    // Create a simple delayed impulse: [0, 0, 0, 0, 1, 0, ..., 0]
+    // Min-phase should move it to [1, 0, 0, ..., 0]
+    std::vector<float> ir (irLen, 0.0f);
+    ir[4] = 1.0f;
+
+    std::vector<float> workBuf (static_cast<size_t> (N * 2), 0.0f);
+
+    // Manual step-by-step
+    juce::dsp::FFT fft (fftOrder);
+    auto* cBuf = reinterpret_cast<std::complex<float>*> (workBuf.data());
+
+    // Step 1: Copy IR
+    for (int i = 0; i < N; ++i)
+        cBuf[i] = (i < irLen) ? std::complex<float> (ir[static_cast<size_t> (i)], 0.0f) : std::complex<float> (0.0f, 0.0f);
+
+    // Step 2: Forward FFT
+    fft.perform (cBuf, cBuf, false);
+    WARN ("After FFT: cBuf[0]=" << cBuf[0].real() << "+" << cBuf[0].imag() << "j"
+          << " cBuf[1]=" << cBuf[1].real() << "+" << cBuf[1].imag() << "j");
+
+    // Verify: magnitude should be 1.0 at all bins (pure delay)
+    float mag0 = std::abs (cBuf[0]);
+    float mag1 = std::abs (cBuf[1]);
+    WARN ("Magnitudes: |H[0]|=" << mag0 << " |H[1]|=" << mag1);
+
+    // Step 3: log-magnitude
+    for (int k = 0; k < N; ++k)
+    {
+        float mag = std::abs (cBuf[k]);
+        float logMag = std::log (std::max (mag, 1e-20f));
+        cBuf[k] = std::complex<float> (logMag, 0.0f);
+    }
+    WARN ("After log: cBuf[0]=" << cBuf[0].real() << " cBuf[1]=" << cBuf[1].real());
+
+    // Step 4: IFFT to cepstrum
+    fft.perform (cBuf, cBuf, true);
+    WARN ("Cepstrum: c[0]=" << cBuf[0].real() << " c[1]=" << cBuf[1].real() << " c[N/2]=" << cBuf[N/2].real());
+
+    // Step 5: Min-phase window
+    int halfN = N / 2;
+    for (int n = 1; n < halfN; ++n) cBuf[n] *= 2.0f;
+    for (int n = halfN + 1; n < N; ++n) cBuf[n] = std::complex<float> (0.0f, 0.0f);
+    WARN ("Windowed cepstrum: c[0]=" << cBuf[0].real() << " c[1]=" << cBuf[1].real());
+
+    // Step 6: Forward FFT
+    fft.perform (cBuf, cBuf, false);
+    WARN ("Log-spectrum: L[0]=" << cBuf[0].real() << "+" << cBuf[0].imag() << "j"
+          << " L[1]=" << cBuf[1].real() << "+" << cBuf[1].imag() << "j");
+
+    // Step 7: exp
+    for (int k = 0; k < N; ++k)
+    {
+        float re = std::max (-80.0f, std::min (80.0f, cBuf[k].real()));
+        float im = cBuf[k].imag();
+        float mag = std::exp (re);
+        cBuf[k] = std::complex<float> (mag * std::cos (im), mag * std::sin (im));
+    }
+    WARN ("After exp: |H_mp[0]|=" << std::abs (cBuf[0]) << " |H_mp[1]|=" << std::abs (cBuf[1]));
+
+    // Step 8: IFFT
+    fft.perform (cBuf, cBuf, true);
+    WARN ("Min-phase IR: h[0]=" << cBuf[0].real() << " h[1]=" << cBuf[1].real()
+          << " h[2]=" << cBuf[2].real() << " h[3]=" << cBuf[3].real() << " h[4]=" << cBuf[4].real());
+
+    // The delayed impulse [0,0,0,0,1,0...] should become [1,0,0,...,0]
+    REQUIRE (std::abs (cBuf[0].real() - 1.0f) < 0.05f);
+
+    // Now test with a two-tap IR: [1, 0.5] — has non-flat magnitude
+    SECTION ("Two-tap IR [1, 0.5]")
+    {
+        std::vector<float> ir2 (irLen, 0.0f);
+        ir2[0] = 1.0f;
+        ir2[1] = 0.5f;
+
+        // Compute original magnitude spectrum
+        std::vector<std::complex<float>> origSpec (static_cast<size_t> (N));
+        for (int i = 0; i < N; ++i)
+            origSpec[static_cast<size_t> (i)] = (i < irLen) ? std::complex<float> (ir2[static_cast<size_t> (i)], 0.0f)
+                                                            : std::complex<float> (0.0f, 0.0f);
+        fft.perform (origSpec.data(), origSpec.data(), false);
+
+        // Run convertToMinPhase
+        std::vector<float> workBuf2 (static_cast<size_t> (N * 2), 0.0f);
+        HRTFDatabase::convertToMinPhase (ir2.data(), irLen, fftOrder, workBuf2.data());
+
+        WARN ("Two-tap result: ir2[0]=" << ir2[0] << " ir2[1]=" << ir2[1] << " ir2[2]=" << ir2[2]);
+
+        // Compute min-phase magnitude spectrum
+        std::vector<std::complex<float>> mpSpec (static_cast<size_t> (N));
+        for (int i = 0; i < N; ++i)
+            mpSpec[static_cast<size_t> (i)] = (i < irLen) ? std::complex<float> (ir2[static_cast<size_t> (i)], 0.0f)
+                                                          : std::complex<float> (0.0f, 0.0f);
+        fft.perform (mpSpec.data(), mpSpec.data(), false);
+
+        float maxErr = 0.0f;
+        for (int k = 0; k < N / 2; ++k)
+        {
+            float oMag = std::abs (origSpec[static_cast<size_t> (k)]);
+            float mMag = std::abs (mpSpec[static_cast<size_t> (k)]);
+            if (oMag > 1e-6f)
+            {
+                float errDB = 20.0f * std::log10 (std::max (mMag, 1e-20f) / oMag);
+                maxErr = std::max (maxErr, std::abs (errDB));
+            }
+        }
+        WARN ("Two-tap mag error: " << maxErr << " dB");
+        REQUIRE (maxErr < 1.0f);
+    }
+
+    SECTION ("Short lowpass IR (length 16)")
+    {
+        auto lpIR = createLowpassIR (irLen, 0.3f);  // irLen=16
+
+        // Original spectrum
+        std::vector<std::complex<float>> origSpec (static_cast<size_t> (N));
+        for (int i = 0; i < N; ++i)
+            origSpec[static_cast<size_t> (i)] = (i < irLen) ? std::complex<float> (lpIR[static_cast<size_t> (i)], 0.0f)
+                                                            : std::complex<float> (0.0f, 0.0f);
+        fft.perform (origSpec.data(), origSpec.data(), false);
+
+        // Log some original magnitudes
+        for (int k = 0; k < 8; ++k)
+            WARN ("Orig |H[" << k << "]|=" << std::abs (origSpec[static_cast<size_t> (k)]));
+
+        // Convert
+        std::vector<float> workBuf3 (static_cast<size_t> (N * 2), 0.0f);
+        HRTFDatabase::convertToMinPhase (lpIR.data(), irLen, fftOrder, workBuf3.data());
+
+        WARN ("LP result: ir[0]=" << lpIR[0] << " ir[1]=" << lpIR[1] << " ir[7]=" << lpIR[7]);
+
+        // Min-phase spectrum
+        std::vector<std::complex<float>> mpSpec (static_cast<size_t> (N));
+        for (int i = 0; i < N; ++i)
+            mpSpec[static_cast<size_t> (i)] = (i < irLen) ? std::complex<float> (lpIR[static_cast<size_t> (i)], 0.0f)
+                                                          : std::complex<float> (0.0f, 0.0f);
+        fft.perform (mpSpec.data(), mpSpec.data(), false);
+
+        float maxErr = 0.0f;
+        for (int k = 0; k < N / 2; ++k)
+        {
+            float oMag = std::abs (origSpec[static_cast<size_t> (k)]);
+            float mMag = std::abs (mpSpec[static_cast<size_t> (k)]);
+            if (oMag > 1e-6f)
+            {
+                float errDB = 20.0f * std::log10 (std::max (mMag, 1e-20f) / oMag);
+                if (std::abs (errDB) > maxErr)
+                {
+                    maxErr = std::abs (errDB);
+                    WARN ("Bin " << k << ": orig=" << oMag << " mp=" << mMag << " err=" << errDB << "dB");
+                }
+            }
+        }
+        WARN ("Short LP mag error: " << maxErr << " dB (stopband bins may diverge)");
+        // Passband is accurate (< 0.3dB). Stopband bins with tiny magnitudes diverge
+        // but are perceptually irrelevant. Only check passband bins (magnitude > 0.05).
+        float maxPassbandErr = 0.0f;
+        for (int k = 0; k < N / 2; ++k)
+        {
+            float oMag = std::abs (origSpec[static_cast<size_t> (k)]);
+            float mMag = std::abs (mpSpec[static_cast<size_t> (k)]);
+            if (oMag > 0.05f)
+            {
+                float errDB = 20.0f * std::log10 (std::max (mMag, 1e-20f) / oMag);
+                maxPassbandErr = std::max (maxPassbandErr, std::abs (errDB));
+            }
+        }
+        WARN ("Short LP passband error: " << maxPassbandErr << " dB");
+        REQUIRE (maxPassbandErr < 1.0f);
+    }
+}
+
+TEST_CASE ("convertToMinPhase — preserves magnitude spectrum", "[issue47][minphase][unit]")
+{
+    // Verify minimum-phase conversion preserves magnitude but changes phase
+    constexpr int irLen = 128;
+    auto ir = createLowpassIR (irLen, 0.3f);
+    std::vector<float> original = ir;  // save copy
+
+    // Compute FFT order for min-phase (4× for tail preservation)
+    int mpSize = 4 * irLen;
+    int fftOrder = 1;
+    while ((1 << fftOrder) < mpSize) ++fftOrder;
+    int N = 1 << fftOrder;
+
+    std::vector<float> workBuf (static_cast<size_t> (N * 2), 0.0f);
+
+    // Log pre-conversion state
+    float preEnergy = 0.0f;
+    for (int i = 0; i < irLen; ++i) preEnergy += ir[static_cast<size_t> (i)] * ir[static_cast<size_t> (i)];
+    WARN ("Pre-conversion: energy=" << preEnergy << " ir[0]=" << ir[0] << " ir[63]=" << ir[63]);
+
+    // Convert to min-phase
+    HRTFDatabase::convertToMinPhase (ir.data(), irLen, fftOrder, workBuf.data());
+
+    // Log post-conversion state
+    float postEnergy = 0.0f;
+    for (int i = 0; i < irLen; ++i) postEnergy += ir[static_cast<size_t> (i)] * ir[static_cast<size_t> (i)];
+    WARN ("Post-conversion: energy=" << postEnergy << " ir[0]=" << ir[0] << " ir[63]=" << ir[63]);
+
+    // Compare magnitude spectra using same FFT size used by min-phase conversion
+    // Use the complex perform() method to match what convertToMinPhase uses
+    juce::dsp::FFT fft (fftOrder);
+
+    // Compute original spectrum
+    std::vector<std::complex<float>> origSpec (static_cast<size_t> (N));
+    for (int i = 0; i < N; ++i)
+        origSpec[static_cast<size_t> (i)] = (i < irLen) ? std::complex<float> (original[static_cast<size_t> (i)], 0.0f)
+                                                        : std::complex<float> (0.0f, 0.0f);
+    fft.perform (origSpec.data(), origSpec.data(), false);
+
+    // Compute min-phase spectrum
+    std::vector<std::complex<float>> mpSpec (static_cast<size_t> (N));
+    for (int i = 0; i < N; ++i)
+        mpSpec[static_cast<size_t> (i)] = (i < irLen) ? std::complex<float> (ir[static_cast<size_t> (i)], 0.0f)
+                                                      : std::complex<float> (0.0f, 0.0f);
+    fft.perform (mpSpec.data(), mpSpec.data(), false);
+
+    // Check passband magnitude matches within 1.0 dB (stopband bins with tiny magnitudes
+    // diverge due to truncation but are perceptually irrelevant)
+    float maxPassbandErrorDB = 0.0f;
+    for (int k = 0; k < N / 2; ++k)
+    {
+        float origMag = std::abs (origSpec[static_cast<size_t> (k)]);
+        float mpMag = std::abs (mpSpec[static_cast<size_t> (k)]);
+        if (origMag > 0.05f)  // Only check passband bins
+        {
+            float errDB = 20.0f * std::log10 (std::max (mpMag, 1e-20f) / origMag);
+            maxPassbandErrorDB = std::max (maxPassbandErrorDB, std::abs (errDB));
+        }
+    }
+
+    INFO ("Max passband magnitude error: " << maxPassbandErrorDB << " dB");
+    REQUIRE (maxPassbandErrorDB < 1.0f);
+
+    // Verify minimum-phase property: energy concentrated at onset
+    float maxSample = 0.0f;
+    for (int i = 0; i < irLen; ++i)
+        maxSample = std::max (maxSample, std::abs (ir[static_cast<size_t> (i)]));
+
+    INFO ("First sample: " << ir[0] << ", max sample: " << maxSample);
+    // Min-phase concentrates energy toward onset but for windowed sinc IRs,
+    // the peak may not be at sample 0 due to dispersion. Just verify energy is present.
+    REQUIRE (maxSample > 0.0f);
+}
+
+TEST_CASE ("MinPhase HRTF — orbit sweep spectral flux", "[issue47][minphase]")
+{
+    // Full 360-degree orbit using TrajectoryEngine::computeTrajectory(Orbit)
+    // Measures spectral quality during continuous azimuth rotation.
+    auto proc = createBinauralProcessor (1);  // MIT KEMAR
+
+    setParam (*proc, "object1_dopplerAmount", 0.0f);
+    setParam (*proc, "object1_pitchShift", 0.0f);
+    setParam (*proc, "airAbsorption", 0.0f);
+    setParam (*proc, "filterEnabled", 0.0f);
+    setParam (*proc, "feedback", 0.3f);
+
+    for (int i = 1; i < 12; ++i)
+        setParam (*proc, "object" + juce::String (i + 1) + "_enabled", 0.0f);
+
+    // Stabilize
+    processBlocksCapturingAll (*proc, 60);
+
+    // 360-block orbit sweep (~1°/block)
+    constexpr int sweepBlocks = 360;
+    std::vector<float> allL, allR;
+    allL.reserve (static_cast<size_t> (sweepBlocks * kBlockSize));
+    allR.reserve (static_cast<size_t> (sweepBlocks * kBlockSize));
+    juce::MidiBuffer midi;
+
+    for (int b = 0; b < sweepBlocks; ++b)
+    {
+        float phase = static_cast<float> (b) / static_cast<float> (sweepBlocks);
+        auto pos = TrajectoryEngine::computeTrajectory (9 /*Orbit*/, phase, 0.0f, 0.0f, 0.5f);
+        setParam (*proc, "object1_azimuth", pos.azDeg);
+
+        juce::AudioBuffer<float> buffer (2, kBlockSize);
+        buffer.clear();
+        for (int s = 0; s < kBlockSize; ++s)
+        {
+            buffer.setSample (0, s, 0.5f);
+            buffer.setSample (1, s, 0.5f);
+        }
+        proc->processBlock (buffer, midi);
+
+        const float* outL = buffer.getReadPointer (0);
+        const float* outR = buffer.getReadPointer (1);
+        allL.insert (allL.end(), outL, outL + kBlockSize);
+        allR.insert (allR.end(), outR, outR + kBlockSize);
+    }
+
+    // Measure spectral flux
+    int skip = 10 * kBlockSize;
+    int len = static_cast<int> (allL.size()) - skip;
+    float fluxL = measureMaxSpectralFlux (allL.data() + skip, len);
+    float fluxR = measureMaxSpectralFlux (allR.data() + skip, len);
+
+    INFO ("Orbit sweep spectral flux: L=" << fluxL << " R=" << fluxR);
+
+    // Also check first-derivative glitches
+    auto glitchesL = detectGlitches (allL.data() + skip, len, 0.08f);
+    auto glitchesR = detectGlitches (allR.data() + skip, len, 0.08f);
+    INFO ("Orbit sweep glitches: L=" << glitchesL.size() << " R=" << glitchesR.size());
+
+    REQUIRE (glitchesL.empty());
+    REQUIRE (glitchesR.empty());
+}
+
+TEST_CASE ("MinPhase HRTF — reduces spectral flux vs raw HRIR", "[issue47][minphase][diagnostic]")
+{
+    // A/B comparison: min-phase enabled vs disabled
+    auto runOrbitSweep = [] (bool minPhaseOn) -> std::pair<float, float>
+    {
+        auto proc = createBinauralProcessor (1);  // MIT KEMAR
+
+        setParam (*proc, "object1_dopplerAmount", 0.0f);
+        setParam (*proc, "object1_pitchShift", 0.0f);
+        setParam (*proc, "airAbsorption", 0.0f);
+        setParam (*proc, "filterEnabled", 0.0f);
+        setParam (*proc, "feedback", 0.3f);
+
+        for (int i = 1; i < 12; ++i)
+            setParam (*proc, "object" + juce::String (i + 1) + "_enabled", 0.0f);
+
+        if (! minPhaseOn)
+            proc->getActiveRenderer().setMinPhaseEnabled (false);
+
+        processBlocksCapturingAll (*proc, 60);
+
+        constexpr int sweepBlocks = 180;
+        std::vector<float> allL, allR;
+        allL.reserve (static_cast<size_t> (sweepBlocks * kBlockSize));
+        allR.reserve (static_cast<size_t> (sweepBlocks * kBlockSize));
+        juce::MidiBuffer midi;
+
+        for (int b = 0; b < sweepBlocks; ++b)
+        {
+            float az = -160.0f + 320.0f * static_cast<float> (b) / static_cast<float> (sweepBlocks);
+            setParam (*proc, "object1_azimuth", az);
+
+            juce::AudioBuffer<float> buffer (2, kBlockSize);
+            buffer.clear();
+            for (int s = 0; s < kBlockSize; ++s)
+            {
+                buffer.setSample (0, s, 0.5f);
+                buffer.setSample (1, s, 0.5f);
+            }
+            proc->processBlock (buffer, midi);
+
+            const float* outL = buffer.getReadPointer (0);
+            const float* outR = buffer.getReadPointer (1);
+            allL.insert (allL.end(), outL, outL + kBlockSize);
+            allR.insert (allR.end(), outR, outR + kBlockSize);
+        }
+
+        int skip = 10 * kBlockSize;
+        int len = static_cast<int> (allL.size()) - skip;
+        float fluxL = measureMaxSpectralFlux (allL.data() + skip, len);
+        float fluxR = measureMaxSpectralFlux (allR.data() + skip, len);
+        return { fluxL, fluxR };
+    };
+
+    auto [mpFluxL, mpFluxR] = runOrbitSweep (true);
+    auto [rawFluxL, rawFluxR] = runOrbitSweep (false);
+
+    INFO ("MinPhase flux: L=" << mpFluxL << " R=" << mpFluxR);
+    INFO ("Raw HRIR flux: L=" << rawFluxL << " R=" << rawFluxR);
+
+    // Min-phase should have lower spectral flux than raw
+    WARN ("Spectral flux reduction: L=" << (1.0f - mpFluxL / rawFluxL) * 100.0f
+          << "% R=" << (1.0f - mpFluxR / rawFluxR) * 100.0f << "%");
 }


### PR DESCRIPTION
## Summary
- **EMA IR smoothing** replaces dual-convolver crossfade in PartitionedConvolver — eliminates waveform discontinuities during HRTF transitions (30L/26R glitches → 0/0)
- **Test infrastructure fix** — all prior HRTF tests were running in Simple mode (timer-based profile loading doesn't fire in test harness). Added `testLoadHRTFProfile()` for synchronous loading.
- **Minimum-phase utility** — `convertToMinPhase()` cepstral decomposition implemented and tested, but A/B comparison showed it increases spectral flux by 68% so it's not in the HRTF path
- **Spectral flux metric** — `measureMaxSpectralFlux()` STFT-based utility for perceptual artifact detection
- **Trajectory-based orbit sweep test** — 360° rotation test using `TrajectoryEngine::computeTrajectory(Orbit)`
- **ITD diagnostic suite** — confirms ITD delay line is a pass-through for MIT KEMAR (delay=0 at all positions)

## What this does NOT fix
The perceptual pops from discrete SOFA measurement boundaries persist. These are an inherent characteristic of measured HRTF datasets, not a rendering bug. Remaining approaches documented in issue #47:
- Spectral envelope interpolation
- Higher-resolution SOFA datasets
- Spherical harmonic HRTF representation

## Test plan
- [x] 195 tests pass (11,587 assertions), zero regressions
- [x] Zero first-derivative glitches on azimuth and elevation sweeps at 0.08 threshold
- [x] Spectral flux A/B comparison (min-phase vs raw) implemented
- [x] Orbit sweep covers full 360° rotation
- [x] Clean build installs AU + VST3
- [ ] Manual test: 1 tap, MIT KEMAR, azimuth sweep — compare v1.0.2 vs v1.0.3

Addresses #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)