### PR TITLE
AU param ordering + hide config params from automation (#68)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,8 @@ bash scripts/build_version.sh <commit-hash> v1.0.X O10X
 - v1.0.6 / O106 — Phase vocoder pitch shifter replacing WSOLA-Lite (issue #60)
 - v1.0.7 / O107 — dry path latency compensation + unique CFBundleIdentifier per build (issues #63, #62)
 - v1.0.8 / O108 — transport-aware PV reset for intermittent buzzing (issue #65)
-- Next available: **v1.0.9 / O109**
+- v1.0.9 / O109 — AU parameter ordering via unique version hints + blank row fix (issue #68)
+- Next available: **v1.0.10 / O110**
 
 ### Running tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,8 @@ bash scripts/build_version.sh <commit-hash> v1.0.X O10X
 - v1.0.6 / O106 — Phase vocoder pitch shifter replacing WSOLA-Lite (issue #60)
 - v1.0.7 / O107 — dry path latency compensation + unique CFBundleIdentifier per build (issues #63, #62)
 - v1.0.8 / O108 — transport-aware PV reset for intermittent buzzing (issue #65)
-- v1.0.9 / O109 — AU parameter ordering via unique version hints + blank row fix (issue #68)
-- v1.0.10 / O110 — hide 4 config params from DAW automation list (issue #68)
-- Next available: **v1.0.11 / O111**
+- v1.0.9 / O109 — AU param ordering + hide config params from automation (issue #68)
+- Next available: **v1.0.10 / O110**
 
 ### Running tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,8 @@ bash scripts/build_version.sh <commit-hash> v1.0.X O10X
 - v1.0.7 / O107 — dry path latency compensation + unique CFBundleIdentifier per build (issues #63, #62)
 - v1.0.8 / O108 — transport-aware PV reset for intermittent buzzing (issue #65)
 - v1.0.9 / O109 — AU parameter ordering via unique version hints + blank row fix (issue #68)
-- Next available: **v1.0.10 / O110**
+- v1.0.10 / O110 — hide 4 config params from DAW automation list (issue #68)
+- Next available: **v1.0.11 / O111**
 
 ### Running tests
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,7 @@ if(BUILD_OSD_TESTS)
     FetchContent_MakeAvailable(Catch2)
 
     add_executable(OpenSpatialDelayTests
+        Tests/ParameterCountTests.cpp
         Tests/TrajectoryTests.cpp
         Tests/SurroundOutputTests.cpp
         Tests/OscTests.cpp

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -2006,14 +2006,23 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         if (selectedId > 0)
         {
             int paramIdx = selectedId - 1;  // IDs are 1-based, param indices are 0-based
-            auto* param = processorRef.apvts.getParameter ("algorithm");
-            float normVal = static_cast<float> (paramIdx) / 10.0f;  // 11 items (0..10)
-            param->setValueNotifyingHost (normVal);
+            processorRef.configAlgorithm.store (paramIdx, std::memory_order_relaxed);
         }
     };
-    setupCombo (hrtfProfileBox, hrtfProfileLabel, "PROFILE",
-                "hrtfProfile", { "Simple", "Studio Ref", "Immersive", "Natural", "Precise", "Spatial" },
-                hrtfProfileAttach);
+    {
+        juce::StringArray hrtfItems { "Simple", "Studio Ref", "Immersive", "Natural", "Precise", "Spatial" };
+        for (int i = 0; i < hrtfItems.size(); ++i)
+            hrtfProfileBox.addItem (hrtfItems[i], i + 1);
+        hrtfProfileBox.setLookAndFeel (&osdLookAndFeel);
+        addAndMakeVisible (hrtfProfileBox);
+        styleLabel (hrtfProfileLabel, "PROFILE", &osdLookAndFeel);
+        addAndMakeVisible (hrtfProfileLabel);
+        hrtfProfileBox.setSelectedItemIndex (processorRef.configHrtfProfile.load (std::memory_order_relaxed),
+                                             juce::dontSendNotification);
+        hrtfProfileBox.onChange = [this] {
+            processorRef.configHrtfProfile.store (hrtfProfileBox.getSelectedItemIndex(), std::memory_order_relaxed);
+        };
+    }
     // v0.7: syncMode reworked to 3-state (Straight/Dotted/Triplet)
     // Uses music note icons: straight = ♩, dotted = ♩., triplet = ♩³
     setupCombo (syncModeBox, delayTimeLabel, "SYNC MODE",
@@ -2027,8 +2036,17 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         juce::StringArray formatNames;
         for (const auto& info : OpenSpatialDelayProcessor::outputFormatRegistry)
             formatNames.add (info.name);
-        setupCombo (outputFormatBox, outputFormatLabel, "OUTPUT",
-                    "outputFormat", formatNames, outputFormatAttach);
+        for (int i = 0; i < formatNames.size(); ++i)
+            outputFormatBox.addItem (formatNames[i], i + 1);
+        outputFormatBox.setLookAndFeel (&osdLookAndFeel);
+        addAndMakeVisible (outputFormatBox);
+        styleLabel (outputFormatLabel, "OUTPUT", &osdLookAndFeel);
+        addAndMakeVisible (outputFormatLabel);
+        outputFormatBox.setSelectedItemIndex (processorRef.configOutputFormat.load (std::memory_order_relaxed),
+                                              juce::dontSendNotification);
+        outputFormatBox.onChange = [this] {
+            processorRef.configOutputFormat.store (outputFormatBox.getSelectedItemIndex(), std::memory_order_relaxed);
+        };
     }
 
     // --- Header dropdown labels: left-aligned, JetBrains Mono Medium ----------
@@ -2438,7 +2456,11 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
     inputFormatBox.addItem ("Mono", 1);
     inputFormatBox.addItem ("Stereo", 2);
     addAndMakeVisible (inputFormatBox);
-    inputFormatAttach = std::make_unique<ComboBoxAttachment> (processorRef.apvts, "inputFormat", inputFormatBox);
+    inputFormatBox.setSelectedItemIndex (processorRef.configInputFormat.load (std::memory_order_relaxed),
+                                        juce::dontSendNotification);
+    inputFormatBox.onChange = [this] {
+        processorRef.configInputFormat.store (inputFormatBox.getSelectedItemIndex(), std::memory_order_relaxed);
+    };
 
     // Header dropdown labels: JetBrains Mono Medium 7.5px, wide kerning
     {
@@ -2705,7 +2727,7 @@ void OpenSpatialDelayEditor::selectObject (int index)
             objInputChannelButton->setAccentColour (objCol);
 
         // Visibility: only show when Input Format = Stereo (index 1)
-        int inputFmt = static_cast<int> (processorRef.apvts.getRawParameterValue ("inputFormat")->load());
+        int inputFmt = processorRef.configInputFormat.load (std::memory_order_relaxed);
         objInputChannelButton->setVisible (inputFmt == 1);
     }
 
@@ -2893,7 +2915,7 @@ void OpenSpatialDelayEditor::timerCallback()
 
     // v0.8: Show/hide input channel button based on Input Format (Mono=hide, Stereo=show)
     {
-        int inputFmt = static_cast<int> (processorRef.apvts.getRawParameterValue ("inputFormat")->load());
+        int inputFmt = processorRef.configInputFormat.load (std::memory_order_relaxed);
         if (objInputChannelButton) objInputChannelButton->setVisible (inputFmt == 1);
     }
 
@@ -2989,7 +3011,7 @@ void OpenSpatialDelayEditor::timerCallback()
     // Ambisonics: show disabled, text = "Ambisonics Encode"
     // Stereo: show only stereo modes (param indices 6-10)
     // Surround: show only surround algorithms (param indices 0-5)
-    int algoIdx = static_cast<int> (processorRef.apvts.getRawParameterValue ("algorithm")->load());
+    int algoIdx = processorRef.configAlgorithm.load (std::memory_order_relaxed);
 
     // Determine current format category: 0=binaural, 1=ambi, 2=stereo, 3=surround
     int fmtCategory = isBinaural ? 0 : isAmbiOutput ? 1 : isStereoVariant ? 2 : 3;
@@ -3030,8 +3052,7 @@ void OpenSpatialDelayEditor::timerCallback()
                 // Auto-snap if current param is a surround algorithm
                 if (algoIdx < 6)
                 {
-                    processorRef.apvts.getParameter ("algorithm")
-                        ->setValueNotifyingHost (6.0f / 10.0f);  // Equal Power
+                    processorRef.configAlgorithm.store (6, std::memory_order_relaxed);  // Equal Power
                     algoIdx = 6;
                 }
             }
@@ -3048,8 +3069,7 @@ void OpenSpatialDelayEditor::timerCallback()
                 // Auto-snap if current param is a stereo mode
                 if (algoIdx > 5)
                 {
-                    processorRef.apvts.getParameter ("algorithm")
-                        ->setValueNotifyingHost (4.0f / 10.0f);  // VBAP
+                    processorRef.configAlgorithm.store (4, std::memory_order_relaxed);  // VBAP
                     algoIdx = 4;
                 }
             }

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -638,7 +638,7 @@ private:
     std::unique_ptr<SliderAttachment> delayTimeAttach, noteDivisionAttach, feedbackAttach;
     std::unique_ptr<SliderAttachment> filterHPAttach, filterLPAttach;
     std::unique_ptr<SliderAttachment> dryWetAttach;
-    std::unique_ptr<ComboBoxAttachment> hrtfProfileAttach, syncModeAttach, outputFormatAttach;
+    std::unique_ptr<ComboBoxAttachment> syncModeAttach;
     int lastAlgoCategoryShown = -1;  // Track format category to avoid redundant combo rebuilds
     int lastMaxBusChannels    = -1;  // v0.7: Gate format availability re-check
     int lastOscPort           = -1;  // v0.7: Gate OSC port label sync
@@ -658,8 +658,7 @@ private:
     // v0.7: Per-object pitch shift attachment (rebound in selectObject)
     std::unique_ptr<SliderAttachment> objPitchShiftAttach;
 
-    // v0.7: Input format attachment
-    std::unique_ptr<ComboBoxAttachment> inputFormatAttach;
+    // v0.7: Input format — no attachment, uses onChange callback (issue #68)
 
     // v0.8: Per-object input channel attachment (rebound in selectObject)
     std::unique_ptr<ComboBoxAttachment> objInputChannelAttach;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -319,88 +319,62 @@ juce::AudioProcessorValueTreeState::ParameterLayout
         juce::NormalisableRange<float> (-100.0f, 12.0f, 0.1f, 3.0f), 0.0f,
         juce::AudioParameterFloatAttributes().withStringFromValueFunction (fmtDbInf)));
 
-    // G14: Algorithm (non-automatable — switching mid-playback causes glitches)
-    params.push_back (std::make_unique<juce::AudioParameterChoice> (
-        juce::ParameterID ("algorithm", 14), "Algorithm",
-        juce::StringArray { "Ambisonics (HOA)", "DBAP", "KNN", "MDAP", "VBAP", "VBIP",
-                            "Equal Power", "Stereo VBAP", "XY Pair", "MS Encode", "Blumlein" }, 0,
-        juce::AudioParameterChoiceAttributes().withAutomatable (false)));
+    // Issue #68: Algorithm, HRTF Profile, Output Format, and Input Format removed from APVTS.
+    // They are now stored as raw std::atomic<int> members (configAlgorithm, configHrtfProfile,
+    // configOutputFormat, configInputFormat) to hide them from DAW automation lists.
 
-    // G15: HRTF Profile (non-automatable — triggers async SOFA reload)
-    params.push_back (std::make_unique<juce::AudioParameterChoice> (
-        juce::ParameterID ("hrtfProfile", 15), "HRTF Profile",
-        juce::StringArray { "Simple (Low CPU)", "Studio Reference", "Immersive",
-                            "Natural", "Precise", "Spatial" }, 0,
-        juce::AudioParameterChoiceAttributes().withAutomatable (false)));
-
-    // G16: Output Format (non-automatable — changes bus layout)
-    {
-        juce::StringArray formatNames;
-        for (const auto& info : outputFormatRegistry)
-            formatNames.add (info.name);
-        params.push_back (std::make_unique<juce::AudioParameterChoice> (
-            juce::ParameterID ("outputFormat", 16), "Output Format", formatNames, 0,
-            juce::AudioParameterChoiceAttributes().withAutomatable (false)));
-    }
-
-    // G17: Air Absorption
+    // G14: Air Absorption
     params.push_back (std::make_unique<juce::AudioParameterBool> (
-        juce::ParameterID ("airAbsorption", 17), "Air Absorption", false));
+        juce::ParameterID ("airAbsorption", 14), "Air Absorption", false));
 
-    // G18: Wobble On (was "Wobble Enabled" — moved before wobble params, enable→configure)
+    // G15: Wobble On (was "Wobble Enabled" — moved before wobble params, enable→configure)
     params.push_back (std::make_unique<juce::AudioParameterBool> (
-        juce::ParameterID ("wobbleEnabled", 18), "Wobble On", false));
+        juce::ParameterID ("wobbleEnabled", 15), "Wobble On", false));
 
-    // G19: Wobble Amount
+    // G16: Wobble Amount
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("wobbleAmount", 19), "Wobble Amount",
+        juce::ParameterID ("wobbleAmount", 16), "Wobble Amount",
         juce::NormalisableRange<float> (0.0f, 100.0f, 0.1f), 0.0f,
         juce::AudioParameterFloatAttributes().withLabel ("%").withStringFromValueFunction (fmtPct100)));
 
-    // G20: Wobble Morph
+    // G17: Wobble Morph
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("wobbleMorph", 20), "Wobble Morph",
+        juce::ParameterID ("wobbleMorph", 17), "Wobble Morph",
         juce::NormalisableRange<float> (0.0f, 100.0f, 0.1f), 0.0f,
         juce::AudioParameterFloatAttributes().withLabel ("%").withStringFromValueFunction (fmtPct100)));
 
-    // G21: Input Format (non-automatable — changes bus routing)
-    params.push_back (std::make_unique<juce::AudioParameterChoice> (
-        juce::ParameterID ("inputFormat", 21), "Input Format",
-        juce::StringArray { "Mono", "Stereo" }, 0,
-        juce::AudioParameterChoiceAttributes().withAutomatable (false)));
-
-    // G22: OSC Bypass (was "ADM-OSC Enabled" — inverted: true=bypassed=all OSC off)
+    // G18: OSC Bypass (was "ADM-OSC Enabled" — inverted: true=bypassed=all OSC off)
     params.push_back (std::make_unique<juce::AudioParameterBool> (
-        juce::ParameterID ("admOscEnabled", 22), "OSC Bypass", true));
+        juce::ParameterID ("admOscEnabled", 18), "OSC Bypass", true));
 
-    // G23–G28: Global Tap Offsets (promoted from OSC-only atomics to APVTS)
+    // G19–G24: Global Tap Offsets (promoted from OSC-only atomics to APVTS)
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("globalTapAzimuth", 23), "Global Tap Azimuth",
+        juce::ParameterID ("globalTapAzimuth", 19), "Global Tap Azimuth",
         juce::NormalisableRange<float> (-180.0f, 180.0f, 0.1f), 0.0f,
         juce::AudioParameterFloatAttributes().withStringFromValueFunction (fmtDeg)));
 
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("globalTapElevation", 24), "Global Tap Elevation",
+        juce::ParameterID ("globalTapElevation", 20), "Global Tap Elevation",
         juce::NormalisableRange<float> (-90.0f, 90.0f, 0.1f), 0.0f,
         juce::AudioParameterFloatAttributes().withStringFromValueFunction (fmtDeg)));
 
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("globalTapDistance", 25), "Global Tap Distance",
+        juce::ParameterID ("globalTapDistance", 21), "Global Tap Distance",
         juce::NormalisableRange<float> (-1.0f, 1.0f, 0.01f), 0.0f));
 
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("globalTapPitch", 26), "Global Tap Pitch",
+        juce::ParameterID ("globalTapPitch", 22), "Global Tap Pitch",
         juce::NormalisableRange<float> (-24.0f, 24.0f, 1.0f), 0.0f,
         juce::AudioParameterFloatAttributes().withStringFromValueFunction (
             [](float value, int) { return juce::String (juce::roundToInt (value)) + " st"; })));
 
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("globalTapDoppler", 27), "Global Tap Doppler",
+        juce::ParameterID ("globalTapDoppler", 23), "Global Tap Doppler",
         juce::NormalisableRange<float> (-100.0f, 100.0f, 0.1f), 0.0f,
         juce::AudioParameterFloatAttributes().withLabel ("%").withStringFromValueFunction (fmtPct100)));
 
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("globalTapSpeed", 28), "Global Tap Speed",
+        juce::ParameterID ("globalTapSpeed", 24), "Global Tap Speed",
         juce::NormalisableRange<float> (-5.0f, 5.0f, 0.01f), 0.0f,
         juce::AudioParameterFloatAttributes().withLabel ("Hz").withStringFromValueFunction (
             [](float value, int) { return juce::String (value, 2) + " Hz"; })));
