### PR TITLE
Fix 18 surround integration test failures (192/195 pass)

### DIFF
--- a/Tests/SurroundOutputTests.cpp
+++ b/Tests/SurroundOutputTests.cpp
@@ -35,6 +35,13 @@ static std::unique_ptr<Proc> createTestProcessor (int outputFormat = 0, int algo
     if (auto* p = proc->apvts.getParameter ("algorithm"))
         p->setValueNotifyingHost (p->convertTo0to1 (static_cast<float> (algorithm)));
 
+    // Set short delay and 100% wet BEFORE prepareToPlay so smoothed values
+    // initialize correctly — prevents 500ms default from starving the delay line
+    if (auto* p = proc->apvts.getParameter ("delayTime"))
+        p->setValueNotifyingHost (p->convertTo0to1 (1.0f));
+    if (auto* p = proc->apvts.getParameter ("dryWet"))
+        p->setValueNotifyingHost (p->convertTo0to1 (1.0f));
+
     proc->prepareToPlay (48000.0, 512);
     return proc;
 }
@@ -51,6 +58,13 @@ static std::unique_ptr<Proc> createConstrainedProcessor (int outputFormat, int a
     if (auto* p = proc->apvts.getParameter ("algorithm"))
         p->setValueNotifyingHost (p->convertTo0to1 (static_cast<float> (algorithm)));
 
+    // Set short delay and 100% wet BEFORE prepareToPlay so smoothed values
+    // initialize correctly — prevents 500ms default from starving the delay line
+    if (auto* p = proc->apvts.getParameter ("delayTime"))
+        p->setValueNotifyingHost (p->convertTo0to1 (1.0f));
+    if (auto* p = proc->apvts.getParameter ("dryWet"))
+        p->setValueNotifyingHost (p->convertTo0to1 (1.0f));
+
     juce::AudioProcessor::BusesLayout layout;
     layout.inputBuses.add (juce::AudioChannelSet::stereo());
     layout.outputBuses.add (outputChannelSet);
@@ -61,12 +75,27 @@ static std::unique_ptr<Proc> createConstrainedProcessor (int outputFormat, int a
 }
 
 // Process blocks with a buffer matching the constrained bus channel count.
+// Includes warmup period to fill the delay line and let parameter smoothing settle.
 static juce::AudioBuffer<float> processBlocksConstrained (Proc& proc, int numBlocks, int blockSize,
                                                            int numOutChannels, float inputLevel = 0.5f)
 {
     juce::AudioBuffer<float> result (numOutChannels, blockSize);
     result.clear();
     juce::MidiBuffer midi;
+
+    // Warmup: fill delay line and let smoothing settle (matches createBinauralProcessor pattern)
+    for (int w = 0; w < 30; ++w)
+    {
+        juce::AudioBuffer<float> buffer (numOutChannels, blockSize);
+        buffer.clear();
+        for (int s = 0; s < blockSize; ++s)
+        {
+            buffer.setSample (0, s, inputLevel);
+            if (numOutChannels > 1)
+                buffer.setSample (1, s, inputLevel);
+        }
+        proc.processBlock (buffer, midi);
+    }
 
     for (int b = 0; b < numBlocks; ++b)
     {
@@ -1045,6 +1074,7 @@ TEST_CASE ("Elevation: all algorithms — height isolation for horizontal source
 // Helper: process N blocks through the processor with a constant input signal.
 // Uses the processor's actual total output channel count (typically 50) for the buffer,
 // since processBlock may access channels up to getTotalNumOutputChannels().
+// Includes warmup period to fill the delay line and let parameter smoothing settle.
 static juce::AudioBuffer<float> processBlocks (Proc& proc, int numBlocks, int blockSize,
                                                 int /*numOutChannels_unused*/, float inputLevel = 0.5f)
 {
@@ -1053,6 +1083,19 @@ static juce::AudioBuffer<float> processBlocks (Proc& proc, int numBlocks, int bl
     result.clear();
 
     juce::MidiBuffer midi;
+
+    // Warmup: fill delay line and let smoothing settle (matches createBinauralProcessor pattern)
+    for (int w = 0; w < 30; ++w)
+    {
+        juce::AudioBuffer<float> buffer (totalCh, blockSize);
+        buffer.clear();
+        for (int s = 0; s < blockSize; ++s)
+        {
+            buffer.setSample (0, s, inputLevel);
+            buffer.setSample (1, s, inputLevel);
+        }
+        proc.processBlock (buffer, midi);
+    }
 
     for (int b = 0; b < numBlocks; ++b)
     {


### PR DESCRIPTION
## Summary
- Fix 18 pre-existing test failures documented in PR #70 (174→192 of 195 pass)
- **Test-only changes** — no plugin source code modified
- Root cause: `createTestProcessor()` set `delayTime` after `prepareToPlay()`, so `smoothedDelayTime` initialized to 500ms default. With only 8 blocks of processing, the delay buffer never filled — all surround output was zero.

## Changes (`Tests/SurroundOutputTests.cpp` only)
- `createTestProcessor()`: set `delayTime=1ms` and `dryWet=1.0` before `prepareToPlay()` so smoothed values initialize correctly
- `createConstrainedProcessor()`: same fix
- `processBlocks()`: add 30-block warmup period to fill delay line before capture
- `processBlocksConstrained()`: same warmup

## Remaining 3 failures (deferred)
All in `ConvolverGlitchTests.cpp` — HRTF/MinPhase tests that require plugin source changes:
- `Binaural HRTF — azimuth sweep glitch detection` (line 500)
- `Binaural HRTF — preset cycle with tap changes produces no clicks` (line 2392)
- `MinPhase HRTF — orbit sweep spectral flux` (line 3022)

## Test plan
- [x] Full test suite: 192/195 pass (3 deferred HRTF failures, 0 regressions)
- [x] All surround integration tests pass: 24/24
- [x] OSC tests: 47/47 pass
- [x] Trajectory tests: all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)