### PR TITLE
Fix Doppler buzz + offline render (issue #77)

### DIFF
--- a/Source/DopplerVelocity.cpp
+++ b/Source/DopplerVelocity.cpp
@@ -98,8 +98,17 @@ void DopplerVelocity::clearDisabled (int objectIndex)
 //==============================================================================
 void DopplerVelocity::smooth (int objectIndex)
 {
+    // Store previous smoothed value before updating (for per-sample interpolation)
+    prevSmoothedSemitones_[objectIndex] = smoothedSemitones_[objectIndex];
+
+    // Two-pole (cascaded) EMA: continuous first derivative, eliminates
+    // staircase artifacts that cause hop-rate buzz in the phase vocoder.
+    // Stage 1: raw → intermediate
+    intermediateSmoothed_[objectIndex] += kSmoothAlpha
+        * (rawSemitones_[objectIndex] - intermediateSmoothed_[objectIndex]);
+    // Stage 2: intermediate → output
     smoothedSemitones_[objectIndex] += kSmoothAlpha
-        * (rawSemitones_[objectIndex] - smoothedSemitones_[objectIndex]);
+        * (intermediateSmoothed_[objectIndex] - smoothedSemitones_[objectIndex]);
 }
 
 //==============================================================================
@@ -110,6 +119,8 @@ void DopplerVelocity::reset (int objectIndex, float azRad, float elRad, float di
     prevDist_[objectIndex] = dist;
     rawSemitones_[objectIndex] = 0.0f;
     smoothedSemitones_[objectIndex] = 0.0f;
+    prevSmoothedSemitones_[objectIndex] = 0.0f;
+    intermediateSmoothed_[objectIndex] = 0.0f;
     smoothedVelocity_[objectIndex] = 0.0f;
     posChanged_[objectIndex] = false;
 }

--- a/Source/DopplerVelocity.h
+++ b/Source/DopplerVelocity.h
@@ -31,8 +31,11 @@ public:
     /** Reset all objects. */
     void resetAll();
 
-    /** Get the smoothed Doppler pitch in semitones. */
+    /** Get the smoothed Doppler pitch in semitones (current block value). */
     float getSmoothedSemitones (int objectIndex) const { return smoothedSemitones_[objectIndex]; }
+
+    /** Get the previous block's smoothed Doppler pitch in semitones (for per-sample interpolation). */
+    float getPrevSmoothedSemitones (int objectIndex) const { return prevSmoothedSemitones_[objectIndex]; }
 
     /** Get the raw (unsmoothed) Doppler pitch in semitones. */
     float getRawSemitones (int objectIndex) const { return rawSemitones_[objectIndex]; }
@@ -50,6 +53,8 @@ private:
     float smoothedVelocity_[kMaxObjects] = {};
     float rawSemitones_[kMaxObjects] = {};
     float smoothedSemitones_[kMaxObjects] = {};
+    float prevSmoothedSemitones_[kMaxObjects] = {};  // Previous block's value for per-sample interpolation
+    float intermediateSmoothed_[kMaxObjects] = {};    // First stage of two-pole EMA
     bool  posChanged_[kMaxObjects] = {};
 
     // Constants

--- a/Source/PhaseVocoderPitchShifter.h
+++ b/Source/PhaseVocoderPitchShifter.h
@@ -60,6 +60,10 @@ public:
         std::memset (fluxHistory,     0, sizeof (fluxHistory));
         fluxWritePos     = 0;
         transientHold    = 0;
+
+        // Bypass hysteresis state
+        bypassed_    = true;
+        bypassFade_  = 1.0f;
     }
 
     /** Process one sample with pitch shift in semitones (-12 to +12).
@@ -72,25 +76,54 @@ public:
         inputWritePos = (inputWritePos + 1) % kFFTSize;
         inputCount++;
 
-        // Bypass: no pitch shift — just delay by kFFTSize for latency compensation
-        if (std::abs (semitones) < 0.01f)
+        // Hysteresis bypass: enter at |s| < 0.005, exit at |s| > 0.02
+        // Prevents oscillation near zero crossing from toggling PV on/off
+        float absSemi = std::abs (semitones);
+        if (bypassed_)
         {
-            // Reset phase state so re-engaging pitch shift starts clean
-            std::memset (lastInputPhase,  0, sizeof (lastInputPhase));
-            std::memset (lastOutputPhase, 0, sizeof (lastOutputPhase));
-            std::memset (prevAnalysisMag, 0, sizeof (prevAnalysisMag));
-            std::memset (fluxHistory,     0, sizeof (fluxHistory));
-            fluxWritePos  = 0;
-            transientHold = 0;
-
-            // Read from kFFTSize samples ago in the ring buffer
-            int readPos = (inputWritePos - kFFTSize + kFFTSize) % kFFTSize;
-
-            if (inputCount < kFFTSize)
-                return 0.0f;
-
-            return inputRing[readPos];
+            if (absSemi > kBypassExitThreshold)
+                bypassed_ = false;
         }
+        else
+        {
+            if (absSemi < kBypassEnterThreshold)
+                bypassed_ = true;
+        }
+
+        if (bypassed_)
+        {
+            // Fade toward dry — NO FFT processing, just drain the accumulator
+            if (bypassFade_ < 1.0f)
+                bypassFade_ = std::min (bypassFade_ + kBypassFadeStep, 1.0f);
+
+            // Keep hop counter in sync (no processOneFrame — too expensive)
+            hopCounter++;
+            if (hopCounter >= kHopSize)
+                hopCounter = 0;
+
+            // Read bypass (latency-compensated dry)
+            int readPos = (inputWritePos - kFFTSize + kFFTSize) % kFFTSize;
+            float dry = (inputCount < kFFTSize) ? 0.0f : inputRing[readPos];
+
+            // Drain PV accumulator during crossfade to prevent stale data buildup
+            if (filledLatency && bypassFade_ < 1.0f)
+            {
+                float pvOut = outputAccum[outputReadPos];
+                outputAccum[outputReadPos] = 0.0f;
+                outputReadPos = (outputReadPos + 1) % kOutputSize;
+                return dry * bypassFade_ + pvOut * (1.0f - bypassFade_);
+            }
+
+            // Fully bypassed — just return latency-compensated dry
+            if (! filledLatency && inputCount >= kFFTSize + kHopSize)
+                filledLatency = true;
+
+            return dry;
+        }
+
+        // Active PV: fade in PV, fade out dry
+        if (bypassFade_ > 0.0f)
+            bypassFade_ = std::max (bypassFade_ - kBypassFadeStep, 0.0f);
 
         // Accumulate until we have a hop's worth
         hopCounter++;
@@ -113,11 +146,19 @@ public:
         }
 
         // Pop one sample from output accumulator
-        float out = outputAccum[outputReadPos];
+        float pvOut = outputAccum[outputReadPos];
         outputAccum[outputReadPos] = 0.0f;  // Clear for next overlap-add cycle
         outputReadPos = (outputReadPos + 1) % kOutputSize;
 
-        return out;
+        // If still crossfading from bypass, blend with dry
+        if (bypassFade_ > 0.0f)
+        {
+            int readPos = (inputWritePos - kFFTSize + kFFTSize) % kFFTSize;
+            float dry = inputRing[readPos];
+            return dry * bypassFade_ + pvOut * (1.0f - bypassFade_);
+        }
+
+        return pvOut;
     }
 
     static constexpr int getLatency() { return kFFTSize; }
@@ -149,6 +190,13 @@ private:
     // Phase vocoder state (per bin)
     float lastInputPhase[kNumBins]  = {};
     float lastOutputPhase[kNumBins] = {};
+
+    // Bypass hysteresis state
+    bool  bypassed_    = true;   // Start bypassed (no pitch shift initially)
+    float bypassFade_  = 1.0f;   // 1.0 = full bypass/dry, 0.0 = full PV
+    static constexpr float kBypassEnterThreshold = 0.005f;  // Enter bypass below this
+    static constexpr float kBypassExitThreshold  = 0.02f;   // Exit bypass above this
+    static constexpr float kBypassFadeStep       = 1.0f / 128.0f;  // ~2.7ms crossfade at 48kHz
 
     // Transient detection state
     static constexpr int kFluxHistorySize = 16;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -3696,7 +3696,7 @@ inline float OpenSpatialDelayProcessor::applyWobble (float baseDelaySamples, flo
 //==============================================================================
 // v0.5: Shared inline helpers for render methods
 //==============================================================================
-float OpenSpatialDelayProcessor::readObjectSample (int objectIndex, float baseDelaySamples)
+float OpenSpatialDelayProcessor::readObjectSample (int objectIndex, float baseDelaySamples, float blockFraction)
 {
     float objDelaySamples = static_cast<float> (objectIndex + 1) * baseDelaySamples;
     objDelaySamples = juce::jlimit (1.0f, static_cast<float> (delayBufferSize - 2), objDelaySamples);
@@ -3704,8 +3704,12 @@ float OpenSpatialDelayProcessor::readObjectSample (int objectIndex, float baseDe
     // v0.9: Per-tap pitch via WSOLA-lite (timing-preserving)
     float perTapPitch = cachedObj[objectIndex].pitchShift->load (std::memory_order_relaxed);
 
-    // v1.0: Combined pitch = user pitch + Doppler (smoothed per-block in processBlock)
-    float combinedPitch = perTapPitch + doppler.getSmoothedSemitones (objectIndex);
+    // v1.0.1: Per-sample Doppler interpolation — converts block-rate staircase into
+    // smooth ramp, eliminating hop-rate buzz in the phase vocoder (issue #77)
+    float prevDoppler = doppler.getPrevSmoothedSemitones (objectIndex);
+    float curDoppler  = doppler.getSmoothedSemitones (objectIndex);
+    float interpDoppler = prevDoppler + blockFraction * (curDoppler - prevDoppler);
+    float combinedPitch = perTapPitch + interpDoppler;
 
     // v0.8: Per-tap input channel routing
     int inputCh = static_cast<int> (cachedObj[objectIndex].inputChannel->load (std::memory_order_relaxed));
@@ -4270,7 +4274,7 @@ void OpenSpatialDelayProcessor::renderDirectBinauralHRTF (
             else if (tapFadeGain[t] > tapFadeTarget[t])
                 tapFadeGain[t] = std::max (tapFadeGain[t] - tapFadeIncrement, 0.0f);
             // v1.0.8: Always feed PV to keep it in sync — prevents chirp on tap enable (issue #65)
-            float objMono = readObjectSample (t, baseDelaySamples);
+            float objMono = readObjectSample (t, baseDelaySamples, static_cast<float> (s) / static_cast<float> (numSamples));
             if (tapFadeGain[t] <= 0.0f) continue;
             float dist = prevDistGain[t] + frac * (objDistGain[t] - prevDistGain[t]);
             sourceAccumBufPtrs[t][s] = objMono * dist * tapFadeGain[t];
@@ -4352,7 +4356,7 @@ void OpenSpatialDelayProcessor::renderSimpleBinauralWoodworth (
             else if (tapFadeGain[t] > tapFadeTarget[t])
                 tapFadeGain[t] = std::max (tapFadeGain[t] - tapFadeIncrement, 0.0f);
             // v1.0.8: Always feed PV to keep it in sync — prevents chirp on tap enable (issue #65)
-            float objMono = readObjectSample (t, baseDelaySamples);
+            float objMono = readObjectSample (t, baseDelaySamples, static_cast<float> (s) / static_cast<float> (numSamples));
             if (tapFadeGain[t] <= 0.0f) continue;
 
             // Interpolate between previous and current block gains
@@ -4489,7 +4493,7 @@ void OpenSpatialDelayProcessor::renderStereoVariant (
             else if (tapFadeGain[t] > tapFadeTarget[t])
                 tapFadeGain[t] = std::max (tapFadeGain[t] - tapFadeIncrement, 0.0f);
             // v1.0.8: Always feed PV to keep it in sync — prevents chirp on tap enable (issue #65)
-            float objMono = readObjectSample (t, baseDelaySamples);
+            float objMono = readObjectSample (t, baseDelaySamples, static_cast<float> (s) / static_cast<float> (numSamples));
             if (tapFadeGain[t] <= 0.0f) continue;
 
             // Interpolate between previous and current block gains
@@ -4635,7 +4639,7 @@ void OpenSpatialDelayProcessor::renderAmbisonicsOutput (
             else if (tapFadeGain[t] > tapFadeTarget[t])
                 tapFadeGain[t] = std::max (tapFadeGain[t] - tapFadeIncrement, 0.0f);
             // v1.0.8: Always feed PV to keep it in sync — prevents chirp on tap enable (issue #65)
-            float objMono = readObjectSample (t, baseDelaySamples);
+            float objMono = readObjectSample (t, baseDelaySamples, static_cast<float> (s) / static_cast<float> (numSamples));
             if (tapFadeGain[t] <= 0.0f) continue;
 
             // Interpolate distance gain between previous and current block
@@ -4734,7 +4738,7 @@ void OpenSpatialDelayProcessor::renderDiscreteSurround (
             else if (tapFadeGain[t] > tapFadeTarget[t])
                 tapFadeGain[t] = std::max (tapFadeGain[t] - tapFadeIncrement, 0.0f);
             // v1.0.8: Always feed PV to keep it in sync — prevents chirp on tap enable (issue #65)
-            float objMono = readObjectSample (t, baseDelaySamples);
+            float objMono = readObjectSample (t, baseDelaySamples, static_cast<float> (s) / static_cast<float> (numSamples));
             if (tapFadeGain[t] <= 0.0f) continue;
 
             // Interpolate distance gain and channel gains between previous and current block

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -2497,6 +2497,7 @@ void OpenSpatialDelayProcessor::prepareToPlay (double sampleRate, int samplesPer
 
     // v1.0.1: Reset Doppler velocity tracking
     doppler.resetAll();
+    std::memset (dopplerDelayAccum, 0, sizeof (dopplerDelayAccum));
 
     // HRTF convolution: prepare both renderers (double-buffered)
     binauralRenderers[0].prepare (sampleRate, samplesPerBlock);
@@ -3682,30 +3683,37 @@ inline float OpenSpatialDelayProcessor::applyWobble (float baseDelaySamples, flo
 //==============================================================================
 float OpenSpatialDelayProcessor::readObjectSample (int objectIndex, float baseDelaySamples, float blockFraction)
 {
-    float objDelaySamples = static_cast<float> (objectIndex + 1) * baseDelaySamples;
+    // v1.0.2: Doppler via delay line modulation — the standard artifact-free approach.
+    // Accumulate per-sample delay offset from Doppler velocity. The rate of change
+    // of the read position naturally produces pitch shift without PV artifacts.
+    // PV is reserved for user pitch shift only (constant ratio = no grain-rate buzz).
+    float prevDoppler = doppler.getPrevSmoothedSemitones (objectIndex);
+    float curDoppler  = doppler.getSmoothedSemitones (objectIndex);
+    float interpDoppler = prevDoppler + blockFraction * (curDoppler - prevDoppler);
+
+    // delayRate: how much delay changes per sample. Negative when pitch up (approaching).
+    // pow(2, semitones/12) is the playback speed ratio. (1 - ratio) gives delay accumulation rate.
+    float delayRate = 1.0f - std::pow (2.0f, interpDoppler / 12.0f);
+    dopplerDelayAccum[objectIndex] += delayRate;
+
+    float objDelaySamples = static_cast<float> (objectIndex + 1) * baseDelaySamples
+                          + dopplerDelayAccum[objectIndex];
     objDelaySamples = juce::jlimit (1.0f, static_cast<float> (delayBufferSize - 2), objDelaySamples);
 
     // v0.9: Per-tap pitch via WSOLA-lite (timing-preserving)
     float perTapPitch = cachedObj[objectIndex].pitchShift->load (std::memory_order_relaxed);
 
-    // v1.0.1: Per-sample Doppler interpolation — converts block-rate staircase into
-    // smooth ramp, eliminating hop-rate buzz in the phase vocoder (issue #77)
-    float prevDoppler = doppler.getPrevSmoothedSemitones (objectIndex);
-    float curDoppler  = doppler.getSmoothedSemitones (objectIndex);
-    float interpDoppler = prevDoppler + blockFraction * (curDoppler - prevDoppler);
-    float combinedPitch = perTapPitch + interpDoppler;
-
     // v0.8: Per-tap input channel routing
     int inputCh = static_cast<int> (cachedObj[objectIndex].inputChannel->load (std::memory_order_relaxed));
     DelayChannel ch = (inputCh == 1) ? DelayChannel::Left : (inputCh == 2) ? DelayChannel::Right : DelayChannel::Mono;
 
-    // v0.8: Channel-aware delay line read
+    // v0.8: Channel-aware delay line read (now with Doppler-modulated position)
     float objMono = readDelayLineMono (objDelaySamples);
     if (ch == DelayChannel::Left)       objMono = readDelayLineL (objDelaySamples);
     else if (ch == DelayChannel::Right) objMono = readDelayLineR (objDelaySamples);
 
-    // v1.0.6: Phase vocoder pitch shift — handles bypass internally when |semitones| < 0.01 (issue #60)
-    objMono = pvPitchShifters[objectIndex].process (objMono, combinedPitch);
+    // v1.0.6: Phase vocoder pitch shift — user pitch only, no Doppler (issue #77)
+    objMono = pvPitchShifters[objectIndex].process (objMono, perTapPitch);
     // v1.0.1: Air absorption + tap filters via FilterBank class
     float result = filters.processAirSample (objectIndex, objMono);
     result = filters.processTapSample (objectIndex, result);
@@ -3792,7 +3800,10 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
                 if (transportStarted || transportJumped)
                 {
                     for (int i = 0; i < MAX_OBJECTS; ++i)
+                    {
                         pvPitchShifters[i].reset();
+                        dopplerDelayAccum[i] = 0.0f;
+                    }
                 }
 
                 wasPlaying = isPlaying;
@@ -3807,7 +3818,10 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
     if (presetResetPending.load (std::memory_order_acquire))
     {
         for (int i = 0; i < MAX_OBJECTS; ++i)
+        {
             doppler.reset (i, pendingReset.prevAz[i], pendingReset.prevEl[i], pendingReset.prevDist[i]);
+            dopplerDelayAccum[i] = 0.0f;
+        }
 
         for (int i = 0; i < MAX_OBJECTS; ++i)
             pvPitchShifters[i].reset();
@@ -4010,6 +4024,7 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
             if (! objects[t].enabled && tapFadeGain[t] <= 0.0f)
             {
                 doppler.clearDisabled (t);
+                dopplerDelayAccum[t] = 0.0f;
                 filters.clearAirAbsorption (t);
                 continue;
             }
@@ -4019,6 +4034,8 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
             float dist  = objects[t].distance;
 
             float objDopplerAmount = cachedObj[t].dopplerAmount->load();
+            if (objDopplerAmount < 0.001f)
+                dopplerDelayAccum[t] = 0.0f;  // Reset when Doppler disabled
             doppler.update (t, azRad, elRad, dist, objDopplerAmount, blockDuration);
             doppler.smooth (t);
 

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1310,25 +1310,9 @@ void OpenSpatialDelayProcessor::timerCallback()
         }
     }
 
-    // v1.0.1: Trajectory animation — delegated to TrajectoryEngine class
-    {
-        for (int t = 0; t < MAX_OBJECTS; ++t)
-        {
-            TrajectoryEngine::ObjectInput input;
-            input.shape     = juce::roundToInt (cachedParam_trajectoryShape[t] != nullptr
-                                                ? cachedParam_trajectoryShape[t]->load() : 0.0f);
-            input.speed     = cachedParam_trajectorySpeed[t] != nullptr
-                              ? cachedParam_trajectorySpeed[t]->load() : 1.0f;
-            input.reverse   = (cachedParam_trajectoryDirection[t] == nullptr
-                               || cachedParam_trajectoryDirection[t]->load() < 0.5f);
-            input.originAz   = cachedObj[t].azimuth->load();
-            input.originEl   = cachedObj[t].elevation->load();
-            input.originDist = cachedObj[t].distance->load();
-            input.oscOverride = oscOverrideActive[t].load (std::memory_order_relaxed);
-
-            trajectory.tick (t, input);
-        }
-    }
+    // v1.0.2: Trajectory tick moved to processBlock (audio thread) — see issue #77.
+    // Trajectory now advances in audio-time, fixing offline render speed mismatch
+    // and eliminating 60Hz staircase buzz in Doppler velocity.
 
     // --- SPATIAL MEDIA LIBRARY: ADM-OSC Send — broadcast object positions at 30Hz ---
     if (oscSendEnabled && admEnabled && oscSendConnected && ++oscSendTickCounter >= 2)
@@ -3929,6 +3913,30 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
                               layoutState.ambiDecodeMatrix, layoutState.ambiNumSpeakers };
 
     BinauralContext binCtx { profileIndex, currentSampleRate, binauralProfiles.data() };
+
+    // --- v1.0.2: Tick trajectory on audio thread (issue #77) -----------------
+    // Trajectory must advance in audio-time (not wall-clock) so that:
+    //   1) Offline render produces the same orbit speed as realtime
+    //   2) Position updates every audio block (eliminates 60Hz staircase buzz)
+    {
+        float blockDt = static_cast<float> (numSamples) / static_cast<float> (currentSampleRate);
+        for (int t = 0; t < MAX_OBJECTS; ++t)
+        {
+            TrajectoryEngine::ObjectInput input;
+            input.shape     = juce::roundToInt (cachedParam_trajectoryShape[t] != nullptr
+                                                ? cachedParam_trajectoryShape[t]->load() : 0.0f);
+            input.speed     = cachedParam_trajectorySpeed[t] != nullptr
+                              ? cachedParam_trajectorySpeed[t]->load() : 1.0f;
+            input.reverse   = (cachedParam_trajectoryDirection[t] == nullptr
+                               || cachedParam_trajectoryDirection[t]->load() < 0.5f);
+            input.originAz   = cachedObj[t].azimuth->load();
+            input.originEl   = cachedObj[t].elevation->load();
+            input.originDist = cachedObj[t].distance->load();
+            input.oscOverride = oscOverrideActive[t].load (std::memory_order_relaxed);
+
+            trajectory.tick (t, input, blockDt);
+        }
+    }
 
     // --- Read object states and pre-compute spatial gains -------------------
     ObjectState objects[MAX_OBJECTS];

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -897,6 +897,10 @@ private:
     // v1.0.6: Phase vocoder pitch shifter — replaces WSOLA-Lite (issue #60)
     PhaseVocoderPitchShifter pvPitchShifters[MAX_OBJECTS];
 
+    // v1.0.2: Doppler via delay modulation — accumulates per-sample delay offset
+    // from Doppler velocity. Natural pitch shift without PV artifacts (issue #77).
+    float dopplerDelayAccum[MAX_OBJECTS] = {};
+
     // v1.0.8: Transport-aware PV reset — clears stale phase state on transport
     // stop/start/seek to prevent intermittent buzzing artifacts (issue #65)
     bool wasPlaying = false;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -714,8 +714,9 @@ private:
     float getTempoSyncedDelayMs (int noteDivisionIndex) const;
 
     //--- DELAY-SPECIFIC: Render path methods (v0.5 refactor) ------------------
-    /** Read one tap sample: delay + per-tap pitch shift + air absorption. */
-    float readObjectSample (int objectIndex, float baseDelaySamples);
+    /** Read one tap sample: delay + per-tap pitch shift + air absorption.
+        blockFraction: 0..1 position within block, for per-sample Doppler interpolation. */
+    float readObjectSample (int objectIndex, float baseDelaySamples, float blockFraction);
     /** Process feedback: read from end of chain, filter, soft-clip, NaN guard. */
     void  processFeedbackSample (float currentLoopMult, float baseDelaySamples,
                                  float fb);