@@ -1429,8 +1403,8 @@ void OpenSpatialDelayProcessor::timerCallback()
             if (cachedParam_dryWet)         sendGlobal ("drywet",        cachedParam_dryWet->load(),         pg.dryWet);
             if (cachedParam_inputGain)      sendGlobal ("inputgain",     cachedParam_inputGain->load(),      pg.inputGain);
             if (cachedParam_outputGain)     sendGlobal ("outputgain",    cachedParam_outputGain->load(),     pg.outputGain);
-            if (cachedParam_algorithm)      sendGlobal ("algorithm",     cachedParam_algorithm->load(),      pg.algorithm);
-            if (cachedParam_hrtfProfile)    sendGlobal ("hrtfprofile",   cachedParam_hrtfProfile->load(),    pg.hrtfProfile);
+            sendGlobal ("algorithm",     static_cast<float> (configAlgorithm.load (std::memory_order_relaxed)),  pg.algorithm);
+            sendGlobal ("hrtfprofile",   static_cast<float> (configHrtfProfile.load (std::memory_order_relaxed)), pg.hrtfProfile);
             if (cachedParam_airAbsorption)  sendGlobal ("air",           cachedParam_airAbsorption->load(),  pg.airAbsorption);
             if (cachedParam_wobbleEnabled)  sendGlobal ("wobble",        cachedParam_wobbleEnabled->load(),  pg.wobbleEnabled);
             if (cachedParam_wobbleAmount)   sendGlobal ("wobbleamount",  cachedParam_wobbleAmount->load(),   pg.wobbleAmount);
