### PR TITLE
Update version registry for issue #97

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,8 @@ bash scripts/build_version.sh <commit-hash> v1.0.Z O10Z
 
 **Version number registry (do not reuse) — reset 2026-04-02, collapsed after issue #77:**
 - v1.0.0 / O100 — baseline (commit 3ef9c79, includes issues #76 + #77)
-- Next available: **v1.0.1 / O101**
+- v1.0.1 / O101 — fix dry signal attenuation at 0% wet (issue #97, commit a0f39c5)
+- Next available: **v1.0.2 / O102**
 
 ### Running tests
 


### PR DESCRIPTION
## Summary

- Registers v1.0.1 / O101 in CLAUDE.md version registry (issue #97 fix)
- Bumps next available to v1.0.2 / O102

🤖 Generated with [Claude Code](https://claude.com/claude-code)