### PR DESCRIPTION
## Summary

- **Moved trajectory tick from 60Hz timer thread to audio thread** — fixes offline render orbit speed mismatch and eliminates 60Hz staircase in Doppler velocity
- **Replaced PV-based Doppler with delay line modulation** — the standard artifact-free Doppler technique (CCRMA/J.O. Smith). Per-sample delay offset accumulates from Doppler velocity, producing natural pitch shift via rate-of-change of the read position
- **PV now handles user pitch shift only** (constant ratio = zero grain-rate buzz)
- **Two-pole cascaded EMA smoothing** for Doppler semitones (continuous first derivative)
- **PV bypass hysteresis** (enter <0.005st, exit >0.02st) with 128-sample crossfade — eliminates phase state destruction at zero crossings

## Root Cause

Two independent root causes identified through systematic debugging:

1. **Offline render speed mismatch**: `trajectory.tick()` ran on a 60Hz `juce::Timer` thread. In offline render, REAPER processes blocks faster than realtime, but the timer still fires at 60Hz wall-clock — orbit advances slower relative to audio time.

2. **Doppler buzzing**: The Phase Vocoder inherently produces grain-rate buzz (~93.75Hz at 48kHz/512 hop) when its pitch ratio changes between STFT frames. Since Doppler continuously varies the pitch ratio during orbit, every frame boundary creates phase prediction mismatch in the overlap-add region. This is a fundamental PV limitation documented in Prussa & Holighaus 2022 ("Phase Vocoder Done Right").

## Files Changed

- `Source/PluginProcessor.cpp` — trajectory tick moved to processBlock, Doppler delay accumulator, PV receives user pitch only
- `Source/PluginProcessor.h` — added `dopplerDelayAccum[MAX_OBJECTS]`
- `Source/DopplerVelocity.h/.cpp` — two-pole EMA, prevSmoothedSemitones for per-sample interpolation
- `Source/PhaseVocoderPitchShifter.h` — bypass hysteresis with soft crossfade

## Test Plan

- [x] All 203 tests pass (201 + 2 mayfail)
- [x] Listening test: Orbit 0.5Hz + Doppler ON, Stereo mode — buzz eliminated
- [x] Offline render matches realtime orbit speed
- [x] v1.0.2 AU/VST3 built and verified

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)