@@ -1448,9 +1422,8 @@ void OpenSpatialDelayProcessor::timerCallback()
                     oscSender.send (m);
                 }
             }
-            if (auto* fmtParam = apvts.getRawParameterValue ("outputFormat"))
             {
-                float v = fmtParam->load();
+                float v = static_cast<float> (configOutputFormat.load (std::memory_order_relaxed));
                 if (std::abs (v - pg.outputFormat) > 0.001f)
                 {
                     pg.outputFormat = v;
@@ -1524,18 +1497,15 @@ OpenSpatialDelayProcessor::OpenSpatialDelayProcessor()
     cachedParam_filterHPQ       = apvts.getRawParameterValue ("filterHPQ");
     cachedParam_filterLPQ       = apvts.getRawParameterValue ("filterLPQ");
     cachedParam_filterEnabled   = apvts.getRawParameterValue ("filterEnabled");
-    cachedParam_hrtfProfile     = apvts.getRawParameterValue ("hrtfProfile");
     cachedParam_airAbsorption   = apvts.getRawParameterValue ("airAbsorption");
     cachedParam_wobbleEnabled   = apvts.getRawParameterValue ("wobbleEnabled");
     cachedParam_wobbleAmount    = apvts.getRawParameterValue ("wobbleAmount");
     cachedParam_wobbleMorph     = apvts.getRawParameterValue ("wobbleMorph");
-    cachedParam_inputFormat     = apvts.getRawParameterValue ("inputFormat");
     cachedParam_delayTime       = apvts.getRawParameterValue ("delayTime");
     cachedParam_dryWet          = apvts.getRawParameterValue ("dryWet");
     cachedParam_feedback        = apvts.getRawParameterValue ("feedback");
     cachedParam_inputGain       = apvts.getRawParameterValue ("inputGain");
     cachedParam_outputGain      = apvts.getRawParameterValue ("outputGain");
-    cachedParam_algorithm       = apvts.getRawParameterValue ("algorithm");
     cachedParam_admOscEnabled   = apvts.getRawParameterValue ("admOscEnabled");
     // issue #68: Cache global tap offset APVTS pointers
     cachedParam_globalTapAzimuth   = apvts.getRawParameterValue ("globalTapAzimuth");
@@ -1721,8 +1691,8 @@ void OpenSpatialDelayProcessor::loadPreset (int index)
     setBool   ("wobbleEnabled", preset->wobbleEnabled);
     setFloat  ("wobbleAmount", preset->wobbleAmount);
     setFloat  ("wobbleMorph",  preset->wobbleMorph);
-    setChoice ("algorithm",    preset->algorithm);
-    setChoice ("hrtfProfile",  preset->hrtfProfile);
+    configAlgorithm.store (preset->algorithm, std::memory_order_relaxed);
+    configHrtfProfile.store (preset->hrtfProfile, std::memory_order_relaxed);
     // NOTE: outputFormat, admOscEnabled, oscReceivePort are NOT modified by presets
 
     // Per-tap params
@@ -1822,8 +1792,8 @@ PresetData OpenSpatialDelayProcessor::captureCurrentState() const
     pd.wobbleEnabled = apvts.getRawParameterValue ("wobbleEnabled")->load() > 0.5f;
     pd.wobbleAmount  = apvts.getRawParameterValue ("wobbleAmount")->load();
     pd.wobbleMorph   = apvts.getRawParameterValue ("wobbleMorph")->load();
-    pd.algorithm    = static_cast<int> (apvts.getRawParameterValue ("algorithm")->load());
-    pd.hrtfProfile  = static_cast<int> (apvts.getRawParameterValue ("hrtfProfile")->load());
+    pd.algorithm    = configAlgorithm.load (std::memory_order_relaxed);
+    pd.hrtfProfile  = configHrtfProfile.load (std::memory_order_relaxed);
 
     for (int i = 0; i < MAX_OBJECTS; ++i)
     {
@@ -2479,7 +2449,7 @@ void OpenSpatialDelayProcessor::prepareToPlay (double sampleRate, int samplesPer
 
     // v0.2: Resolve output format from user selection + bus constraint
     maxBusChannels = getTotalNumOutputChannels();
-    int userFormatIndex = static_cast<int> (apvts.getRawParameterValue ("outputFormat")->load());
+    int userFormatIndex = configOutputFormat.load (std::memory_order_relaxed);
     auto userFormat = outputFormatRegistry[static_cast<size_t> (juce::jlimit (0, NUM_OUTPUT_FORMATS - 1, userFormatIndex))].format;
     auto effectiveFormat = resolveEffectiveFormat (userFormat, maxBusChannels);
     activateLayout (effectiveFormat);
@@ -3842,7 +3812,7 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
     float filterLPQ       = cachedParam_filterLPQ->load();
     // v0.9: Filter bypass driven by dedicated parameter (not threshold inference)
     bool filterEnabled = cachedParam_filterEnabled->load() > 0.5f;
-    int   profileIndex    = static_cast<int> (cachedParam_hrtfProfile->load());
+    int   profileIndex    = configHrtfProfile.load (std::memory_order_relaxed);
 
     // v0.4: Air absorption — true bypass with edge detection for immediate toggle response
     airAbsorptionActive = cachedParam_airAbsorption->load() > 0.5f;
@@ -3857,7 +3827,7 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
     }
 
     // v0.8: Input format (0=Mono, 1=Stereo) — selects whether dual delay lines receive L/R or summed mono
-    int inputFormat = static_cast<int> (cachedParam_inputFormat->load());
+    int inputFormat = configInputFormat.load (std::memory_order_relaxed);
 
     // (#3) Calculate target base delay
     float targetBaseDelayMs;
@@ -3896,7 +3866,7 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
 
 
     // --- Read algorithm selection (block-rate, surround only) -----------------
-    int algorithmIndex = static_cast<int> (cachedParam_algorithm->load());
+    int algorithmIndex = configAlgorithm.load (std::memory_order_relaxed);
     auto* algo = algorithms[juce::jlimit (0, NUM_ALGORITHMS - 1, algorithmIndex)];
 
     // For surround output, fall back if algorithm doesn't support speakers
@@ -4910,9 +4880,9 @@ void OpenSpatialDelayProcessor::oscMessageReceived (const juce::OSCMessage& mess
         else if (property == "/drywet")        handleOSCParam ("dryWet", val);
         else if (property == "/inputgain")     handleOSCParam ("inputGain", val);
         else if (property == "/outputgain")    handleOSCParam ("outputGain", val);
-        else if (property == "/algorithm")     handleOSCParam ("algorithm", val);
-        else if (property == "/hrtfprofile")   handleOSCParam ("hrtfProfile", val);
-        else if (property == "/outputformat")  handleOSCParam ("outputFormat", val);
+        else if (property == "/algorithm")    configAlgorithm.store (juce::roundToInt (val), std::memory_order_relaxed);
+        else if (property == "/hrtfprofile")  configHrtfProfile.store (juce::roundToInt (val), std::memory_order_relaxed);
+        else if (property == "/outputformat") configOutputFormat.store (juce::roundToInt (val), std::memory_order_relaxed);
         else if (property == "/air")           handleOSCParam ("airAbsorption", val);
         else if (property == "/wobble")        handleOSCParam ("wobbleEnabled", val);
         else if (property == "/wobbleamount")  handleOSCParam ("wobbleAmount", val);
@@ -5003,7 +4973,12 @@ void OpenSpatialDelayProcessor::handleOSCPosition (int objIdx, float azDeg, floa
 void OpenSpatialDelayProcessor::getStateInformation (juce::MemoryBlock& destData)
 {
     auto state = apvts.copyState();
-    state.setProperty ("pluginStateVersion", 19, nullptr);  // v1.0 state format (19 = 9.1.4 added)
+    state.setProperty ("pluginStateVersion", 20, nullptr);  // v1.0 state format (20 = config params moved out of APVTS)
+    // Issue #68: Config params stored as top-level properties (not APVTS children)
+    state.setProperty ("configAlgorithm", configAlgorithm.load (std::memory_order_relaxed), nullptr);
+    state.setProperty ("configHrtfProfile", configHrtfProfile.load (std::memory_order_relaxed), nullptr);
+    state.setProperty ("configOutputFormat", configOutputFormat.load (std::memory_order_relaxed), nullptr);
+    state.setProperty ("configInputFormat", configInputFormat.load (std::memory_order_relaxed), nullptr);
     state.setProperty ("oscReceivePort", oscReceivePort, nullptr);  // v0.6: persist OSC port
     state.setProperty ("globalDrawerOpen", globalDrawerOpen, nullptr);  // v1.0: persist drawer state
     state.setProperty ("currentPresetIndex", currentPresetIndex, nullptr);  // v0.6: persist preset selection
@@ -5496,6 +5471,54 @@ void OpenSpatialDelayProcessor::setStateInformation (const void* data, int sizeI
         }
 
         tree.setProperty ("pluginStateVersion", 19, nullptr);
+    }
+
+    // Issue #68: Migrate config params from APVTS children (old sessions) to top-level properties.
+    // Old sessions (savedVersion < 20) stored algorithm/hrtfProfile/outputFormat/inputFormat
+    // as normalized-float APVTS child nodes. New sessions store them as integer top-level properties.
+    if (savedVersion < 20)
+    {
+        // Extract config param values from APVTS child nodes, then remove those children
+        // so APVTS doesn't try to restore params that no longer exist in the layout.
+        struct ConfigParamMigration { const char* id; int numChoices; std::atomic<int>* target; };
+        ConfigParamMigration migrations[] = {
+            { "algorithm",    11, &configAlgorithm },
+            { "hrtfProfile",   6, &configHrtfProfile },
+            { "outputFormat", 22, &configOutputFormat },
+            { "inputFormat",   2, &configInputFormat },
+        };
+
+        for (auto& m : migrations)
+        {
+            for (int i = tree.getNumChildren() - 1; i >= 0; --i)
+            {
+                auto child = tree.getChild (i);
+                if (child.hasProperty ("id") && child.getProperty ("id").toString() == m.id)
+                {
+                    float normVal = static_cast<float> (child.getProperty ("value", 0.0f));
+                    int index = juce::roundToInt (normVal * static_cast<float> (m.numChoices - 1));
+                    index = juce::jlimit (0, m.numChoices - 1, index);
+                    m.target->store (index, std::memory_order_relaxed);
+                    tree.removeChild (i, nullptr);
+                    break;
+                }
+            }
+        }
+
+        // Store as top-level properties for future saves
+        tree.setProperty ("configAlgorithm", configAlgorithm.load (std::memory_order_relaxed), nullptr);
+        tree.setProperty ("configHrtfProfile", configHrtfProfile.load (std::memory_order_relaxed), nullptr);
+        tree.setProperty ("configOutputFormat", configOutputFormat.load (std::memory_order_relaxed), nullptr);
+        tree.setProperty ("configInputFormat", configInputFormat.load (std::memory_order_relaxed), nullptr);
+        tree.setProperty ("pluginStateVersion", 20, nullptr);
+    }
+    else
+    {
+        // New session format: config params are top-level integer properties
+        configAlgorithm.store (static_cast<int> (tree.getProperty ("configAlgorithm", 0)), std::memory_order_relaxed);
+        configHrtfProfile.store (static_cast<int> (tree.getProperty ("configHrtfProfile", 0)), std::memory_order_relaxed);
+        configOutputFormat.store (static_cast<int> (tree.getProperty ("configOutputFormat", 0)), std::memory_order_relaxed);
+        configInputFormat.store (static_cast<int> (tree.getProperty ("configInputFormat", 0)), std::memory_order_relaxed);
     }
 
     // v0.6: Restore OSC receive port (non-APVTS property)

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -221,6 +221,8 @@ juce::AudioProcessorValueTreeState::ParameterLayout
     };
 
     // --- Global parameters (issue #68: reordered, renamed, audited) ---------
+    // Version hints: unique ascending per param for correct AU enumeration order.
+    // Globals use 1–28, per-tap uses 100 + tapIndex*20 + offset. See issue #68.
 
     // G1: Delay Time
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
@@ -235,12 +237,12 @@ juce::AudioProcessorValueTreeState::ParameterLayout
 
     // G2: Delay Sync (was "Tempo Sync")
     params.push_back (std::make_unique<juce::AudioParameterBool> (
-        juce::ParameterID ("tempoSync", 1), "Delay Sync", false));
+        juce::ParameterID ("tempoSync", 2), "Delay Sync", false));
 
     // G3: Delay Division (was "Note Division")
     // Value = number of 16th notes. Range: 0.5 (1/32) to 32 (2/1)
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("noteDivision", 1), "Delay Division",
+        juce::ParameterID ("noteDivision", 3), "Delay Division",
         juce::NormalisableRange<float> (0.5f, 32.0f, 0.5f), 4.0f,
         juce::AudioParameterFloatAttributes().withStringFromValueFunction (
             [](float value, int) {
@@ -259,29 +261,29 @@ juce::AudioProcessorValueTreeState::ParameterLayout
 
     // G4: Sync Mode
     params.push_back (std::make_unique<juce::AudioParameterChoice> (
-        juce::ParameterID ("syncMode", 7), "Sync Mode",
+        juce::ParameterID ("syncMode", 4), "Sync Mode",
         juce::StringArray { "Straight", "Dotted", "Triplet" }, 0));
 
     // G5: Feedback
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("feedback", 1), "Feedback",
+        juce::ParameterID ("feedback", 5), "Feedback",
         juce::NormalisableRange<float> (0.0f, 1.0f, 0.01f), 0.3f,
         juce::AudioParameterFloatAttributes().withLabel ("%").withStringFromValueFunction (fmtPct01)));
 
     // G6: Filter On (was "Filter Enabled" — moved before filter params, enable→configure)
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("filterEnabled", 9), "Filter On",
+        juce::ParameterID ("filterEnabled", 6), "Filter On",
         juce::NormalisableRange<float> (0.0f, 1.0f, 1.0f), 0.0f));
 
     // G7: High-Pass Frequency (was "High-Pass Filter" — HP grouped before LP)
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("filterHP", 9), "High-Pass Frequency",
+        juce::ParameterID ("filterHP", 7), "High-Pass Frequency",
         juce::NormalisableRange<float> (20.0f, 5000.0f, 1.0f, 0.3f), 50.0f,
         juce::AudioParameterFloatAttributes().withStringFromValueFunction (fmtFreq)));
 
     // G8: High-Pass Resonance (was "HP Resonance")
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("filterHPQ", 7), "High-Pass Resonance",
+        juce::ParameterID ("filterHPQ", 8), "High-Pass Resonance",
         juce::NormalisableRange<float> (0.5f, 8.0f, 0.01f, 0.4f), 0.707f,
         juce::AudioParameterFloatAttributes().withStringFromValueFunction (
             [](float value, int) { return juce::String (value, 2); })));
