### PR TITLE
Fix Global Pitch knob range ±24→±12st (#101)

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1630,7 +1630,7 @@ GlobalTapDrawerComponent::GlobalTapDrawerComponent (OSDLookAndFeel& lf)
     setupKnob (distSlider,    distLabel,    "DIST",    -1.0f,   1.0f,   0.01f, kDistance);
     setupKnob (dopplerSlider, dopplerLabel, "DOPPLER", -100.0f, 100.0f, 1.0f,  kDoppler);
     dopplerSlider.setTextValueSuffix ("%");
-    setupKnob (pitchSlider,   pitchLabel,   "PITCH",   -24.0f,  24.0f,  1.0f,  kPitch);
+    setupKnob (pitchSlider,   pitchLabel,   "PITCH",   -12.0f,  12.0f,  1.0f,  kPitch);
     pitchSlider.setTextValueSuffix (" st");
     setupKnob (speedSlider,   speedLabel,   "SPEED",   -5.0f,   5.0f,   0.01f, kSpeed);
     speedSlider.setTextValueSuffix (" Hz");

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -364,7 +364,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout
 
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("globalTapPitch", 22), "Global Tap Pitch",
-        juce::NormalisableRange<float> (-24.0f, 24.0f, 1.0f), 0.0f,
+        juce::NormalisableRange<float> (-12.0f, 12.0f, 1.0f), 0.0f,
         juce::AudioParameterFloatAttributes().withStringFromValueFunction (
             [](float value, int) { return juce::String (juce::roundToInt (value)) + " st"; })));
 


### PR DESCRIPTION
## Summary
- Updates Global Pitch UI knob range from ±24st to ±12st (`PluginEditor.cpp`)
- Updates `globalTapPitch` APVTS automatable parameter range to match (`PluginProcessor.cpp`)
- Aligns with the per-tap ±12st limit set previously

Closes #101