### PR TITLE
Swap Global Doppler/Pitch knob order (issue #43)

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1724,7 +1724,7 @@ void GlobalTapDrawerComponent::resetToCenter()
 float GlobalTapDrawerComponent::getKnobValue (int knobIdx) const
 {
     const juce::Slider* sliders[] = { &azSlider, &elSlider, &distSlider,
-                                       &dopplerSlider, &pitchSlider, &speedSlider };
+                                       &pitchSlider, &dopplerSlider, &speedSlider };
     if (knobIdx < 0 || knobIdx >= kNumKnobs) return 0.0f;
     return static_cast<float> (sliders[knobIdx]->getValue());
 }
@@ -1732,7 +1732,7 @@ float GlobalTapDrawerComponent::getKnobValue (int knobIdx) const
 void GlobalTapDrawerComponent::setKnobValueSilent (int knobIdx, float value)
 {
     juce::Slider* sliders[] = { &azSlider, &elSlider, &distSlider,
-                                 &dopplerSlider, &pitchSlider, &speedSlider };
+                                 &pitchSlider, &dopplerSlider, &speedSlider };
     if (knobIdx < 0 || knobIdx >= kNumKnobs) return;
     suppressCallbacks = true;
     sliders[knobIdx]->setValue (value, juce::dontSendNotification);
@@ -1824,8 +1824,8 @@ void GlobalTapDrawerComponent::layoutKnobs()
     int panelW = knobPanel.getWidth();
     int contentH = labelH + knobSize + textBoxH;  // total content per knob slot
 
-    juce::Slider* sliders[] = { &azSlider, &elSlider, &distSlider, &dopplerSlider, &pitchSlider, &speedSlider };
-    juce::Label* labels[] = { &azLabel, &elLabel, &distLabel, &dopplerLabel, &pitchLabel, &speedLabel };
+    juce::Slider* sliders[] = { &azSlider, &elSlider, &distSlider, &pitchSlider, &dopplerSlider, &speedSlider };
+    juce::Label* labels[] = { &azLabel, &elLabel, &distLabel, &pitchLabel, &dopplerLabel, &speedLabel };
 
     for (int i = 0; i < kNumKnobs; ++i)
     {
@@ -2784,14 +2784,14 @@ void OpenSpatialDelayEditor::applyGlobalTapDelta (int knobIndex, float delta)
 {
     static const char* suffixes[] = {
         "azimuth", "elevation", "distance",
-        "dopplerAmount", "pitchShift", "trajectorySpeed"
+        "pitchShift", "dopplerAmount", "trajectorySpeed"
     };
     if (knobIndex < 0 || knobIndex >= 6) return;
     const bool wraps = (knobIndex == GlobalTapDrawerComponent::kAzimuth);
 
     // Scale factors: knob display range → APVTS denormalized range
     // Doppler: knob shows -100..+100 (%), APVTS is 0..1 → scale by 0.01
-    static const float scaleFactors[] = { 1.0f, 1.0f, 1.0f, 0.01f, 1.0f, 1.0f };
+    static const float scaleFactors[] = { 1.0f, 1.0f, 1.0f, 1.0f, 0.01f, 1.0f };
     float scaledDelta = delta * scaleFactors[knobIndex];
 
     for (int i = 0; i < SpatialMapComponent::MAX_OBJECTS; ++i)

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -457,7 +457,7 @@ public:
     static constexpr int kHandleWidth = 16;
     static constexpr int kPanelWidth  = kOpenWidth - kHandleWidth;  // 62px knob area
 
-    enum KnobID { kAzimuth = 0, kElevation, kDistance, kDoppler, kPitch, kSpeed, kNumKnobs };
+    enum KnobID { kAzimuth = 0, kElevation, kDistance, kPitch, kDoppler, kSpeed, kNumKnobs };
 
 private:
     bool open = false;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1414,9 +1414,9 @@ void OpenSpatialDelayProcessor::timerCallback()
 
             // v1.0: Global tap offset knobs (UI-only, change-gated)
             static const char* tapOffsetProps[] = { "tapazimuth", "tapelevation", "tapdistance",
-                                                    "tapdoppler", "tappitch",     "tapspeed" };
+                                                    "tappitch",   "tapdoppler",  "tapspeed" };
             float* tapOffsetPrevs[] = { &pg.tapAzimuth, &pg.tapElevation, &pg.tapDistance,
-                                        &pg.tapDoppler, &pg.tapPitch,     &pg.tapSpeed };
+                                        &pg.tapPitch,   &pg.tapDoppler,   &pg.tapSpeed };
             for (int i = 0; i < kNumGlobalTapOffsets; ++i)
                 sendGlobal (tapOffsetProps[i], globalTapOffset[i].load (std::memory_order_relaxed), *tapOffsetPrevs[i]);
         }