@@ -294,39 +296,39 @@ juce::AudioProcessorValueTreeState::ParameterLayout
 
     // G10: Low-Pass Resonance (was "LP Resonance")
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("filterLPQ", 7), "Low-Pass Resonance",
+        juce::ParameterID ("filterLPQ", 10), "Low-Pass Resonance",
         juce::NormalisableRange<float> (0.5f, 8.0f, 0.01f, 0.4f), 0.707f,
         juce::AudioParameterFloatAttributes().withStringFromValueFunction (
             [](float value, int) { return juce::String (value, 2); })));
 
     // G11: Dry/Wet
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("dryWet", 1), "Dry/Wet",
+        juce::ParameterID ("dryWet", 11), "Dry/Wet",
         juce::NormalisableRange<float> (0.0f, 1.0f, 0.01f), 0.5f,
         juce::AudioParameterFloatAttributes().withLabel ("%").withStringFromValueFunction (fmtPct01)));
 
     // G12: Input Gain (-100 dB shown as -∞ to +40 dB)
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("inputGain", 1), "Input Gain",
+        juce::ParameterID ("inputGain", 12), "Input Gain",
         juce::NormalisableRange<float> (-100.0f, 40.0f, 0.1f, 3.0f), 0.0f,
         juce::AudioParameterFloatAttributes().withStringFromValueFunction (fmtDbInf)));
 
     // G13: Output Gain (-100 dB shown as -∞ to +12 dB)
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("outputGain", 1), "Output Gain",
+        juce::ParameterID ("outputGain", 13), "Output Gain",
         juce::NormalisableRange<float> (-100.0f, 12.0f, 0.1f, 3.0f), 0.0f,
         juce::AudioParameterFloatAttributes().withStringFromValueFunction (fmtDbInf)));
 
     // G14: Algorithm (non-automatable — switching mid-playback causes glitches)
     params.push_back (std::make_unique<juce::AudioParameterChoice> (
-        juce::ParameterID ("algorithm", 8), "Algorithm",
+        juce::ParameterID ("algorithm", 14), "Algorithm",
         juce::StringArray { "Ambisonics (HOA)", "DBAP", "KNN", "MDAP", "VBAP", "VBIP",
                             "Equal Power", "Stereo VBAP", "XY Pair", "MS Encode", "Blumlein" }, 0,
         juce::AudioParameterChoiceAttributes().withAutomatable (false)));
 
     // G15: HRTF Profile (non-automatable — triggers async SOFA reload)
     params.push_back (std::make_unique<juce::AudioParameterChoice> (
-        juce::ParameterID ("hrtfProfile", 3), "HRTF Profile",
+        juce::ParameterID ("hrtfProfile", 15), "HRTF Profile",
         juce::StringArray { "Simple (Low CPU)", "Studio Reference", "Immersive",
                             "Natural", "Precise", "Spatial" }, 0,
         juce::AudioParameterChoiceAttributes().withAutomatable (false)));
