### PR TITLE
Fix dry signal mono collapse + equal-power crossfade (issue #73)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,10 +27,9 @@ bash scripts/build_version.sh <commit-hash> v1.0.Z O10Z
 
 **Why this is critical:** The default `cmake --build` installs to `OpenSpatialDelay v1.0.component`. The user tests with individually-named versioned plugins (e.g., `OpenSpatialDelay v1.0.1.component`) loaded side-by-side in REAPER for A/B comparison. If you don't use `build_version.sh`, the user will never hear your changes.
 
-**Version number registry (do not reuse) — reset 2026-03-25, see issue #55:**
-- v1.0.0 / O100 — baseline (commit 023670a)
-- v1.0.1 / O101 — stereo dry path + equal-power crossfade (commit 6e128c6, issue #73)
-- Next available: **v1.0.2 / O102**
+**Version number registry (do not reuse) — reset 2026-04-01, see issue #73:**
+- v1.0.0 / O100 — baseline (commit 6c629ef)
+- Next available: **v1.0.1 / O101**
 
 ### Running tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,16 +18,8 @@ bash scripts/build_version.sh <commit-hash> v1.0.X O10X
 
 **Version number registry (do not reuse) — reset 2026-03-25, see issue #55:**
 - v1.0.0 / O100 — baseline (commit 023670a)
-- v1.0.1 / O101 — dual-convolver output crossfade + feedback smoothing (commit 99d1525)
-- v1.0.2 / O102 — smootherstep crossfade + 6-block duration, 195/195 pass (commit 44185d4)
-- v1.0.3 / O103 — WSOLA float precision fix + 5 bug fixes + doubled buffers (commit 19ddb28)
-- v1.0.4 / O104 — spectral envelope EMA smoothing
-- v1.0.5 / O105 — feedback EMA smoothing for HRTF crossfade pops
-- v1.0.6 / O106 — Phase vocoder pitch shifter replacing WSOLA-Lite (issue #60)
-- v1.0.7 / O107 — dry path latency compensation + unique CFBundleIdentifier per build (issues #63, #62)
-- v1.0.8 / O108 — transport-aware PV reset for intermittent buzzing (issue #65)
-- v1.0.9 / O109 — AU param ordering + hide config params from automation (issue #68)
-- Next available: **v1.0.10 / O110**
+- v1.0.1 / O101 — stereo dry path + equal-power crossfade (commit 6e128c6, issue #73)
+- Next available: **v1.0.2 / O102**
 
 ### Running tests
 
@@ -68,8 +60,10 @@ Replaces WSOLA-Lite. Uses STFT (2048-point FFT, 4x overlap) with:
 - Latency: 2048 samples (reported to DAW via setLatencySamples)
 - Range: ±12 semitones (combined with Doppler)
 
-### Dry Path Latency Compensation (v1.0.7)
-The phase vocoder adds 2048 samples of latency to the wet path. The dry signal must be delayed by the same amount so the DAW's plugin delay compensation (PDC) is correct at all dry/wet settings. Implemented as a circular `dryDelayLine` buffer that pre-fills `dryCompBuffer` at the start of each processBlock, before dispatch to render methods. All 5 render paths read from `dryCompBuffer` instead of `monoInputBuffer` for dry mixing.
+### Dry Path Latency Compensation (v1.0.7) + Stereo Dry (v1.0.1)
+The phase vocoder adds 2048 samples of latency to the wet path. The dry signal must be delayed by the same amount so the DAW's plugin delay compensation (PDC) is correct at all dry/wet settings. Implemented as stereo circular `dryDelayLineL/R` buffers that pre-fill `dryCompBufferL/R` from `inputBufferL/R` at the start of each processBlock.
+
+The dry/wet mix happens in a single post-render stage in processBlock — render paths output raw wet signal only. This ensures the dry signal truly bypasses the entire plugin. Equal-power crossfade (cos/sin) replaces linear (1-dw/dw) for constant perceived loudness at all mix settings.
 
 ### ITD delay line
 For MIT KEMAR SOFA file, ITD values are always 0 (embedded in HRIR waveform). The ITD delay line is effectively a pass-through for this dataset.

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -2391,9 +2391,14 @@ void OpenSpatialDelayProcessor::prepareToPlay (double sampleRate, int samplesPer
 
     // v1.0.7: Dry path latency compensation (issue #63)
     // Delay dry signal by kFFTSize samples to match the phase vocoder's wet path latency.
-    dryDelayLine.assign (static_cast<size_t> (PhaseVocoderPitchShifter::kFFTSize), 0.0f);
+    // v1.0.1: Stereo dry buffers — dry path preserves stereo input (issue #73)
+    dryDelayLineL.assign (static_cast<size_t> (PhaseVocoderPitchShifter::kFFTSize), 0.0f);
+    dryDelayLineR.assign (static_cast<size_t> (PhaseVocoderPitchShifter::kFFTSize), 0.0f);
     dryDelayWritePos = 0;
-    dryCompBuffer.resize (static_cast<size_t> (samplesPerBlock), 0.0f);
+    dryCompBufferL.resize (static_cast<size_t> (samplesPerBlock), 0.0f);
+    dryCompBufferR.resize (static_cast<size_t> (samplesPerBlock), 0.0f);
+    perSampleDW.resize (static_cast<size_t> (samplesPerBlock), 0.0f);
+    perSampleOutGain.resize (static_cast<size_t> (samplesPerBlock), 0.0f);
 
     // v1.0: Initialize tap fade envelopes
     for (int t = 0; t < MAX_OBJECTS; ++t)
@@ -4027,15 +4032,19 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
     // v1.0.7: Fill latency-compensated dry buffer (issue #63)
     // The phase vocoder adds kFFTSize samples of latency to the wet path.
     // Delay the dry signal by the same amount so DAW PDC is correct at all dry/wet levels.
-    if (dryCompBuffer.size() < ns)
-        dryCompBuffer.resize (ns);
+    // v1.0.1: Stereo dry path — reads from inputBufferL/R to preserve stereo (issue #73)
+    if (dryCompBufferL.size() < ns) dryCompBufferL.resize (ns);
+    if (dryCompBufferR.size() < ns) dryCompBufferR.resize (ns);
     {
-        const int dryDelaySize = static_cast<int> (dryDelayLine.size());
+        const int dryDelaySize = static_cast<int> (dryDelayLineL.size());
         for (int i = 0; i < numSamples; ++i)
         {
-            // Read delayed sample first, then overwrite with new input
-            dryCompBuffer[static_cast<size_t> (i)] = dryDelayLine[static_cast<size_t> (dryDelayWritePos)];
-            dryDelayLine[static_cast<size_t> (dryDelayWritePos)] = monoInputBuffer[static_cast<size_t> (i)];
+            auto si = static_cast<size_t> (i);
+            auto wp = static_cast<size_t> (dryDelayWritePos);
+            dryCompBufferL[si] = dryDelayLineL[wp];
+            dryCompBufferR[si] = dryDelayLineR[wp];
+            dryDelayLineL[wp] = inputBufferL[si];
+            dryDelayLineR[wp] = inputBufferR[si];
             dryDelayWritePos = (dryDelayWritePos + 1) % dryDelaySize;
         }
     }
@@ -4063,7 +4072,18 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
     }
     smoothedLoopMultiplier.setCurrentAndTargetValue (loopMultiplierTarget);
 
+    // v1.0.1: Pre-advance dryWet / outputGain smoothers into per-sample arrays (issue #73)
+    // Render paths now output raw wet signal; dry/wet mix happens once after dispatch.
+    if (perSampleDW.size() < ns)       perSampleDW.resize (ns);
+    if (perSampleOutGain.size() < ns)  perSampleOutGain.resize (ns);
+    for (int s = 0; s < numSamples; ++s)
+    {
+        perSampleDW[static_cast<size_t> (s)]       = smoothedDryWet.getNextValue();
+        perSampleOutGain[static_cast<size_t> (s)]  = smoothedOutputGain.getNextValue();
+    }
+
     // --- Dispatch to appropriate render method --------------------------------
+    // Render paths write RAW WET signal to the output buffer (no dry, no dw, no outGain, no limiter).
     if (isStereoVariant)
     {
         // Stereo mode from algorithm parameter: indices 6-10 → modes 0-4
@@ -4088,6 +4108,50 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
     {
         renderDiscreteSurround (buffer, numSamples, objects, objChannelGains,
                                 objDistGain, surLayout);
+    }
+
+    // === v1.0.1: Single-point dry/wet mix with equal-power crossfade (issue #73) ===
+    // The dry signal bypasses the entire plugin; only dryWet and outputGain affect it.
+    // Equal-power (cos/sin) crossfade maintains constant perceived loudness at all dw settings.
+    {
+        const int numOutCh = buffer.getNumChannels();
+        constexpr int kMaxPostRenderCh = 64;  // Covers surround (16), ambi (49), and any DAW padding
+        float* outPtrs[kMaxPostRenderCh] = {};
+        const int usableCh = std::min (numOutCh, kMaxPostRenderCh);
+        for (int ch = 0; ch < usableCh; ++ch)
+            outPtrs[ch] = buffer.getWritePointer (ch);
+
+        for (int s = 0; s < numSamples; ++s)
+        {
+            auto si = static_cast<size_t> (s);
+            float dw       = perSampleDW[si];
+            float outGain  = perSampleOutGain[si];
+            float dryCoeff = std::cos (dw * juce::MathConstants<float>::halfPi);
+            float wetCoeff = std::sin (dw * juce::MathConstants<float>::halfPi);
+
+            if (isAmbiOutput)
+            {
+                // Ambisonics: mono dry → W channel (ACN 0), wet → all SH channels
+                float dryMono = (dryCompBufferL[si] + dryCompBufferR[si]) * 0.5f;
+                if (outPtrs[0])
+                    outPtrs[0][s] = outputLimiter ((outPtrs[0][s] * wetCoeff + dryMono * dryCoeff) * outGain);
+                for (int ch = 1; ch < usableCh; ++ch)
+                    if (outPtrs[ch])
+                        outPtrs[ch][s] = outputLimiter (outPtrs[ch][s] * wetCoeff * outGain);
+            }
+            else
+            {
+                // Binaural / Stereo / Surround: stereo dry → L/R (ch 0/1)
+                if (outPtrs[0])
+                    outPtrs[0][s] = outputLimiter ((outPtrs[0][s] * wetCoeff + dryCompBufferL[si] * dryCoeff) * outGain);
+                if (usableCh > 1 && outPtrs[1])
+                    outPtrs[1][s] = outputLimiter ((outPtrs[1][s] * wetCoeff + dryCompBufferR[si] * dryCoeff) * outGain);
+                // Remaining channels (surround speakers, LFE): wet only
+                for (int ch = 2; ch < usableCh; ++ch)
+                    if (outPtrs[ch])
+                        outPtrs[ch][s] = outputLimiter (outPtrs[ch][s] * wetCoeff * outGain);
+            }
+        }
     }
 
     // v0.7: Store per-tap peak to atomics for UI glow
@@ -4138,10 +4202,6 @@ void OpenSpatialDelayProcessor::renderDirectBinauralHRTF (
         wetBufR.resize (static_cast<size_t> (numSamples), 0.0f);
     }
 
-    // Capture smoothed value start positions for Pass 3 interpolation
-    float dwStart      = smoothedDryWet.getCurrentValue();
-    float outGainStart = smoothedOutputGain.getCurrentValue();
-
     // v1.0: Per-sample distGain interpolation to prevent clicks on rapid position changes
     float hrtfInvN = (numSamples > 1) ? 1.0f / static_cast<float> (numSamples - 1) : 1.0f;
 
@@ -4157,9 +4217,7 @@ void OpenSpatialDelayProcessor::renderDirectBinauralHRTF (
 
         float inGain = smoothedInputGain.getNextValue();
         float fb     = smoothedFeedback.getNextValue();
-        // Advance dryWet/outputGain smoothing per-sample; values read at block-end in PASS 3
-        smoothedDryWet.getNextValue();
-        smoothedOutputGain.getNextValue();
+        // v1.0.1: dryWet/outputGain smoothers pre-advanced in processBlock (issue #73)
 
         // STAGE 1: WRITE to delay line (dual L/R)
         float rawL = inputBufferL[static_cast<size_t> (s)] * inGain;
@@ -4204,21 +4262,9 @@ void OpenSpatialDelayProcessor::renderDirectBinauralHRTF (
     activeRenderer.renderSourceBuffers (srcBufPtrs, sourceEnabled, MAX_OBJECTS,
                                         numSamples, wetBufL.data(), wetBufR.data());
 
-    // === PASS 3: Per-sample dry/wet mix + output gain ===
-    float dwEnd      = smoothedDryWet.getCurrentValue();
-    float outGainEnd = smoothedOutputGain.getCurrentValue();
-    float invN = (numSamples > 1) ? 1.0f / static_cast<float> (numSamples - 1) : 1.0f;
-
-    for (int s = 0; s < numSamples; ++s)
-    {
-        float frac    = static_cast<float> (s) * invN;
-        float dw      = dwStart + frac * (dwEnd - dwStart);
-        float outGain = outGainStart + frac * (outGainEnd - outGainStart);
-        float rawInput = dryCompBuffer[static_cast<size_t> (s)];  // v1.0.7: latency-compensated dry signal (issue #63)
-
-        outL[s] = outputLimiter ((rawInput * (1.0f - dw) + wetBufL[static_cast<size_t> (s)] * dw) * outGain);
-        outR[s] = outputLimiter ((rawInput * (1.0f - dw) + wetBufR[static_cast<size_t> (s)] * dw) * outGain);
-    }
+    // === PASS 3: Write raw wet signal to output (dry/wet mix handled in processBlock) ===
+    std::memcpy (outL, wetBufL.data(), sizeof (float) * static_cast<size_t> (numSamples));
+    std::memcpy (outR, wetBufR.data(), sizeof (float) * static_cast<size_t> (numSamples));
 
     // Zero remaining channels when binaural is selected on a multi-channel bus
     for (int ch = 2; ch < buffer.getNumChannels(); ++ch)
@@ -4251,9 +4297,8 @@ void OpenSpatialDelayProcessor::renderSimpleBinauralWoodworth (
         float currentLoopMult = smoothedLoopMultiplier.getNextValue();
 
         float inGain  = smoothedInputGain.getNextValue();
-        float dw      = smoothedDryWet.getNextValue();
         float fb      = smoothedFeedback.getNextValue();
-        float outGain = smoothedOutputGain.getNextValue();
+        // v1.0.1: dryWet/outputGain smoothers pre-advanced in processBlock (issue #73)
 
         // === STAGE 1: WRITE (dual L/R) ===
         float rawL = inputBufferL[static_cast<size_t> (s)] * inGain;
@@ -4261,7 +4306,6 @@ void OpenSpatialDelayProcessor::renderSimpleBinauralWoodworth (
         float delayInputL = softClip ((rawL + feedbackSample * fb) * kFeedbackInputHeadroom);
         float delayInputR = softClip ((rawR + feedbackSample * fb) * kFeedbackInputHeadroom);
         writeDelayLine (delayInputL, delayInputR);
-        float rawInput = dryCompBuffer[static_cast<size_t> (s)];  // v1.0.7: latency-compensated dry signal (issue #63)
 
         // === STAGE 2: READ & SPATIALIZE ===
         float wetL = 0.0f, wetR = 0.0f;
@@ -4287,9 +4331,9 @@ void OpenSpatialDelayProcessor::renderSimpleBinauralWoodworth (
         // === STAGE 3: FEEDBACK ===
         processFeedbackSample (currentLoopMult, baseDelaySamples, fb);
 
-        // === STAGE 4: OUTPUT MIX ===
-        outL[s] = outputLimiter ((rawInput * (1.0f - dw) + wetL * dw) * outGain);
-        outR[s] = outputLimiter ((rawInput * (1.0f - dw) + wetR * dw) * outGain);
+        // === STAGE 4: OUTPUT — raw wet (dry/wet mix handled in processBlock) ===
+        outL[s] = wetL;
+        outR[s] = wetR;
     }
 
     // Store current gains as previous for next block
@@ -4390,9 +4434,8 @@ void OpenSpatialDelayProcessor::renderStereoVariant (
         float currentLoopMult = smoothedLoopMultiplier.getNextValue();
 
         float inGain  = smoothedInputGain.getNextValue();
-        float dw      = smoothedDryWet.getNextValue();
         float fb      = smoothedFeedback.getNextValue();
-        float outGain = smoothedOutputGain.getNextValue();
+        // v1.0.1: dryWet/outputGain smoothers pre-advanced in processBlock (issue #73)
 
         // === STAGE 1: WRITE (dual L/R) ===
         float rawL = inputBufferL[static_cast<size_t> (s)] * inGain;
@@ -4400,7 +4443,6 @@ void OpenSpatialDelayProcessor::renderStereoVariant (
         float delayInputL = softClip ((rawL + feedbackSample * fb) * kFeedbackInputHeadroom);
         float delayInputR = softClip ((rawR + feedbackSample * fb) * kFeedbackInputHeadroom);
         writeDelayLine (delayInputL, delayInputR);
-        float rawInput = dryCompBuffer[static_cast<size_t> (s)];  // v1.0.7: latency-compensated dry signal (issue #63)
 
         // === STAGE 2: READ & SPATIALIZE ===
         float wetL = 0.0f, wetR = 0.0f;
@@ -4426,9 +4468,9 @@ void OpenSpatialDelayProcessor::renderStereoVariant (
         // === STAGE 3: FEEDBACK ===
         processFeedbackSample (currentLoopMult, baseDelaySamples, fb);
 
-        // === STAGE 4: OUTPUT MIX ===
-        outL[s] = outputLimiter ((rawInput * (1.0f - dw) + wetL * dw) * outGain);
-        outR[s] = outputLimiter ((rawInput * (1.0f - dw) + wetR * dw) * outGain);
+        // === STAGE 4: OUTPUT — raw wet (dry/wet mix handled in processBlock) ===
+        outL[s] = wetL;
+        outR[s] = wetR;
     }
 
     // Store current gains as previous for next block
@@ -4538,9 +4580,8 @@ void OpenSpatialDelayProcessor::renderAmbisonicsOutput (
         float currentLoopMult = smoothedLoopMultiplier.getNextValue();
 
         float inGain  = smoothedInputGain.getNextValue();
-        float dw      = smoothedDryWet.getNextValue();
         float fb      = smoothedFeedback.getNextValue();
-        float outGain = smoothedOutputGain.getNextValue();
+        // v1.0.1: dryWet/outputGain smoothers pre-advanced in processBlock (issue #73)
 
         // === STAGE 1: WRITE (dual L/R) ===
         float rawL = inputBufferL[static_cast<size_t> (s)] * inGain;
@@ -4548,7 +4589,6 @@ void OpenSpatialDelayProcessor::renderAmbisonicsOutput (
         float delayInputL = softClip ((rawL + feedbackSample * fb) * kFeedbackInputHeadroom);
         float delayInputR = softClip ((rawR + feedbackSample * fb) * kFeedbackInputHeadroom);
         writeDelayLine (delayInputL, delayInputR);
-        float rawInput = dryCompBuffer[static_cast<size_t> (s)];  // v1.0.7: latency-compensated dry signal (issue #63)
 
         // === STAGE 2: READ & SH ENCODE (with NFC-HOA) ===
         float ambiAccum[MAX_AMBI_CHANNELS] = {};
@@ -4589,17 +4629,12 @@ void OpenSpatialDelayProcessor::renderAmbisonicsOutput (
         // === STAGE 3: FEEDBACK ===
         processFeedbackSample (currentLoopMult, baseDelaySamples, fb);
 
-        // === STAGE 4: OUTPUT MIX ===
-        // Wet: SH-encoded signal to all Ambisonics channels
+        // === STAGE 4: OUTPUT — raw wet (dry/wet mix handled in processBlock) ===
         for (int c = 0; c < numAmbiCh && c < numOutCh; ++c)
         {
             if (outChannels[c] != nullptr)
-                outChannels[c][s] = outputLimiter (ambiAccum[c] * dw * outGain);
+                outChannels[c][s] = ambiAccum[c];
         }
-
-        // Dry: omnidirectional (W channel = ACN 0 only)
-        if (outChannels[0] != nullptr)
-            outChannels[0][s] = outputLimiter (outChannels[0][s] + rawInput * (1.0f - dw) * outGain);
     }
 
     // Store current SH coefficients and distance gains as previous for next block
@@ -4643,9 +4678,8 @@ void OpenSpatialDelayProcessor::renderDiscreteSurround (
         float currentLoopMult = smoothedLoopMultiplier.getNextValue();
 
         float inGain  = smoothedInputGain.getNextValue();
-        float dw      = smoothedDryWet.getNextValue();
         float fb      = smoothedFeedback.getNextValue();
-        float outGain = smoothedOutputGain.getNextValue();
+        // v1.0.1: dryWet/outputGain smoothers pre-advanced in processBlock (issue #73)
 
         // === STAGE 1: WRITE (dual L/R) ===
         float rawL = inputBufferL[static_cast<size_t> (s)] * inGain;
@@ -4653,7 +4687,6 @@ void OpenSpatialDelayProcessor::renderDiscreteSurround (
         float delayInputL = softClip ((rawL + feedbackSample * fb) * kFeedbackInputHeadroom);
         float delayInputR = softClip ((rawR + feedbackSample * fb) * kFeedbackInputHeadroom);
         writeDelayLine (delayInputL, delayInputR);
-        float rawInput = dryCompBuffer[static_cast<size_t> (s)];  // v1.0.7: latency-compensated dry signal (issue #63)
 
         // === STAGE 2: READ & SPATIALIZE ===
         float channelAccum[16] = {};
@@ -4685,26 +4718,17 @@ void OpenSpatialDelayProcessor::renderDiscreteSurround (
         // === STAGE 3: FEEDBACK ===
         processFeedbackSample (currentLoopMult, baseDelaySamples, fb);
 
-        // === STAGE 4: OUTPUT MIX ===
-        // Route spatialized signal to output channels
+        // === STAGE 4: OUTPUT — raw wet (dry/wet mix handled in processBlock) ===
         for (int sp = 0; sp < numSpeakers; ++sp)
         {
             int ch = surLayout.speakers[sp].channelIndex;
             if (ch >= 0 && ch < numOutCh && outChannels[ch] != nullptr)
-                outChannels[ch][s] = outputLimiter (channelAccum[sp] * dw * outGain);
+                outChannels[ch][s] = channelAccum[sp];
         }
 
-        // Dry signal → L and R only (channels 0 and 1)
-        float drySignal = rawInput * (1.0f - dw) * outGain;
-        if (outChannels[0] != nullptr) outChannels[0][s] = outputLimiter (outChannels[0][s] + drySignal);
-        if (outChannels[1] != nullptr) outChannels[1][s] = outputLimiter (outChannels[1][s] + drySignal);
-
-        // LFE generation — low-pass filtered mono sum at −10 dB
+        // LFE generation — low-pass filtered mono sum at −10 dB (raw, no dw/outGain)
         if (lfeIdx >= 0 && lfeIdx < numOutCh && outChannels[lfeIdx] != nullptr)
-        {
-            float lfeSig = outputLimiter (lfeFilter.processSample (wetMono) * 0.316f * dw * outGain);  // −10 dB ≈ 0.316
-            outChannels[lfeIdx][s] = lfeSig;
-        }
+            outChannels[lfeIdx][s] = lfeFilter.processSample (wetMono) * 0.316f;
     }
 
     // Store current gains as previous for next block

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -4029,10 +4029,14 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
     // v1.0.7: Fill latency-compensated dry buffer (issue #63)
     // The phase vocoder adds kFFTSize samples of latency to the wet path.
     // Delay the dry signal by the same amount so DAW PDC is correct at all dry/wet levels.
-    // v1.0.1: Stereo dry path — reads from inputBufferL/R to preserve stereo (issue #73)
+    // v1.0.1: Stereo dry path — reads raw DAW input, bypasses input selector (issue #73)
+    // The Input selector only affects the wet (delay) path. The dry signal is a true bypass
+    // of whatever the DAW sends, affected only by the Output knob.
     if (dryCompBufferL.size() < ns) dryCompBufferL.resize (ns);
     if (dryCompBufferR.size() < ns) dryCompBufferR.resize (ns);
     {
+        auto* rawInL = buffer.getReadPointer (0);
+        auto* rawInR = (numInputChannels > 1) ? buffer.getReadPointer (1) : buffer.getReadPointer (0);
         const int dryDelaySize = static_cast<int> (dryDelayLineL.size());
         for (int i = 0; i < numSamples; ++i)
         {
@@ -4040,8 +4044,8 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
             auto wp = static_cast<size_t> (dryDelayWritePos);
             dryCompBufferL[si] = dryDelayLineL[wp];
             dryCompBufferR[si] = dryDelayLineR[wp];
-            dryDelayLineL[wp] = inputBufferL[si];
-            dryDelayLineR[wp] = inputBufferR[si];
+            dryDelayLineL[wp] = rawInL[i];
+            dryDelayLineR[wp] = rawInR[i];
             dryDelayWritePos = (dryDelayWritePos + 1) % dryDelaySize;
         }
     }

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -343,9 +343,9 @@ juce::AudioProcessorValueTreeState::ParameterLayout
         juce::NormalisableRange<float> (0.0f, 100.0f, 0.1f), 0.0f,
         juce::AudioParameterFloatAttributes().withLabel ("%").withStringFromValueFunction (fmtPct100)));
 
-    // G18: OSC Bypass (was "ADM-OSC Enabled" — inverted: true=bypassed=all OSC off)
+    // G18: OSC Receive (true=enabled, false=disabled; default OFF)
     params.push_back (std::make_unique<juce::AudioParameterBool> (
-        juce::ParameterID ("admOscEnabled", 18), "OSC Bypass", true));
+        juce::ParameterID ("admOscEnabled", 18), "OSC Receive", false));
 
     // G19–G24: Global Tap Offsets (promoted from OSC-only atomics to APVTS)
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
@@ -1247,10 +1247,8 @@ void OpenSpatialDelayProcessor::timerCallback()
     }
 
     // --- v0.6: ADM-OSC connection management (edge-detect enable/disable) ---
-    // issue #68: admOscEnabled param is now "OSC Bypass" (true=bypassed=OSC off)
-    bool oscBypassed = cachedParam_admOscEnabled != nullptr
-                       && cachedParam_admOscEnabled->load() >= 0.5f;
-    bool admEnabled = ! oscBypassed;
+    bool admEnabled = cachedParam_admOscEnabled != nullptr
+                      && cachedParam_admOscEnabled->load() >= 0.5f;
     if (admEnabled && ! prevAdmOscEnabled)
     {
         // Transition OFF→ON: connect
@@ -1305,8 +1303,7 @@ void OpenSpatialDelayProcessor::timerCallback()
     }
 
     // --- SPATIAL MEDIA LIBRARY: ADM-OSC Send — broadcast object positions at 30Hz ---
-    // issue #68: OSC Bypass disables both send and receive
-    if (oscSendEnabled && ! oscBypassed && oscSendConnected && ++oscSendTickCounter >= 2)
+    if (oscSendEnabled && admEnabled && oscSendConnected && ++oscSendTickCounter >= 2)
     {
         oscSendTickCounter = 0;
         for (int t = 0; t < MAX_OBJECTS; ++t)

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -979,9 +979,16 @@ private:
     // The phase vocoder adds kFFTSize (2048) samples of latency to the wet path.
     // The dry signal must be delayed by the same amount so the DAW's PDC is correct
     // at all dry/wet settings. Without this, the dry signal arrives 2048 samples early.
-    std::vector<float> dryDelayLine;        // circular buffer, size = kFFTSize
+    // v1.0.1: Stereo dry buffers — dry path preserves stereo input (issue #73)
+    std::vector<float> dryDelayLineL;       // circular buffer L, size = kFFTSize
+    std::vector<float> dryDelayLineR;       // circular buffer R, size = kFFTSize
     int dryDelayWritePos = 0;
-    std::vector<float> dryCompBuffer;       // pre-filled delayed dry signal for current block
+    std::vector<float> dryCompBufferL;      // pre-filled delayed dry signal L for current block
+    std::vector<float> dryCompBufferR;      // pre-filled delayed dry signal R for current block
+
+    // v1.0.1: Pre-computed per-sample dryWet / outputGain for post-render mix (issue #73)
+    std::vector<float> perSampleDW;
+    std::vector<float> perSampleOutGain;
 
     // v0.5: Contiguous per-source accumulation buffers for direct HRTF convolution
     std::vector<float> sourceAccumBufStorage;          // MAX_OBJECTS * maxBlockSize (contiguous)


### PR DESCRIPTION
## Summary
- **Stereo dry path**: Replaced mono `dryDelayLine`/`dryCompBuffer` with stereo `dryDelayLineL/R`/`dryCompBufferL/R` — dry signal preserves stereo image
- **True bypass**: Dry path reads raw DAW input directly, bypassing the Input selector (Mono/Stereo/L/R). Only the Output knob affects the dry signal.
- **Equal-power crossfade**: Replaced linear `(1-dw)/dw` gain law with `cos/sin` equal-power crossfade, eliminating the -6dB dip at 50% Dry/Wet
- **Single-point dry/wet mix**: Extracted dry/wet mixing from all 5 render paths into a single post-render stage in `processBlock` — render paths output raw wet signal only
- **Cherry-picked OSC fix**: Includes PR #74 (OSC Receive defaults to OFF)

## Commits
1. `6e128c6` — Stereo dry buffers + equal-power crossfade + post-render mix refactor
2. `f139e70` — CLAUDE.md architecture notes update
3. `bea5fbe` — Cherry-pick OSC Receive default fix (PR #74)
4. `a2a71c6` — Dry path reads raw DAW input, bypasses Input selector
5. `6c629ef` — Merge origin/main (resolved 2 CLAUDE.md conflicts)
6. `95f6678` — Reset version registry to v1.0.0 baseline

## Test plan
- [x] 197/200 tests pass (3 pre-existing convolver glitch failures)
- [ ] A/B listening: stereo material at 50% Dry/Wet — no volume dip
- [ ] Input selector set to Mono → dry signal remains stereo
- [ ] Phase-inverted stereo at Dry/Wet 0% → audible output (not silence)
- [ ] OSC Receive defaults to OFF

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)