### PR TITLE
Register v1.0.2 / O102 in version registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,8 @@ bash scripts/build_version.sh <commit-hash> v1.0.Z O10Z
 **Version number registry (do not reuse) — reset 2026-04-01, see issue #73:**
 - v1.0.0 / O100 — baseline (commit 6c629ef)
 - v1.0.1 / O101 — MS Encode subcardioid Mid fix for ±90° center collapse (commit 59f244a, issue #76)
-- Next available: **v1.0.2 / O102**
+- v1.0.2 / O102 — Doppler buzz fix: delay modulation + trajectory on audio thread (commit 0914cd9, issue #77)
+- Next available: **v1.0.3 / O103**
 
 ### Running tests
 


### PR DESCRIPTION
## Summary

- Register v1.0.2 / O102 in CLAUDE.md version registry (Doppler buzz fix, issue #77)
- Update next available to v1.0.3 / O103

🤖 Generated with [Claude Code](https://claude.com/claude-code)