@@ -337,78 +339,79 @@ juce::AudioProcessorValueTreeState::ParameterLayout
         for (const auto& info : outputFormatRegistry)
             formatNames.add (info.name);
         params.push_back (std::make_unique<juce::AudioParameterChoice> (
-            juce::ParameterID ("outputFormat", 9), "Output Format", formatNames, 0,
+            juce::ParameterID ("outputFormat", 16), "Output Format", formatNames, 0,
             juce::AudioParameterChoiceAttributes().withAutomatable (false)));
     }
 
     // G17: Air Absorption
     params.push_back (std::make_unique<juce::AudioParameterBool> (
-        juce::ParameterID ("airAbsorption", 4), "Air Absorption", false));
+        juce::ParameterID ("airAbsorption", 17), "Air Absorption", false));
 
     // G18: Wobble On (was "Wobble Enabled" — moved before wobble params, enable→configure)
     params.push_back (std::make_unique<juce::AudioParameterBool> (
-        juce::ParameterID ("wobbleEnabled", 8), "Wobble On", false));
+        juce::ParameterID ("wobbleEnabled", 18), "Wobble On", false));
 
     // G19: Wobble Amount
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("wobbleAmount", 8), "Wobble Amount",
+        juce::ParameterID ("wobbleAmount", 19), "Wobble Amount",
         juce::NormalisableRange<float> (0.0f, 100.0f, 0.1f), 0.0f,
         juce::AudioParameterFloatAttributes().withLabel ("%").withStringFromValueFunction (fmtPct100)));
 
     // G20: Wobble Morph
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("wobbleMorph", 8), "Wobble Morph",
+        juce::ParameterID ("wobbleMorph", 20), "Wobble Morph",
         juce::NormalisableRange<float> (0.0f, 100.0f, 0.1f), 0.0f,
         juce::AudioParameterFloatAttributes().withLabel ("%").withStringFromValueFunction (fmtPct100)));
 
     // G21: Input Format (non-automatable — changes bus routing)
     params.push_back (std::make_unique<juce::AudioParameterChoice> (
-        juce::ParameterID ("inputFormat", 7), "Input Format",
+        juce::ParameterID ("inputFormat", 21), "Input Format",
         juce::StringArray { "Mono", "Stereo" }, 0,
         juce::AudioParameterChoiceAttributes().withAutomatable (false)));
 
     // G22: OSC Bypass (was "ADM-OSC Enabled" — inverted: true=bypassed=all OSC off)
-    // Version bumped 5→10 so old sessions reset to new default (true=bypassed)
     params.push_back (std::make_unique<juce::AudioParameterBool> (
-        juce::ParameterID ("admOscEnabled", 10), "OSC Bypass", true));
+        juce::ParameterID ("admOscEnabled", 22), "OSC Bypass", true));
 
     // G23–G28: Global Tap Offsets (promoted from OSC-only atomics to APVTS)
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("globalTapAzimuth", 10), "Global Tap Azimuth",
+        juce::ParameterID ("globalTapAzimuth", 23), "Global Tap Azimuth",
         juce::NormalisableRange<float> (-180.0f, 180.0f, 0.1f), 0.0f,
         juce::AudioParameterFloatAttributes().withStringFromValueFunction (fmtDeg)));
 
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("globalTapElevation", 10), "Global Tap Elevation",
+        juce::ParameterID ("globalTapElevation", 24), "Global Tap Elevation",
         juce::NormalisableRange<float> (-90.0f, 90.0f, 0.1f), 0.0f,
         juce::AudioParameterFloatAttributes().withStringFromValueFunction (fmtDeg)));
 
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("globalTapDistance", 10), "Global Tap Distance",
+        juce::ParameterID ("globalTapDistance", 25), "Global Tap Distance",
         juce::NormalisableRange<float> (-1.0f, 1.0f, 0.01f), 0.0f));
 
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("globalTapPitch", 10), "Global Tap Pitch",
+        juce::ParameterID ("globalTapPitch", 26), "Global Tap Pitch",
         juce::NormalisableRange<float> (-24.0f, 24.0f, 1.0f), 0.0f,
         juce::AudioParameterFloatAttributes().withStringFromValueFunction (
             [](float value, int) { return juce::String (juce::roundToInt (value)) + " st"; })));
 
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("globalTapDoppler", 10), "Global Tap Doppler",
+        juce::ParameterID ("globalTapDoppler", 27), "Global Tap Doppler",
         juce::NormalisableRange<float> (-100.0f, 100.0f, 0.1f), 0.0f,
         juce::AudioParameterFloatAttributes().withLabel ("%").withStringFromValueFunction (fmtPct100)));
 
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
-        juce::ParameterID ("globalTapSpeed", 10), "Global Tap Speed",
+        juce::ParameterID ("globalTapSpeed", 28), "Global Tap Speed",
         juce::NormalisableRange<float> (-5.0f, 5.0f, 0.01f), 0.0f,
         juce::AudioParameterFloatAttributes().withLabel ("Hz").withStringFromValueFunction (
             [](float value, int) { return juce::String (value, 2) + " Hz"; })));
 
     // --- Per-tap parameters (issue #68: "Object N" → "Tap 0N") ---------------