@@ -4787,8 +4787,8 @@ void OpenSpatialDelayProcessor::oscMessageReceived (const juce::OSCMessage& mess
         else if (property == "/tapazimuth")    { globalTapOffset[0].store (juce::jlimit (-180.0f, 180.0f, val), std::memory_order_relaxed); globalTapOffsetChanged.store (true, std::memory_order_relaxed); }
         else if (property == "/tapelevation")  { globalTapOffset[1].store (juce::jlimit (-90.0f,  90.0f,  val), std::memory_order_relaxed); globalTapOffsetChanged.store (true, std::memory_order_relaxed); }
         else if (property == "/tapdistance")   { globalTapOffset[2].store (juce::jlimit (-1.0f,   1.0f,   val), std::memory_order_relaxed); globalTapOffsetChanged.store (true, std::memory_order_relaxed); }
-        else if (property == "/tapdoppler")    { globalTapOffset[3].store (juce::jlimit (-100.0f, 100.0f, val), std::memory_order_relaxed); globalTapOffsetChanged.store (true, std::memory_order_relaxed); }
-        else if (property == "/tappitch")      { globalTapOffset[4].store (juce::jlimit (-24.0f,  24.0f,  val), std::memory_order_relaxed); globalTapOffsetChanged.store (true, std::memory_order_relaxed); }
+        else if (property == "/tappitch")      { globalTapOffset[3].store (juce::jlimit (-24.0f,  24.0f,  val), std::memory_order_relaxed); globalTapOffsetChanged.store (true, std::memory_order_relaxed); }
+        else if (property == "/tapdoppler")    { globalTapOffset[4].store (juce::jlimit (-100.0f, 100.0f, val), std::memory_order_relaxed); globalTapOffsetChanged.store (true, std::memory_order_relaxed); }
         else if (property == "/tapspeed")      { globalTapOffset[5].store (juce::jlimit (-5.0f,   5.0f,   val), std::memory_order_relaxed); globalTapOffsetChanged.store (true, std::memory_order_relaxed); }
     }
 }

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -635,7 +635,7 @@ public:
 
     // v1.0: Global tap offset values (for OSC ↔ editor sync)
     static constexpr int kNumGlobalTapOffsets = 6;
-    std::atomic<float> globalTapOffset[kNumGlobalTapOffsets] = {};  // AZ, EL, DIST, DOPPLER, PITCH, SPEED
+    std::atomic<float> globalTapOffset[kNumGlobalTapOffsets] = {};  // AZ, EL, DIST, PITCH, DOPPLER, SPEED
     std::atomic<bool>  globalTapOffsetChanged { false };
 
     // v0.7: OSC Send accessors for editor

--- a/Tests/OscTests.cpp
+++ b/Tests/OscTests.cpp
@@ -378,18 +378,18 @@ TEST_CASE ("OSC: /osd/global/tapdistance sets global DIST offset", "[osc][global
     REQUIRE_THAT (proc->globalTapOffset[2].load(), WithinAbs (0.5f, 0.01f));
 }
 
-TEST_CASE ("OSC: /osd/global/tapdoppler sets global DOPPLER offset", "[osc][global-tap]")
-{
-    auto proc = createOscProcessor();
-    sendOSC (*proc, "/osd/global/tapdoppler", { -30.0f });
-    REQUIRE_THAT (proc->globalTapOffset[3].load(), WithinAbs (-30.0f, 0.01f));
-}
-
 TEST_CASE ("OSC: /osd/global/tappitch sets global PITCH offset", "[osc][global-tap]")
 {
     auto proc = createOscProcessor();
     sendOSC (*proc, "/osd/global/tappitch", { -12.0f });
-    REQUIRE_THAT (proc->globalTapOffset[4].load(), WithinAbs (-12.0f, 0.01f));
+    REQUIRE_THAT (proc->globalTapOffset[3].load(), WithinAbs (-12.0f, 0.01f));
+}
+
+TEST_CASE ("OSC: /osd/global/tapdoppler sets global DOPPLER offset", "[osc][global-tap]")
+{
+    auto proc = createOscProcessor();
+    sendOSC (*proc, "/osd/global/tapdoppler", { -30.0f });
+    REQUIRE_THAT (proc->globalTapOffset[4].load(), WithinAbs (-30.0f, 0.01f));
 }
 
 TEST_CASE ("OSC: /osd/global/tapspeed sets global SPEED offset", "[osc][global-tap]")
@@ -413,7 +413,7 @@ TEST_CASE ("OSC: Global tap offsets clamp to valid range", "[osc][global-tap][ed
     REQUIRE_THAT (proc->globalTapOffset[2].load(), WithinAbs (1.0f, 0.01f));
 
     sendOSC (*proc, "/osd/global/tappitch", { -48.0f });
-    REQUIRE_THAT (proc->globalTapOffset[4].load(), WithinAbs (-24.0f, 0.01f));
+    REQUIRE_THAT (proc->globalTapOffset[3].load(), WithinAbs (-24.0f, 0.01f));
 
     sendOSC (*proc, "/osd/global/tapspeed", { 10.0f });
     REQUIRE_THAT (proc->globalTapOffset[5].load(), WithinAbs (5.0f, 0.01f));


### PR DESCRIPTION
## Summary
- Swaps Global Pitch and Doppler knobs so Pitch appears above Doppler, matching the per-tap layout
- Updates all 6 index-dependent mappings: enum, layout arrays, slider lookup, parameter suffix/scale factors, OSC receive, OSC send

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)