### PR TITLE
Dry path latency compensation + unique CFBundleIdentifier (issues #63, #62)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,8 @@ bash scripts/build_version.sh <commit-hash> v1.0.X O10X
 - v1.0.4 / O104 — spectral envelope EMA smoothing
 - v1.0.5 / O105 — feedback EMA smoothing for HRTF crossfade pops
 - v1.0.6 / O106 — Phase vocoder pitch shifter replacing WSOLA-Lite (issue #60)
-- Next available: **v1.0.7 / O107**
+- v1.0.7 / O107 — dry path latency compensation + unique CFBundleIdentifier per build (issues #63, #62)
+- Next available: **v1.0.8 / O108**
 
 ### Running tests
 
@@ -64,6 +65,9 @@ Replaces WSOLA-Lite. Uses STFT (2048-point FFT, 4x overlap) with:
 - Phase reset on transient frames preserves attack sharpness
 - Latency: 2048 samples (reported to DAW via setLatencySamples)
 - Range: ±12 semitones (combined with Doppler)
+
+### Dry Path Latency Compensation (v1.0.7)
+The phase vocoder adds 2048 samples of latency to the wet path. The dry signal must be delayed by the same amount so the DAW's plugin delay compensation (PDC) is correct at all dry/wet settings. Implemented as a circular `dryDelayLine` buffer that pre-fills `dryCompBuffer` at the start of each processBlock, before dispatch to render methods. All 5 render paths read from `dryCompBuffer` instead of `monoInputBuffer` for dry mixing.
 
 ### ITD delay line
 For MIT KEMAR SOFA file, ITD values are always 0 (embedded in HRIR waveform). The ITD delay line is effectively a pass-through for this dataset.

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -2360,6 +2360,12 @@ void OpenSpatialDelayProcessor::prepareToPlay (double sampleRate, int samplesPer
         pvPitchShifters[i].reset();
     setLatencySamples (PhaseVocoderPitchShifter::kFFTSize);
 
+    // v1.0.7: Dry path latency compensation (issue #63)
+    // Delay dry signal by kFFTSize samples to match the phase vocoder's wet path latency.
+    dryDelayLine.assign (static_cast<size_t> (PhaseVocoderPitchShifter::kFFTSize), 0.0f);
+    dryDelayWritePos = 0;
+    dryCompBuffer.resize (static_cast<size_t> (samplesPerBlock), 0.0f);
+
     // v1.0: Initialize tap fade envelopes
     for (int t = 0; t < MAX_OBJECTS; ++t)
     {
@@ -3945,6 +3951,22 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
         }
     }
 
+    // v1.0.7: Fill latency-compensated dry buffer (issue #63)
+    // The phase vocoder adds kFFTSize samples of latency to the wet path.
+    // Delay the dry signal by the same amount so DAW PDC is correct at all dry/wet levels.
+    if (dryCompBuffer.size() < ns)
+        dryCompBuffer.resize (ns);
+    {
+        const int dryDelaySize = static_cast<int> (dryDelayLine.size());
+        for (int i = 0; i < numSamples; ++i)
+        {
+            // Read delayed sample first, then overwrite with new input
+            dryCompBuffer[static_cast<size_t> (i)] = dryDelayLine[static_cast<size_t> (dryDelayWritePos)];
+            dryDelayLine[static_cast<size_t> (dryDelayWritePos)] = monoInputBuffer[static_cast<size_t> (i)];
+            dryDelayWritePos = (dryDelayWritePos + 1) % dryDelaySize;
+        }
+    }
+
     // --- Clear output buffer -------------------------------------------------
     buffer.clear();
 
@@ -4111,7 +4133,7 @@ void OpenSpatialDelayProcessor::renderDirectBinauralHRTF (
         float frac    = static_cast<float> (s) * invN;
         float dw      = dwStart + frac * (dwEnd - dwStart);
         float outGain = outGainStart + frac * (outGainEnd - outGainStart);
-        float rawInput = monoInputBuffer[static_cast<size_t> (s)];
+        float rawInput = dryCompBuffer[static_cast<size_t> (s)];  // v1.0.7: latency-compensated dry signal (issue #63)
 
         outL[s] = outputLimiter ((rawInput * (1.0f - dw) + wetBufL[static_cast<size_t> (s)] * dw) * outGain);
         outR[s] = outputLimiter ((rawInput * (1.0f - dw) + wetBufR[static_cast<size_t> (s)] * dw) * outGain);
@@ -4158,7 +4180,7 @@ void OpenSpatialDelayProcessor::renderSimpleBinauralWoodworth (
         float delayInputL = softClip ((rawL + feedbackSample * fb) * kFeedbackInputHeadroom);
         float delayInputR = softClip ((rawR + feedbackSample * fb) * kFeedbackInputHeadroom);
         writeDelayLine (delayInputL, delayInputR);
-        float rawInput = monoInputBuffer[static_cast<size_t> (s)];  // for dry mix (no inGain — INPUT only scales delay input)
+        float rawInput = dryCompBuffer[static_cast<size_t> (s)];  // v1.0.7: latency-compensated dry signal (issue #63)
 
         // === STAGE 2: READ & SPATIALIZE ===
         float wetL = 0.0f, wetR = 0.0f;
@@ -4296,7 +4318,7 @@ void OpenSpatialDelayProcessor::renderStereoVariant (
         float delayInputL = softClip ((rawL + feedbackSample * fb) * kFeedbackInputHeadroom);
         float delayInputR = softClip ((rawR + feedbackSample * fb) * kFeedbackInputHeadroom);
         writeDelayLine (delayInputL, delayInputR);
-        float rawInput = monoInputBuffer[static_cast<size_t> (s)];  // for dry mix (no inGain — INPUT only scales delay input)
+        float rawInput = dryCompBuffer[static_cast<size_t> (s)];  // v1.0.7: latency-compensated dry signal (issue #63)
 
         // === STAGE 2: READ & SPATIALIZE ===
         float wetL = 0.0f, wetR = 0.0f;
@@ -4443,7 +4465,7 @@ void OpenSpatialDelayProcessor::renderAmbisonicsOutput (
         float delayInputL = softClip ((rawL + feedbackSample * fb) * kFeedbackInputHeadroom);
         float delayInputR = softClip ((rawR + feedbackSample * fb) * kFeedbackInputHeadroom);
         writeDelayLine (delayInputL, delayInputR);
-        float rawInput = monoInputBuffer[static_cast<size_t> (s)];  // for dry mix (no inGain — INPUT only scales delay input)
+        float rawInput = dryCompBuffer[static_cast<size_t> (s)];  // v1.0.7: latency-compensated dry signal (issue #63)
 
         // === STAGE 2: READ & SH ENCODE (with NFC-HOA) ===
         float ambiAccum[MAX_AMBI_CHANNELS] = {};
@@ -4547,7 +4569,7 @@ void OpenSpatialDelayProcessor::renderDiscreteSurround (
         float delayInputL = softClip ((rawL + feedbackSample * fb) * kFeedbackInputHeadroom);
         float delayInputR = softClip ((rawR + feedbackSample * fb) * kFeedbackInputHeadroom);
         writeDelayLine (delayInputL, delayInputR);
-        float rawInput = monoInputBuffer[static_cast<size_t> (s)];  // for dry mix (no inGain — INPUT only scales delay input)
+        float rawInput = dryCompBuffer[static_cast<size_t> (s)];  // v1.0.7: latency-compensated dry signal (issue #63)
 
         // === STAGE 2: READ & SPATIALIZE ===
         float channelAccum[16] = {};

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -955,6 +955,14 @@ private:
     std::vector<float> inputBufferL;   // v0.8: per-channel input for stereo delay lines
     std::vector<float> inputBufferR;
 
+    // v1.0.7: Dry path latency compensation (issue #63)
+    // The phase vocoder adds kFFTSize (2048) samples of latency to the wet path.
+    // The dry signal must be delayed by the same amount so the DAW's PDC is correct
+    // at all dry/wet settings. Without this, the dry signal arrives 2048 samples early.
+    std::vector<float> dryDelayLine;        // circular buffer, size = kFFTSize
+    int dryDelayWritePos = 0;
+    std::vector<float> dryCompBuffer;       // pre-filled delayed dry signal for current block
+
     // v0.5: Contiguous per-source accumulation buffers for direct HRTF convolution
     std::vector<float> sourceAccumBufStorage;          // MAX_OBJECTS * maxBlockSize (contiguous)
     float* sourceAccumBufPtrs[MAX_OBJECTS] = {};       // pointers into storage

--- a/scripts/build_version.sh
+++ b/scripts/build_version.sh
@@ -37,11 +37,9 @@ git submodule update --init --recursive 2>/dev/null
 sed -i '' "s/PLUGIN_CODE Os10/PLUGIN_CODE ${PLUGIN_CODE}/" CMakeLists.txt
 sed -i '' "s/PRODUCT_NAME \"OpenSpatialDelay v1.0\"/PRODUCT_NAME \"${PLUGIN_NAME}\"/" CMakeLists.txt
 
-# v1.0.7: Unique CFBundleIdentifier per version to prevent heap corruption when
-# multiple versioned builds are loaded simultaneously (issue #62).
-# Without this, macOS shares/confuses static resources between bundles with the same ID.
+# v1.0.7: Compute unique bundle ID suffix for post-build plist patching (issue #62)
 BUNDLE_SUFFIX=$(echo "${VERSION}" | tr '.' '-')  # e.g., v1.0.7 → v1-0-7
-sed -i '' "s/JucePlugin_CFBundleIdentifier=com.SpatialMediaLibrary.OpenSpatialDelay/JucePlugin_CFBundleIdentifier=com.SpatialMediaLibrary.OpenSpatialDelay.${BUNDLE_SUFFIX}/g" CMakeLists.txt
+UNIQUE_BUNDLE_ID="com.SpatialMediaLibrary.OpenSpatialDelay.${BUNDLE_SUFFIX}"
 
 # Step 3: Patch install script with version-specific name
 sed -i '' "s/PLUGIN_NAME=\"OpenSpatialDelay v1.0\"/PLUGIN_NAME=\"${PLUGIN_NAME}\"/" scripts/install_plugins.sh
@@ -105,9 +103,28 @@ if [ ! -f "${AU_BUILT}" ]; then
 fi
 echo "  AU binary verified: $(file "${AU_BUILT}" | grep -o 'Mach-O.*')"
 
+# Step 8b: Patch AU Info.plist with unique CFBundleIdentifier (issue #62)
+# JUCE generates the same bundle ID for all builds; we must differentiate so macOS
+# doesn't share/confuse resources when multiple versioned builds are loaded simultaneously.
+AU_PLIST="build/OpenSpatialDelay_artefacts/Release/AU/${PLUGIN_NAME}.component/Contents/Info.plist"
+if [ -f "${AU_PLIST}" ]; then
+    /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier ${UNIQUE_BUNDLE_ID}" "${AU_PLIST}"
+    echo "  AU bundle ID patched: ${UNIQUE_BUNDLE_ID}"
+fi
+
 # Step 9: Build VST3 (triggers install script via POST_BUILD)
 echo "  Building VST3 + installing..."
 cmake --build build --target OpenSpatialDelay_VST3 -j${NCPU} 2>&1 | tail -3
+
+# Step 9b: Patch installed AU and VST3 plists with unique CFBundleIdentifier
+AU_INSTALLED_PLIST="$HOME/Library/Audio/Plug-Ins/Components/${PLUGIN_NAME}.component/Contents/Info.plist"
+VST3_INSTALLED_PLIST="$HOME/Library/Audio/Plug-Ins/VST3/${PLUGIN_NAME}.vst3/Contents/Info.plist"
+if [ -f "${AU_INSTALLED_PLIST}" ]; then
+    /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier ${UNIQUE_BUNDLE_ID}" "${AU_INSTALLED_PLIST}"
+fi
+if [ -f "${VST3_INSTALLED_PLIST}" ]; then
+    /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier ${UNIQUE_BUNDLE_ID}" "${VST3_INSTALLED_PLIST}"
+fi
 
 # Step 10: Final validation of installed plugins
 echo ""

--- a/scripts/build_version.sh
+++ b/scripts/build_version.sh
@@ -33,9 +33,15 @@ cd "${BUILD_DIR}"
 git checkout "${COMMIT}" -- . 2>/dev/null
 git submodule update --init --recursive 2>/dev/null
 
-# Step 2: Patch CMakeLists.txt with version-specific name and plugin code
+# Step 2: Patch CMakeLists.txt with version-specific name, plugin code, and bundle ID
 sed -i '' "s/PLUGIN_CODE Os10/PLUGIN_CODE ${PLUGIN_CODE}/" CMakeLists.txt
 sed -i '' "s/PRODUCT_NAME \"OpenSpatialDelay v1.0\"/PRODUCT_NAME \"${PLUGIN_NAME}\"/" CMakeLists.txt
+
+# v1.0.7: Unique CFBundleIdentifier per version to prevent heap corruption when
+# multiple versioned builds are loaded simultaneously (issue #62).
+# Without this, macOS shares/confuses static resources between bundles with the same ID.
+BUNDLE_SUFFIX=$(echo "${VERSION}" | tr '.' '-')  # e.g., v1.0.7 → v1-0-7
+sed -i '' "s/JucePlugin_CFBundleIdentifier=com.SpatialMediaLibrary.OpenSpatialDelay/JucePlugin_CFBundleIdentifier=com.SpatialMediaLibrary.OpenSpatialDelay.${BUNDLE_SUFFIX}/g" CMakeLists.txt
 
 # Step 3: Patch install script with version-specific name
 sed -i '' "s/PLUGIN_NAME=\"OpenSpatialDelay v1.0\"/PLUGIN_NAME=\"${PLUGIN_NAME}\"/" scripts/install_plugins.sh


### PR DESCRIPTION
## Summary

- **Issue #63:** Added 2048-sample delay line for dry signal path to match phase vocoder wet path latency. DAW PDC is now correct at all dry/wet settings. Previously, the dry signal arrived ~42ms early at 48kHz.
- **Issue #62:** `build_version.sh` now patches Info.plist with unique CFBundleIdentifier per version (e.g., `com.SpatialMediaLibrary.OpenSpatialDelay.v1-0-7`). Prevents macOS from confusing shared resources when multiple versioned builds are loaded simultaneously.

## Changes

### Dry path latency compensation (issue #63)
- Added `dryDelayLine` (2048-sample circular buffer) and `dryCompBuffer` to `PluginProcessor.h`
- In `prepareToPlay()`: allocate and zero the dry delay line
- In `processBlock()`: fill `dryCompBuffer` from `dryDelayLine` before render dispatch
- All 5 render paths now read from `dryCompBuffer` instead of `monoInputBuffer` for dry mixing:
  - `renderDirectBinauralHRTF()`
  - `renderSimpleBinauralWoodworth()`
  - `renderStereoVariant()`
  - `renderAmbisonicsOutput()`
  - `renderDiscreteSurround()`

### Unique CFBundleIdentifier (issue #62)
- `build_version.sh` uses PlistBuddy to patch Info.plist after building
- Both AU and VST3 get version-specific bundle IDs
- Prevents heap corruption crash in CoreGraphics when multiple versioned builds coexist

## Test plan

- [x] 174/195 tests pass (21 pre-existing surround test failures from PV latency — unrelated)
- [x] Zero regressions from dry delay change (same test count before and after)
- [x] v1.0.7 / O107 built and installed successfully
- [x] Bundle ID verified: `com.SpatialMediaLibrary.OpenSpatialDelay.v1-0-7`
- [ ] Manual test: insert plugin at 100% dry, verify transient is not shifted
- [ ] Manual test: load v1.0.6 + v1.0.7 simultaneously, verify no crash

Closes #63. Addresses #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)