+    // Version hints: 100 + tapIndex*20 + offset (Tap 01=100–109, Tap 02=120–129, …, Tap 12=320–329)
     for (int i = 0; i < MAX_OBJECTS; ++i)
     {
-        auto id  = [&](const char* suffix) {
-            return juce::ParameterID ("object" + juce::String (i + 1) + "_" + suffix, 1);
+        int tapBase = 100 + i * 20;
+        auto id  = [&](const char* suffix, int offset) {
+            return juce::ParameterID ("object" + juce::String (i + 1) + "_" + suffix, tapBase + offset);
         };
         auto name = [&](const char* suffix) {
             return "Tap " + juce::String (i + 1).paddedLeft ('0', 2) + " " + suffix;
@@ -421,61 +424,61 @@ juce::AudioProcessorValueTreeState::ParameterLayout
 
         // T1: Tap On (was "Object N Enabled")
         params.push_back (std::make_unique<juce::AudioParameterBool> (
-            id ("enabled"), name ("On"), defaultEnabled));
+            id ("enabled", 0), name ("On"), defaultEnabled));
 
         // T2: Per-tap Time — REMOVED (orphaned param, issue #68)
 
         // T3: Tap Azimuth
         params.push_back (std::make_unique<juce::AudioParameterFloat> (
-            id ("azimuth"), name ("Azimuth"),
+            id ("azimuth", 1), name ("Azimuth"),
             juce::NormalisableRange<float> (-180.0f, 180.0f, 0.1f), defaultAz,
             juce::AudioParameterFloatAttributes().withStringFromValueFunction (fmtDeg)));
 
         // T4: Tap Elevation
         params.push_back (std::make_unique<juce::AudioParameterFloat> (
-            id ("elevation"), name ("Elevation"),
+            id ("elevation", 2), name ("Elevation"),
             juce::NormalisableRange<float> (-90.0f, 90.0f, 0.1f), 0.0f,
             juce::AudioParameterFloatAttributes().withStringFromValueFunction (fmtDeg)));
 
         // T5: Tap Distance
         params.push_back (std::make_unique<juce::AudioParameterFloat> (
-            id ("distance"), name ("Distance"),
+            id ("distance", 3), name ("Distance"),
             juce::NormalisableRange<float> (0.0f, 1.0f, 0.01f), 0.5f));
 
         // T6: Tap Doppler Amount
         params.push_back (std::make_unique<juce::AudioParameterFloat> (
-            id ("dopplerAmount"), name ("Doppler Amount"),
+            id ("dopplerAmount", 4), name ("Doppler Amount"),
             juce::NormalisableRange<float> (0.0f, 1.0f, 0.01f), 0.0f,
             juce::AudioParameterFloatAttributes().withLabel ("%").withStringFromValueFunction (fmtPct01)));
 
         // T7: Tap Pitch Shift
         params.push_back (std::make_unique<juce::AudioParameterFloat> (
-            id ("pitchShift"), name ("Pitch Shift"),
+            id ("pitchShift", 5), name ("Pitch Shift"),
             juce::NormalisableRange<float> (-12.0f, 12.0f, 1.0f), 0.0f,
             juce::AudioParameterFloatAttributes().withStringFromValueFunction (
                 [](float value, int) { return juce::String (juce::roundToInt (value)) + " st"; })));
 
         // T8: Tap Trajectory Shape
         params.push_back (std::make_unique<juce::AudioParameterChoice> (
-            id ("trajectoryShape"), name ("Trajectory Shape"),
+            id ("trajectoryShape", 6), name ("Trajectory Shape"),
             juce::StringArray { "None", "Bounce", "Circle", "Cross", "Figure-8", "Heart", "Helix",
                                 "Infinity", "Line", "Orbit", "Random", "Spiral", "Square", "Triangle" }, 0));
 
         // T9: Tap Trajectory Speed
         params.push_back (std::make_unique<juce::AudioParameterFloat> (
-            id ("trajectorySpeed"), name ("Trajectory Speed"),
+            id ("trajectorySpeed", 7), name ("Trajectory Speed"),
             juce::NormalisableRange<float> (0.0f, 5.0f, 0.01f), 0.3f,
             juce::AudioParameterFloatAttributes().withLabel ("Hz").withStringFromValueFunction (
                 [](float value, int) { return juce::String (value, 2) + " Hz"; })));
 
         // T10: Tap Trajectory Direction
         params.push_back (std::make_unique<juce::AudioParameterChoice> (
-            id ("trajectoryDirection"), name ("Trajectory Direction"),
+            id ("trajectoryDirection", 8), name ("Trajectory Direction"),
             juce::StringArray { "Forward", "Reverse" }, 0));
 
         // T11: Tap Input Channel
         params.push_back (std::make_unique<juce::AudioParameterChoice> (
-            id ("inputChannel"), name ("Input Channel"),
+            id ("inputChannel", 9), name ("Input Channel"),
             juce::StringArray { "L+R", "L", "R" }, 0));
     }
 

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -637,6 +637,13 @@ public:
     std::atomic<float> globalTapOffset[kNumGlobalTapOffsets] = {};  // AZ, EL, DIST, PITCH, DOPPLER, SPEED
     std::atomic<bool>  globalTapOffsetChanged { false };
 
+    // Issue #68: Config params stored outside APVTS to hide from DAW automation lists.
+    // Saved/restored in getStateInformation/setStateInformation.
+    std::atomic<int> configAlgorithm { 0 };
+    std::atomic<int> configHrtfProfile { 0 };
+    std::atomic<int> configOutputFormat { 0 };
+    std::atomic<int> configInputFormat { 0 };
+
     // v0.7: OSC Send accessors for editor
     bool isOscSendConnected() const { return oscSendConnected; }
     bool getOscSendEnabled() const { return oscSendEnabled; }
@@ -1023,18 +1030,15 @@ private:
     std::atomic<float>* cachedParam_filterHPQ       = nullptr;
     std::atomic<float>* cachedParam_filterLPQ       = nullptr;
     std::atomic<float>* cachedParam_filterEnabled   = nullptr;
-    std::atomic<float>* cachedParam_hrtfProfile     = nullptr;
     std::atomic<float>* cachedParam_airAbsorption   = nullptr;
     std::atomic<float>* cachedParam_wobbleEnabled   = nullptr;
     std::atomic<float>* cachedParam_wobbleAmount    = nullptr;
     std::atomic<float>* cachedParam_wobbleMorph     = nullptr;
-    std::atomic<float>* cachedParam_inputFormat     = nullptr;
     std::atomic<float>* cachedParam_delayTime       = nullptr;
     std::atomic<float>* cachedParam_dryWet          = nullptr;
     std::atomic<float>* cachedParam_feedback        = nullptr;
     std::atomic<float>* cachedParam_inputGain       = nullptr;
     std::atomic<float>* cachedParam_outputGain      = nullptr;
-    std::atomic<float>* cachedParam_algorithm       = nullptr;
     // issue #68: Global tap offset APVTS cached pointers
     std::atomic<float>* cachedParam_globalTapAzimuth   = nullptr;
     std::atomic<float>* cachedParam_globalTapElevation = nullptr;

--- a/Tests/ConvolverGlitchTests.cpp
+++ b/Tests/ConvolverGlitchTests.cpp
@@ -360,8 +360,8 @@ static std::unique_ptr<Proc> createBinauralProcessor (int hrtfProfile = 1)
     auto proc = std::make_unique<Proc>();
 
     // Binaural output = format index 0
-    setParam (*proc, "outputFormat", 0.0f);
-    setParam (*proc, "hrtfProfile", static_cast<float> (hrtfProfile));
+    proc->configOutputFormat.store (0, std::memory_order_relaxed);
+    proc->configHrtfProfile.store (hrtfProfile, std::memory_order_relaxed);
 
     // Set up delay parameters for audible output
     // 50ms delay — taps stabilize within 30 blocks:
