### PR TITLE
Transport-aware PV reset for intermittent buzzing (issue #65)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ bash scripts/build_version.sh <commit-hash> v1.0.X O10X
 - v1.0.5 / O105 — feedback EMA smoothing for HRTF crossfade pops
 - v1.0.6 / O106 — Phase vocoder pitch shifter replacing WSOLA-Lite (issue #60)
 - v1.0.7 / O107 — dry path latency compensation + unique CFBundleIdentifier per build (issues #63, #62)
-- Next available: **v1.0.8 / O108**
+- v1.0.8 / O108 — transport-aware PV reset for intermittent buzzing (issue #65)
+- Next available: **v1.0.9 / O109**
 
 ### Running tests
 

--- a/Source/PhaseVocoderPitchShifter.h
+++ b/Source/PhaseVocoderPitchShifter.h
@@ -29,10 +29,15 @@ public:
     static constexpr int kNumBins   = kFFTSize / 2 + 1;      // 1025
 
     PhaseVocoderPitchShifter()
-        : fft (kFFTOrder),
-          window (static_cast<size_t> (kFFTSize),
-                  juce::dsp::WindowingFunction<float>::hann, false)
+        : fft (kFFTOrder)
     {
+        // v1.0.8: Generate periodic Hann window (N denominator, not N-1).
+        // JUCE's WindowingFunction::hann uses symmetric (N-1), which creates a
+        // ~-66 dB COLA ripple at the hop rate (93.75 Hz @ 48kHz/512 hop).
+        // Periodic Hann sums to exactly 1.5 under 4x overlap — zero ripple.
+        for (int i = 0; i < kFFTSize; ++i)
+            windowData[i] = 0.5f * (1.0f - std::cos (kTwoPi * static_cast<float> (i)
+                                                       / static_cast<float> (kFFTSize)));
         reset();
     }
 
@@ -123,7 +128,7 @@ private:
     static constexpr float kTwoPi      = 2.0f * kPi;
 
     juce::dsp::FFT fft;
-    juce::dsp::WindowingFunction<float> window;
+    float windowData[kFFTSize] = {};  // Periodic Hann window (generated in constructor)
 
     // Input ring buffer (stores last kFFTSize samples)
     float inputRing[kFFTSize] = {};
@@ -207,7 +212,7 @@ private:
             fftData[i] = inputRing[readIdx];
         }
 
-        window.multiplyWithWindowingTable (fftData, static_cast<size_t> (kFFTSize));
+        juce::FloatVectorOperations::multiply (fftData, windowData, kFFTSize);
 
         // Zero the second half (JUCE FFT requires 2*N buffer for real-only transform)
         std::memset (fftData + kFFTSize, 0, sizeof (float) * static_cast<size_t> (kFFTSize));
@@ -400,7 +405,7 @@ private:
         // =====================================================================
         // 8. Apply synthesis window and overlap-add
         // =====================================================================
-        window.multiplyWithWindowingTable (fftData, static_cast<size_t> (kFFTSize));
+        juce::FloatVectorOperations::multiply (fftData, windowData, kFFTSize);
 
         // COLA normalization for Hann window with 4x overlap:
         // Sum of squared Hann windows at hop=N/4 is 1.5, so divide by 1.5

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -4011,9 +4011,11 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
     //   6. OUTPUT MIX: dry/wet blend → output channels
 
     // Determine the loop length multiplier based on the highest enabled object index
-    // Smoothed to prevent clicks when enabling/disabling objects mid-playback
+    // v1.0.8: Snap instantly — the previous 50ms ramp swept the feedback read position
+    // through old buffer content, creating a Doppler chirp on tap enable (issue #65).
+    // The tap fade envelope already handles smooth onset of new taps.
     float loopMultiplierTarget = static_cast<float>(std::max (1, lastEnabledObjectIndex + 1));
-    smoothedLoopMultiplier.setTargetValue (loopMultiplierTarget);
+    smoothedLoopMultiplier.setCurrentAndTargetValue (loopMultiplierTarget);
 
     // --- Dispatch to appropriate render method --------------------------------
     if (isStereoVariant)

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -3861,13 +3861,7 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
         // Read per-object state via cached pointers (no string lookups)
         objects[t].enabled      = cachedObj[t].enabled->load()   > 0.5f;
 
-        // v1.0.8: Reset PV on tap enable transition to prevent chirping (issue #65)
-        // When a tap is disabled, its PV stops receiving samples (readObjectSample skipped).
-        // On re-enable, stale outputAccum/phase data causes a chirp. Reset clears it.
-        float newTarget = objects[t].enabled ? 1.0f : 0.0f;
-        if (newTarget > 0.0f && tapFadeTarget[t] <= 0.0f)
-            pvPitchShifters[t].reset();
-        tapFadeTarget[t] = newTarget;
+        tapFadeTarget[t] = objects[t].enabled ? 1.0f : 0.0f;
 
         // v0.9: When trajectory is active, read animated position from internal arrays
         // (the knobs/APVTS hold the origin; the internal arrays hold origin + trajectory offset)
@@ -4135,9 +4129,11 @@ void OpenSpatialDelayProcessor::renderDirectBinauralHRTF (
                 tapFadeGain[t] = std::min (tapFadeGain[t] + tapFadeIncrement, 1.0f);
             else if (tapFadeGain[t] > tapFadeTarget[t])
                 tapFadeGain[t] = std::max (tapFadeGain[t] - tapFadeIncrement, 0.0f);
+            // v1.0.8: Always feed PV to keep it in sync — prevents chirp on tap enable (issue #65)
+            float objMono = readObjectSample (t, baseDelaySamples);
             if (tapFadeGain[t] <= 0.0f) continue;
             float dist = prevDistGain[t] + frac * (objDistGain[t] - prevDistGain[t]);
-            sourceAccumBufPtrs[t][s] = readObjectSample (t, baseDelaySamples) * dist * tapFadeGain[t];
+            sourceAccumBufPtrs[t][s] = objMono * dist * tapFadeGain[t];
         }
 
         // STAGE 3: FEEDBACK (mono, pre-spatial)
@@ -4229,8 +4225,9 @@ void OpenSpatialDelayProcessor::renderSimpleBinauralWoodworth (
                 tapFadeGain[t] = std::min (tapFadeGain[t] + tapFadeIncrement, 1.0f);
             else if (tapFadeGain[t] > tapFadeTarget[t])
                 tapFadeGain[t] = std::max (tapFadeGain[t] - tapFadeIncrement, 0.0f);
-            if (tapFadeGain[t] <= 0.0f) continue;
+            // v1.0.8: Always feed PV to keep it in sync — prevents chirp on tap enable (issue #65)
             float objMono = readObjectSample (t, baseDelaySamples);
+            if (tapFadeGain[t] <= 0.0f) continue;
 
             // Interpolate between previous and current block gains
             float gL = prevBinauralGains[t].leftGain  + frac * (objGains[t].leftGain  - prevBinauralGains[t].leftGain);
@@ -4367,8 +4364,9 @@ void OpenSpatialDelayProcessor::renderStereoVariant (
                 tapFadeGain[t] = std::min (tapFadeGain[t] + tapFadeIncrement, 1.0f);
             else if (tapFadeGain[t] > tapFadeTarget[t])
                 tapFadeGain[t] = std::max (tapFadeGain[t] - tapFadeIncrement, 0.0f);
-            if (tapFadeGain[t] <= 0.0f) continue;
+            // v1.0.8: Always feed PV to keep it in sync — prevents chirp on tap enable (issue #65)
             float objMono = readObjectSample (t, baseDelaySamples);
+            if (tapFadeGain[t] <= 0.0f) continue;
 
             // Interpolate between previous and current block gains
             float gL = prevStereoGainL[t] + frac * (objGainL[t] - prevStereoGainL[t]);
@@ -4514,8 +4512,9 @@ void OpenSpatialDelayProcessor::renderAmbisonicsOutput (
                 tapFadeGain[t] = std::min (tapFadeGain[t] + tapFadeIncrement, 1.0f);
             else if (tapFadeGain[t] > tapFadeTarget[t])
                 tapFadeGain[t] = std::max (tapFadeGain[t] - tapFadeIncrement, 0.0f);
-            if (tapFadeGain[t] <= 0.0f) continue;
+            // v1.0.8: Always feed PV to keep it in sync — prevents chirp on tap enable (issue #65)
             float objMono = readObjectSample (t, baseDelaySamples);
+            if (tapFadeGain[t] <= 0.0f) continue;
 
             // Interpolate distance gain between previous and current block
             float dist = prevDistGain[t] + frac * (objDistGain[t] - prevDistGain[t]);
@@ -4619,8 +4618,9 @@ void OpenSpatialDelayProcessor::renderDiscreteSurround (
                 tapFadeGain[t] = std::min (tapFadeGain[t] + tapFadeIncrement, 1.0f);
             else if (tapFadeGain[t] > tapFadeTarget[t])
                 tapFadeGain[t] = std::max (tapFadeGain[t] - tapFadeIncrement, 0.0f);
-            if (tapFadeGain[t] <= 0.0f) continue;
+            // v1.0.8: Always feed PV to keep it in sync — prevents chirp on tap enable (issue #65)
             float objMono = readObjectSample (t, baseDelaySamples);
+            if (tapFadeGain[t] <= 0.0f) continue;
 
             // Interpolate distance gain and channel gains between previous and current block
             float dist = prevDistGain[t] + frac * (objDistGain[t] - prevDistGain[t]);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -3680,7 +3680,22 @@ void OpenSpatialDelayProcessor::processFeedbackSample (float currentLoopMult,
     float fbDelaySamples = currentLoopMult * baseDelaySamples;
     fbDelaySamples = juce::jlimit (1.0f, static_cast<float> (delayBufferSize - 2), fbDelaySamples);
 
-    float feedbackRaw = readDelayLineMono (fbDelaySamples);
+    float feedbackRaw;
+    // v1.0.8: Crossfade feedback between old and new positions on loop multiplier change (issue #65)
+    if (fbCrossfadeProgress < 1.0f)
+    {
+        float oldFbDelay = prevLoopMultiplier * baseDelaySamples;
+        oldFbDelay = juce::jlimit (1.0f, static_cast<float> (delayBufferSize - 2), oldFbDelay);
+
+        float oldSample = readDelayLineMono (oldFbDelay);
+        float newSample = readDelayLineMono (fbDelaySamples);
+        feedbackRaw = oldSample + fbCrossfadeProgress * (newSample - oldSample);
+        fbCrossfadeProgress = std::min (fbCrossfadeProgress + fbCrossfadeIncrement, 1.0f);
+    }
+    else
+    {
+        feedbackRaw = readDelayLineMono (fbDelaySamples);
+    }
     float filtered = filters.processFeedbackSample (feedbackRaw);
     const float makeupGain = 1.0f + (fb * fb * kMakeupGainCoeff);
     float newFeedback = softClip (filtered * makeupGain);
@@ -4011,10 +4026,14 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
     //   6. OUTPUT MIX: dry/wet blend → output channels
 
     // Determine the loop length multiplier based on the highest enabled object index
-    // v1.0.8: Snap instantly — the previous 50ms ramp swept the feedback read position
-    // through old buffer content, creating a Doppler chirp on tap enable (issue #65).
-    // The tap fade envelope already handles smooth onset of new taps.
+    // v1.0.8: When the multiplier changes, start a crossfade between old and new feedback
+    // read positions instead of sweeping — sweeping causes a Doppler chirp (issue #65).
     float loopMultiplierTarget = static_cast<float>(std::max (1, lastEnabledObjectIndex + 1));
+    if (loopMultiplierTarget != smoothedLoopMultiplier.getTargetValue())
+    {
+        prevLoopMultiplier = smoothedLoopMultiplier.getCurrentValue();
+        fbCrossfadeProgress = 0.0f;
+    }
     smoothedLoopMultiplier.setCurrentAndTargetValue (loopMultiplierTarget);
 
     // --- Dispatch to appropriate render method --------------------------------

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -3711,6 +3711,36 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
     if (delayBufferL.empty() || numSamples <= 0)
         return;
 
+    // v1.0.8: Transport-aware PV reset — clear stale phase state on transport
+    // stop→play, seek, or position jump to prevent intermittent buzzing (issue #65).
+    // The PV maintains phase/magnitude arrays across blocks; stale data after a
+    // transport discontinuity can cause phase coherence errors that sound like buzz.
+    {
+        auto* playHead = getPlayHead();
+        if (playHead != nullptr)
+        {
+            auto pos = playHead->getPosition();
+            if (pos.hasValue())
+            {
+                bool isPlaying = pos->getIsPlaying();
+                juce::int64 currentSample = pos->getTimeInSamples().orFallback (-1);
+
+                bool transportStarted = (! wasPlaying && isPlaying);
+                bool transportJumped  = (isPlaying && currentSample >= 0
+                                         && std::abs (currentSample - expectedNextSample) > numSamples);
+
+                if (transportStarted || transportJumped)
+                {
+                    for (int i = 0; i < MAX_OBJECTS; ++i)
+                        pvPitchShifters[i].reset();
+                }
+
+                wasPlaying = isPlaying;
+                expectedNextSample = currentSample + numSamples;
+            }
+        }
+    }
+
     // v1.0.1: Apply deferred preset reset on the audio thread (thread-safe).
     // loadPreset() sets the flag; we do the actual WSOLA/Doppler/filter reset here
     // so there's no race between message thread writes and audio thread reads.

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -3860,7 +3860,14 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
     {
         // Read per-object state via cached pointers (no string lookups)
         objects[t].enabled      = cachedObj[t].enabled->load()   > 0.5f;
-        tapFadeTarget[t] = objects[t].enabled ? 1.0f : 0.0f;
+
+        // v1.0.8: Reset PV on tap enable transition to prevent chirping (issue #65)
+        // When a tap is disabled, its PV stops receiving samples (readObjectSample skipped).
+        // On re-enable, stale outputAccum/phase data causes a chirp. Reset clears it.
+        float newTarget = objects[t].enabled ? 1.0f : 0.0f;
+        if (newTarget > 0.0f && tapFadeTarget[t] <= 0.0f)
+            pvPitchShifters[t].reset();
+        tapFadeTarget[t] = newTarget;
 
         // v0.9: When trajectory is active, read animated position from internal arrays
         // (the knobs/APVTS hold the origin; the internal arrays hold origin + trajectory offset)

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -918,6 +918,14 @@ private:
     // Smooth loop multiplier — prevents clicks when enabling/disabling objects
     juce::LinearSmoothedValue<float> smoothedLoopMultiplier;
 
+    // v1.0.8: Feedback crossfade for loop multiplier changes (issue #65)
+    // When the loop multiplier changes, crossfade the feedback read between old and new
+    // positions instead of sweeping — sweeping causes a Doppler chirp.
+    float prevLoopMultiplier = 1.0f;
+    float fbCrossfadeProgress = 1.0f;  // 1.0 = crossfade complete (use new position only)
+    static constexpr float kFbCrossfadeSamples = 1024.0f;  // ~21ms @ 48kHz
+    float fbCrossfadeIncrement = 1.0f / kFbCrossfadeSamples;
+
     //--- SPATIAL FRAMEWORK: Layout & decode state ----------------------------
     float ambiDecodeMatrix[NUM_VIRTUAL_SPEAKERS][HOA_CHANNELS] = {};  // v0.2+ surround decode
 

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -881,6 +881,11 @@ private:
     // v1.0.6: Phase vocoder pitch shifter — replaces WSOLA-Lite (issue #60)
     PhaseVocoderPitchShifter pvPitchShifters[MAX_OBJECTS];
 
+    // v1.0.8: Transport-aware PV reset — clears stale phase state on transport
+    // stop/start/seek to prevent intermittent buzzing artifacts (issue #65)
+    bool wasPlaying = false;
+    juce::int64 expectedNextSample = 0;
+
     // v1.0.1: Thread-safe preset reset — loadPreset() (message thread) stores pending
     // state here; processBlock() (audio thread) applies it, eliminating the data race
     // that caused intermittent WSOLA/Doppler corruption on preset changes (issue #42).


### PR DESCRIPTION
## Summary

Fixes intermittent buzzing and chirping artifacts in the phase vocoder pitch shifter and feedback path.

**Root cause:** When taps were enabled/disabled, the feedback loop multiplier ramp swept the read position through old delay buffer content — a Doppler-like chirp that fed back into the delay line. Confirmed: chirp disappeared at 0% feedback and occurred even at 0 semitones (PV not involved).

## Changes

### Feedback crossfade (root cause fix)
- `processFeedbackSample()` now crossfades between old and new feedback read positions over 1024 samples (~21ms) when the loop multiplier changes
- `smoothedLoopMultiplier` snaps instantly; the crossfade handles the smooth transition
- Eliminates chirp on both single-tap and multi-tap automation

### Phase vocoder improvements (defense in depth)
- **Transport-aware PV reset**: clears stale phase state on transport stop/start/seek
- **Periodic Hann window**: eliminates -66 dB COLA ripple (symmetric→periodic, SNR 66→317 dB)
- **Always-running PV**: feeds all PV instances continuously so tap enable produces immediately valid output

## Test plan
- [x] 174/195 tests pass (same baseline — 21 pre-existing surround failures)
- [x] Zero regressions across all fixes
- [x] Manual: Tap 3 enable/disable automation — no chirp
- [x] Manual: Tap 3 + Tap 7 multi-tap automation — no chirp or clicks
- [x] Manual: All 6 binaural + 5 stereo modes tested — clean
- [x] Manual: 0% feedback confirms feedback path was the source

Closes #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)