### PR TITLE
Update CLAUDE.md with semver scheme and reset version registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,17 @@
 
 ## Build & Test Rules
 
+### Versioning: Major.Minor.Bugfix (issue #55)
+
+OpenSpatialDelay uses **semantic versioning vX.Y.Z**:
+- **X (Major):** Breaking changes, new architecture, incompatible preset format
+- **Y (Minor):** New features, new output formats, new algorithms
+- **Z (Bugfix):** Bug fixes, threshold tweaks, documentation updates
+
+**Current release: v1.0.0** (commit ae86d1e, 2026-04-01)
+
+All prior experimental build numbers (v1.0.1–v1.0.10) from the development cycle have been collapsed into v1.0.0. The next bugfix build will be v1.0.1.
+
 ### MANDATORY: Versioned builds for every fix attempt
 
 Every code change that needs manual listening/testing MUST be built as a uniquely-named versioned plugin. **Never reuse a version number. Never skip this step.**
@@ -10,24 +21,15 @@ Every code change that needs manual listening/testing MUST be built as a uniquel
 # 1. Commit your changes
 git add ... && git commit -m "..."
 
-# 2. Build as a versioned plugin (increment X each time)
-bash scripts/build_version.sh <commit-hash> v1.0.X O10X
+# 2. Build as a versioned plugin (increment Z each time)
+bash scripts/build_version.sh <commit-hash> v1.0.Z O10Z
 ```
 
-**Why this is critical:** The default `cmake --build` installs to `OpenSpatialDelay v1.0.component`. The user tests with individually-named versioned plugins (e.g., `OpenSpatialDelay v1.0.4.component`) loaded side-by-side in REAPER for A/B comparison. If you don't use `build_version.sh`, the user will never hear your changes.
+**Why this is critical:** The default `cmake --build` installs to `OpenSpatialDelay v1.0.component`. The user tests with individually-named versioned plugins (e.g., `OpenSpatialDelay v1.0.1.component`) loaded side-by-side in REAPER for A/B comparison. If you don't use `build_version.sh`, the user will never hear your changes.
 
-**Version number registry (do not reuse) — reset 2026-03-25, see issue #55:**
-- v1.0.0 / O100 — baseline (commit 023670a)
-- v1.0.1 / O101 — dual-convolver output crossfade + feedback smoothing (commit 99d1525)
-- v1.0.2 / O102 — smootherstep crossfade + 6-block duration, 195/195 pass (commit 44185d4)
-- v1.0.3 / O103 — WSOLA float precision fix + 5 bug fixes + doubled buffers (commit 19ddb28)
-- v1.0.4 / O104 — spectral envelope EMA smoothing
-- v1.0.5 / O105 — feedback EMA smoothing for HRTF crossfade pops
-- v1.0.6 / O106 — Phase vocoder pitch shifter replacing WSOLA-Lite (issue #60)
-- v1.0.7 / O107 — dry path latency compensation + unique CFBundleIdentifier per build (issues #63, #62)
-- v1.0.8 / O108 — transport-aware PV reset for intermittent buzzing (issue #65)
-- v1.0.9 / O109 — AU param ordering + hide config params from automation (issue #68)
-- Next available: **v1.0.10 / O110**
+**Version number registry (do not reuse):**
+- v1.0.0 / O100 — first release baseline (commit ae86d1e)
+- Next available: **v1.0.1 / O101**
 
 ### Running tests
 
@@ -57,10 +59,10 @@ cmake --build build --target OpenSpatialDelayTests -j$(sysctl -n hw.ncpu)
 3. Pass 2: per-block HRTF convolution via `BinauralRenderer::renderSourceBuffers()`
 4. Pass 3: per-sample dry/wet mix + output gain
 
-### PartitionedConvolver (v1.0.4)
+### PartitionedConvolver
 Uses spectral envelope EMA smoothing: magnitude and phase smoothed separately per frequency bin. This prevents comb filtering from phase-misaligned time-domain blending.
 
-### Phase Vocoder Pitch Shifter (v1.0.6)
+### Phase Vocoder Pitch Shifter
 Replaces WSOLA-Lite. Uses STFT (2048-point FFT, 4x overlap) with:
 - Laroche-Dolson phase locking for tonal content
 - Röbel-style spectral flux transient detection with adaptive median threshold
@@ -68,7 +70,7 @@ Replaces WSOLA-Lite. Uses STFT (2048-point FFT, 4x overlap) with:
 - Latency: 2048 samples (reported to DAW via setLatencySamples)
 - Range: ±12 semitones (combined with Doppler)
 
-### Dry Path Latency Compensation (v1.0.7)
+### Dry Path Latency Compensation
 The phase vocoder adds 2048 samples of latency to the wet path. The dry signal must be delayed by the same amount so the DAW's plugin delay compensation (PDC) is correct at all dry/wet settings. Implemented as a circular `dryDelayLine` buffer that pre-fills `dryCompBuffer` at the start of each processBlock, before dispatch to render methods. All 5 render paths read from `dryCompBuffer` instead of `monoInputBuffer` for dry mixing.
 
 ### ITD delay line


### PR DESCRIPTION
## Summary

- Added semver scheme definition (Major.Minor.Bugfix) from issue #55
- Collapsed old experimental version registry (v1.0.0–v1.0.10) to single v1.0.0 baseline
- Removed stale version labels from architecture notes
- Next available: v1.0.1 / O101

🤖 Generated with [Claude Code](https://claude.com/claude-code)