@@ -608,7 +608,7 @@ TEST_CASE ("Stereo — azimuth sweep has no glitches (regression guard)", "[ster
     auto proc = std::make_unique<Proc>();
 
     // Stereo output = format index 1
-    setParam (*proc, "outputFormat", 1.0f);
+    proc->configOutputFormat.store (1, std::memory_order_relaxed);
     setParam (*proc, "delayTime", 50.0f);
     setParam (*proc, "feedback", 0.85f);
     setParam (*proc, "dryWet", 1.0f);
@@ -689,8 +689,8 @@ static std::unique_ptr<Proc> createMultiTapBinauralProcessor (int numTaps, float
                                                                int hrtfProfile = 1)
 {
     auto proc = std::make_unique<Proc>();
-    setParam (*proc, "outputFormat", 0.0f);   // Binaural
-    setParam (*proc, "hrtfProfile", static_cast<float> (hrtfProfile));
+    proc->configOutputFormat.store (0, std::memory_order_relaxed);   // Binaural
+    proc->configHrtfProfile.store (hrtfProfile, std::memory_order_relaxed);
     setParam (*proc, "delayTime", 50.0f);
     setParam (*proc, "feedback", feedback);
     setParam (*proc, "dryWet", 1.0f);
@@ -935,8 +935,8 @@ TEST_CASE ("Binaural HRTF — 12-tap simultaneous sweep stress", "[binaural][mul
 TEST_CASE ("Doppler — velocity response latency characterization", "[doppler][latency]")
 {
     auto proc = std::make_unique<Proc>();
-    setParam (*proc, "outputFormat", 0.0f);   // Binaural
-    setParam (*proc, "hrtfProfile", 0.0f);    // Simple/Woodworth (no HRTF convolver variable)
+    proc->configOutputFormat.store (0, std::memory_order_relaxed);   // Binaural
+    proc->configHrtfProfile.store (0, std::memory_order_relaxed);    // Simple/Woodworth (no HRTF convolver variable)
     setParam (*proc, "delayTime", 100.0f);
     setParam (*proc, "feedback", 0.0f);       // Single pass
     setParam (*proc, "dryWet", 1.0f);
@@ -1103,8 +1103,8 @@ TEST_CASE ("Surround VBAP — azimuth sweep has no glitches", "[surround][glitch
     auto proc = std::make_unique<Proc>();
 
     // Surround 5.1 = format index 4, VBAP = algorithm index 4
-    setParam (*proc, "outputFormat", 4.0f);
-    setParam (*proc, "algorithm", 4.0f);
+    proc->configOutputFormat.store (4, std::memory_order_relaxed);
+    proc->configAlgorithm.store (4, std::memory_order_relaxed);
     setParam (*proc, "delayTime", 50.0f);
     setParam (*proc, "feedback", 0.85f);
     setParam (*proc, "dryWet", 1.0f);
@@ -1259,8 +1259,8 @@ TEST_CASE ("Doppler — block size sensitivity", "[doppler][blocksize]")
         SECTION ("Block size " + std::to_string (bs))
         {
             auto proc = std::make_unique<Proc>();
-            setParam (*proc, "outputFormat", 0.0f);
-            setParam (*proc, "hrtfProfile", 0.0f);  // Simple
+            proc->configOutputFormat.store (0, std::memory_order_relaxed);
+            proc->configHrtfProfile.store (0, std::memory_order_relaxed);  // Simple
             setParam (*proc, "delayTime", 100.0f);
             setParam (*proc, "feedback", 0.5f);
             setParam (*proc, "dryWet", 1.0f);
@@ -1360,7 +1360,7 @@ static std::unique_ptr<Proc> createStereoProcessor (float delayMs = 50.0f, float
                                                      int numTaps = 3)
 {
     auto proc = std::make_unique<Proc>();
-    setParam (*proc, "outputFormat", 1.0f);  // Stereo
+    proc->configOutputFormat.store (1, std::memory_order_relaxed);  // Stereo
     setParam (*proc, "delayTime", delayMs);
     setParam (*proc, "feedback", feedback);
     setParam (*proc, "dryWet", 1.0f);
@@ -1531,7 +1531,7 @@ TEST_CASE ("Tap toggle rapid on/off — no clicks", "[issue40][tapfade]")
 TEST_CASE ("Preset change — sequential factory presets produce no clicks", "[issue40][preset]")
 {
     auto proc = std::make_unique<Proc>();
-    setParam (*proc, "outputFormat", 1.0f);  // Stereo
+    proc->configOutputFormat.store (1, std::memory_order_relaxed);  // Stereo
     proc->prepareToPlay (kSampleRate, kBlockSize);
 
     // Load first preset and stabilize

--- a/Tests/OscTests.cpp
+++ b/Tests/OscTests.cpp
@@ -234,14 +234,14 @@ TEST_CASE ("OSC: /osd/global/algorithm sets algorithm", "[osc][global]")
 {
     auto proc = createOscProcessor();
     sendOSC (*proc, "/osd/global/algorithm", { 2.0f });  // KNN
-    REQUIRE_THAT (readParam (*proc, "algorithm"), WithinAbs (2.0f, 0.5f));
+    REQUIRE (proc->configAlgorithm.load (std::memory_order_relaxed) == 2);
 }
 
 TEST_CASE ("OSC: /osd/global/hrtfprofile sets HRTF profile", "[osc][global]")
 {
     auto proc = createOscProcessor();
     sendOSC (*proc, "/osd/global/hrtfprofile", { 3.0f });  // CIPIC
-    REQUIRE_THAT (readParam (*proc, "hrtfProfile"), WithinAbs (3.0f, 0.5f));
+    REQUIRE (proc->configHrtfProfile.load (std::memory_order_relaxed) == 3);
 }
 
 TEST_CASE ("OSC: /osd/global/air sets air absorption toggle", "[osc][global]")
@@ -290,7 +290,7 @@ TEST_CASE ("OSC: /osd/global/outputformat sets output format", "[osc][global]")
 {
     auto proc = createOscProcessor();
     sendOSC (*proc, "/osd/global/outputformat", { 5.0f });  // Binaural
-    REQUIRE_THAT (readParam (*proc, "outputFormat"), WithinAbs (5.0f, 0.5f));
+    REQUIRE (proc->configOutputFormat.load (std::memory_order_relaxed) == 5);
 }
 
 // ============================================================================

--- a/Tests/ParameterCountTests.cpp
+++ b/Tests/ParameterCountTests.cpp
@@ -1,0 +1,78 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../Source/PluginProcessor.h"
+
+// Issue #68: Verify parameter count, naming, automatability, and ordering.
+// These tests catch regressions from parameter layout changes.
+
+TEST_CASE ("Parameter count is exactly 148", "[params]")
+{
+    auto proc = std::make_unique<OpenSpatialDelayProcessor>();
+    auto& params = proc->getParameters();
+    CHECK (params.size() == 148);
+}
+
+TEST_CASE ("All parameters have non-empty names", "[params]")
+{
+    auto proc = std::make_unique<OpenSpatialDelayProcessor>();
+    for (auto* p : proc->getParameters())
+    {
+        REQUIRE (p != nullptr);
+        CHECK_FALSE (p->getName (256).isEmpty());
+    }
+}
+
+TEST_CASE ("144 automatable + 4 non-automatable", "[params]")
+{
+    auto proc = std::make_unique<OpenSpatialDelayProcessor>();
+    int automatable = 0, nonAutomatable = 0;
+    for (auto* p : proc->getParameters())
+    {
+        if (p->isAutomatable())
+            ++automatable;
+        else
+            ++nonAutomatable;
+    }
+    CHECK (automatable == 144);
+    CHECK (nonAutomatable == 4);
+}
+
+TEST_CASE ("Global params appear before per-tap params", "[params]")
+{
+    auto proc = std::make_unique<OpenSpatialDelayProcessor>();
+    auto& params = proc->getParameters();
+
+    // First 28 params are globals; index 28 should be "Tap 01 On"
+    REQUIRE (params.size() >= 29);
+    CHECK (params[0]->getName (256) == "Delay Time");
+    CHECK (params[1]->getName (256) == "Delay Sync");
+    CHECK (params[4]->getName (256) == "Feedback");
+    CHECK (params[10]->getName (256) == "Dry/Wet");
+    CHECK (params[27]->getName (256) == "Global Tap Speed");
+
+    // Per-tap: index 28 = Tap 01 On, 38 = Tap 02 On, etc.
+    CHECK (params[28]->getName (256) == "Tap 01 On");
+    CHECK (params[38]->getName (256) == "Tap 02 On");
+    CHECK (params[48]->getName (256) == "Tap 03 On");
+}
+
+TEST_CASE ("Per-tap params are grouped by tap", "[params]")
+{
+    auto proc = std::make_unique<OpenSpatialDelayProcessor>();
+    auto& params = proc->getParameters();
+
+    // Tap 01: indices 28-37 (10 params)
+    CHECK (params[28]->getName (256) == "Tap 01 On");
+    CHECK (params[29]->getName (256) == "Tap 01 Azimuth");
+    CHECK (params[30]->getName (256) == "Tap 01 Elevation");
+    CHECK (params[31]->getName (256) == "Tap 01 Distance");
+    CHECK (params[32]->getName (256) == "Tap 01 Doppler Amount");
+    CHECK (params[33]->getName (256) == "Tap 01 Pitch Shift");
+    CHECK (params[34]->getName (256) == "Tap 01 Trajectory Shape");
+    CHECK (params[35]->getName (256) == "Tap 01 Trajectory Speed");
+    CHECK (params[36]->getName (256) == "Tap 01 Trajectory Direction");
+    CHECK (params[37]->getName (256) == "Tap 01 Input Channel");
+
+    // Tap 12: indices 138-147 (last 10 params)
+    CHECK (params[138]->getName (256) == "Tap 12 On");
+    CHECK (params[147]->getName (256) == "Tap 12 Input Channel");
+}

--- a/Tests/ParameterCountTests.cpp
+++ b/Tests/ParameterCountTests.cpp
@@ -4,11 +4,11 @@
 // Issue #68: Verify parameter count, naming, automatability, and ordering.
 // These tests catch regressions from parameter layout changes.
 
-TEST_CASE ("Parameter count is exactly 148", "[params]")
+TEST_CASE ("Parameter count is exactly 144", "[params]")
 {
     auto proc = std::make_unique<OpenSpatialDelayProcessor>();
     auto& params = proc->getParameters();
-    CHECK (params.size() == 148);
+    CHECK (params.size() == 144);
 }
 
 TEST_CASE ("All parameters have non-empty names", "[params]")
@@ -21,7 +21,7 @@ TEST_CASE ("All parameters have non-empty names", "[params]")
     }
 }
 
-TEST_CASE ("144 automatable + 4 non-automatable", "[params]")
+TEST_CASE ("144 automatable + 0 non-automatable", "[params]")
 {
     auto proc = std::make_unique<OpenSpatialDelayProcessor>();
     int automatable = 0, nonAutomatable = 0;
@@ -33,7 +33,7 @@ TEST_CASE ("144 automatable + 4 non-automatable", "[params]")
             ++nonAutomatable;
     }
     CHECK (automatable == 144);
-    CHECK (nonAutomatable == 4);
+    CHECK (nonAutomatable == 0);
 }
 
 TEST_CASE ("Global params appear before per-tap params", "[params]")
@@ -41,18 +41,18 @@ TEST_CASE ("Global params appear before per-tap params", "[params]")
     auto proc = std::make_unique<OpenSpatialDelayProcessor>();
     auto& params = proc->getParameters();
 
-    // First 28 params are globals; index 28 should be "Tap 01 On"
-    REQUIRE (params.size() >= 29);
+    // First 24 params are globals; index 24 should be "Tap 01 On"
+    REQUIRE (params.size() >= 25);
     CHECK (params[0]->getName (256) == "Delay Time");
     CHECK (params[1]->getName (256) == "Delay Sync");
     CHECK (params[4]->getName (256) == "Feedback");
     CHECK (params[10]->getName (256) == "Dry/Wet");
-    CHECK (params[27]->getName (256) == "Global Tap Speed");
+    CHECK (params[23]->getName (256) == "Global Tap Speed");
 
-    // Per-tap: index 28 = Tap 01 On, 38 = Tap 02 On, etc.
-    CHECK (params[28]->getName (256) == "Tap 01 On");
-    CHECK (params[38]->getName (256) == "Tap 02 On");
-    CHECK (params[48]->getName (256) == "Tap 03 On");
+    // Per-tap: index 24 = Tap 01 On, 34 = Tap 02 On, etc.
+    CHECK (params[24]->getName (256) == "Tap 01 On");
+    CHECK (params[34]->getName (256) == "Tap 02 On");
+    CHECK (params[44]->getName (256) == "Tap 03 On");
 }
 
 TEST_CASE ("Per-tap params are grouped by tap", "[params]")
@@ -60,19 +60,19 @@ TEST_CASE ("Per-tap params are grouped by tap", "[params]")
     auto proc = std::make_unique<OpenSpatialDelayProcessor>();
     auto& params = proc->getParameters();
 
-    // Tap 01: indices 28-37 (10 params)
-    CHECK (params[28]->getName (256) == "Tap 01 On");
-    CHECK (params[29]->getName (256) == "Tap 01 Azimuth");
-    CHECK (params[30]->getName (256) == "Tap 01 Elevation");
-    CHECK (params[31]->getName (256) == "Tap 01 Distance");
-    CHECK (params[32]->getName (256) == "Tap 01 Doppler Amount");
-    CHECK (params[33]->getName (256) == "Tap 01 Pitch Shift");
-    CHECK (params[34]->getName (256) == "Tap 01 Trajectory Shape");
-    CHECK (params[35]->getName (256) == "Tap 01 Trajectory Speed");
-    CHECK (params[36]->getName (256) == "Tap 01 Trajectory Direction");
-    CHECK (params[37]->getName (256) == "Tap 01 Input Channel");
+    // Tap 01: indices 24-33 (10 params)
+    CHECK (params[24]->getName (256) == "Tap 01 On");
+    CHECK (params[25]->getName (256) == "Tap 01 Azimuth");
+    CHECK (params[26]->getName (256) == "Tap 01 Elevation");
+    CHECK (params[27]->getName (256) == "Tap 01 Distance");
+    CHECK (params[28]->getName (256) == "Tap 01 Doppler Amount");
+    CHECK (params[29]->getName (256) == "Tap 01 Pitch Shift");
+    CHECK (params[30]->getName (256) == "Tap 01 Trajectory Shape");
+    CHECK (params[31]->getName (256) == "Tap 01 Trajectory Speed");
+    CHECK (params[32]->getName (256) == "Tap 01 Trajectory Direction");
+    CHECK (params[33]->getName (256) == "Tap 01 Input Channel");
 
-    // Tap 12: indices 138-147 (last 10 params)
-    CHECK (params[138]->getName (256) == "Tap 12 On");
-    CHECK (params[147]->getName (256) == "Tap 12 Input Channel");
+    // Tap 12: indices 134-143 (last 10 params)
+    CHECK (params[134]->getName (256) == "Tap 12 On");
+    CHECK (params[143]->getName (256) == "Tap 12 Input Channel");
 }

--- a/Tests/SurroundOutputTests.cpp
+++ b/Tests/SurroundOutputTests.cpp
@@ -29,11 +29,9 @@ static std::unique_ptr<Proc> createTestProcessor (int outputFormat = 0, int algo
 {
     auto proc = std::make_unique<Proc>();
 
-    // Set output format and algorithm parameters BEFORE prepareToPlay
-    if (auto* p = proc->apvts.getParameter ("outputFormat"))
-        p->setValueNotifyingHost (p->convertTo0to1 (static_cast<float> (outputFormat)));
-    if (auto* p = proc->apvts.getParameter ("algorithm"))
-        p->setValueNotifyingHost (p->convertTo0to1 (static_cast<float> (algorithm)));
+    // Set output format and algorithm config params BEFORE prepareToPlay
+    proc->configOutputFormat.store (outputFormat, std::memory_order_relaxed);
+    proc->configAlgorithm.store (algorithm, std::memory_order_relaxed);
 
     // Set short delay and 100% wet BEFORE prepareToPlay so smoothed values
     // initialize correctly — prevents 500ms default from starving the delay line
@@ -53,10 +51,8 @@ static std::unique_ptr<Proc> createConstrainedProcessor (int outputFormat, int a
 {
     auto proc = std::make_unique<Proc>();
 
-    if (auto* p = proc->apvts.getParameter ("outputFormat"))
-        p->setValueNotifyingHost (p->convertTo0to1 (static_cast<float> (outputFormat)));
-    if (auto* p = proc->apvts.getParameter ("algorithm"))
-        p->setValueNotifyingHost (p->convertTo0to1 (static_cast<float> (algorithm)));
+    proc->configOutputFormat.store (outputFormat, std::memory_order_relaxed);
+    proc->configAlgorithm.store (algorithm, std::memory_order_relaxed);
 
     // Set short delay and 100% wet BEFORE prepareToPlay so smoothed values
     // initialize correctly — prevents 500ms default from starving the delay line


### PR DESCRIPTION
## Summary

- **AU parameter ordering fixed**: Unique ascending version hints (globals 1–24, per-tap `100+tapIndex*20+offset`) so each param occupies its own AU sort bucket — hash tiebreaker never activates
- **4 config params hidden from automation list**: Algorithm, HRTF Profile, Output Format, Input Format removed from APVTS and stored as `std::atomic<int>` members with manual state save/load. Old sessions (version <20) migrate automatically
- **Parameter count tests added**: 5 test cases (312 assertions) verifying count, naming, automatability, and ordering

## Final parameter counts
- 144 automatable (24 global + 120 per-tap)
- 0 non-automatable visible to host
- 144 total in DAW automation list

## Test plan
- [x] All 5 `[params]` tests pass (312 assertions)
- [x] Full suite: 197/200 (3 pre-existing ConvolverGlitch failures from #69)
- [x] v1.0.9 AU + VST3 verified in REAPER: correct ordering, no blank rows, no config params in automation list
- [ ] Preset save/load preserves algorithm, HRTF, output format, input format
- [ ] OSC control of algorithm/output format still works

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)