### PR TITLE
Fix config changes not marking DAW session dirty (#94)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,8 @@ bash scripts/build_version.sh <commit-hash> v1.0.Z O10Z
 **Version number registry (do not reuse) — reset 2026-04-02, collapsed after issue #77:**
 - v1.0.0 / O100 — baseline (commit 3ef9c79, includes issues #76 + #77)
 - v1.0.1 / O101 — fix dry signal attenuation at 0% wet (issue #97, commit a0f39c5)
-- Next available: **v1.0.2 / O102**
+- v1.0.2 / O102 — call updateHostDisplay() on config changes (issue #94, commit dbf19ce)
+- Next available: **v1.0.3 / O103**
 
 ### Running tests
 

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -2027,6 +2027,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         {
             int paramIdx = selectedId - 1;  // IDs are 1-based, param indices are 0-based
             processorRef.configAlgorithm.store (paramIdx, std::memory_order_relaxed);
+            processorRef.updateHostDisplay();
         }
     };
     {
@@ -2041,6 +2042,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
                                              juce::dontSendNotification);
         hrtfProfileBox.onChange = [this] {
             processorRef.configHrtfProfile.store (hrtfProfileBox.getSelectedItemIndex(), std::memory_order_relaxed);
+            processorRef.updateHostDisplay();
         };
     }
     // v0.7: syncMode reworked to 3-state (Straight/Dotted/Triplet)
@@ -2066,6 +2068,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
                                               juce::dontSendNotification);
         outputFormatBox.onChange = [this] {
             processorRef.configOutputFormat.store (outputFormatBox.getSelectedItemIndex(), std::memory_order_relaxed);
+            processorRef.updateHostDisplay();
         };
     }
 
@@ -2480,6 +2483,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
                                         juce::dontSendNotification);
     inputFormatBox.onChange = [this] {
         processorRef.configInputFormat.store (inputFormatBox.getSelectedItemIndex(), std::memory_order_relaxed);
+        processorRef.updateHostDisplay();
     };
 
     // Header dropdown labels: JetBrains Mono Medium 7.5px, wide kerning
@@ -3073,6 +3077,7 @@ void OpenSpatialDelayEditor::timerCallback()
                 if (algoIdx < 6)
                 {
                     processorRef.configAlgorithm.store (6, std::memory_order_relaxed);  // Equal Power
+                    processorRef.updateHostDisplay();
                     algoIdx = 6;
                 }
             }
@@ -3090,6 +3095,7 @@ void OpenSpatialDelayEditor::timerCallback()
                 if (algoIdx > 5)
                 {
                     processorRef.configAlgorithm.store (4, std::memory_order_relaxed);  // VBAP
+                    processorRef.updateHostDisplay();
                     algoIdx = 4;
                 }
             }

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -2027,7 +2027,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         {
             int paramIdx = selectedId - 1;  // IDs are 1-based, param indices are 0-based
             processorRef.configAlgorithm.store (paramIdx, std::memory_order_relaxed);
-            processorRef.updateHostDisplay();
+            processorRef.updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withNonParameterStateChanged (true));
         }
     };
     {
@@ -2042,7 +2042,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
                                              juce::dontSendNotification);
         hrtfProfileBox.onChange = [this] {
             processorRef.configHrtfProfile.store (hrtfProfileBox.getSelectedItemIndex(), std::memory_order_relaxed);
-            processorRef.updateHostDisplay();
+            processorRef.updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withNonParameterStateChanged (true));
         };
     }
     // v0.7: syncMode reworked to 3-state (Straight/Dotted/Triplet)
@@ -2068,7 +2068,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
                                               juce::dontSendNotification);
         outputFormatBox.onChange = [this] {
             processorRef.configOutputFormat.store (outputFormatBox.getSelectedItemIndex(), std::memory_order_relaxed);
-            processorRef.updateHostDisplay();
+            processorRef.updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withNonParameterStateChanged (true));
         };
     }
 
@@ -2483,7 +2483,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
                                         juce::dontSendNotification);
     inputFormatBox.onChange = [this] {
         processorRef.configInputFormat.store (inputFormatBox.getSelectedItemIndex(), std::memory_order_relaxed);
-        processorRef.updateHostDisplay();
+        processorRef.updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withNonParameterStateChanged (true));
     };
 
     // Header dropdown labels: JetBrains Mono Medium 7.5px, wide kerning
@@ -3077,7 +3077,7 @@ void OpenSpatialDelayEditor::timerCallback()
                 if (algoIdx < 6)
                 {
                     processorRef.configAlgorithm.store (6, std::memory_order_relaxed);  // Equal Power
-                    processorRef.updateHostDisplay();
+                    processorRef.updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withNonParameterStateChanged (true));
                     algoIdx = 6;
                 }
             }
@@ -3095,7 +3095,7 @@ void OpenSpatialDelayEditor::timerCallback()
                 if (algoIdx > 5)
                 {
                     processorRef.configAlgorithm.store (4, std::memory_order_relaxed);  // VBAP
-                    processorRef.updateHostDisplay();
+                    processorRef.updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withNonParameterStateChanged (true));
                     algoIdx = 4;
                 }
             }

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -5016,9 +5016,9 @@ void OpenSpatialDelayProcessor::oscMessageReceived (const juce::OSCMessage& mess
         else if (property == "/drywet")        handleOSCParam ("dryWet", val);
         else if (property == "/inputgain")     handleOSCParam ("inputGain", val);
         else if (property == "/outputgain")    handleOSCParam ("outputGain", val);
-        else if (property == "/algorithm")    configAlgorithm.store (juce::roundToInt (val), std::memory_order_relaxed);
-        else if (property == "/hrtfprofile")  configHrtfProfile.store (juce::roundToInt (val), std::memory_order_relaxed);
-        else if (property == "/outputformat") configOutputFormat.store (juce::roundToInt (val), std::memory_order_relaxed);
+        else if (property == "/algorithm")    { configAlgorithm.store (juce::roundToInt (val), std::memory_order_relaxed); updateHostDisplay(); }
+        else if (property == "/hrtfprofile")  { configHrtfProfile.store (juce::roundToInt (val), std::memory_order_relaxed); updateHostDisplay(); }
+        else if (property == "/outputformat") { configOutputFormat.store (juce::roundToInt (val), std::memory_order_relaxed); updateHostDisplay(); }
         else if (property == "/air")           handleOSCParam ("airAbsorption", val);
         else if (property == "/wobble")        handleOSCParam ("wobbleEnabled", val);
         else if (property == "/wobbleamount")  handleOSCParam ("wobbleAmount", val);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -5016,9 +5016,9 @@ void OpenSpatialDelayProcessor::oscMessageReceived (const juce::OSCMessage& mess
         else if (property == "/drywet")        handleOSCParam ("dryWet", val);
         else if (property == "/inputgain")     handleOSCParam ("inputGain", val);
         else if (property == "/outputgain")    handleOSCParam ("outputGain", val);
-        else if (property == "/algorithm")    { configAlgorithm.store (juce::roundToInt (val), std::memory_order_relaxed); updateHostDisplay(); }
-        else if (property == "/hrtfprofile")  { configHrtfProfile.store (juce::roundToInt (val), std::memory_order_relaxed); updateHostDisplay(); }
-        else if (property == "/outputformat") { configOutputFormat.store (juce::roundToInt (val), std::memory_order_relaxed); updateHostDisplay(); }
+        else if (property == "/algorithm")    { configAlgorithm.store (juce::roundToInt (val), std::memory_order_relaxed); updateHostDisplay (ChangeDetails().withNonParameterStateChanged (true)); }
+        else if (property == "/hrtfprofile")  { configHrtfProfile.store (juce::roundToInt (val), std::memory_order_relaxed); updateHostDisplay (ChangeDetails().withNonParameterStateChanged (true)); }
+        else if (property == "/outputformat") { configOutputFormat.store (juce::roundToInt (val), std::memory_order_relaxed); updateHostDisplay (ChangeDetails().withNonParameterStateChanged (true)); }
         else if (property == "/air")           handleOSCParam ("airAbsorption", val);
         else if (property == "/wobble")        handleOSCParam ("wobbleEnabled", val);
         else if (property == "/wobbleamount")  handleOSCParam ("wobbleAmount", val);


### PR DESCRIPTION
## Summary

- Call `updateHostDisplay(ChangeDetails().withNonParameterStateChanged(true))` when output format, HRTF profile, algorithm, or input format are changed via UI dropdowns or OSC
- Also covers auto-snap algorithm changes triggered by output format switching (stereo/surround)

## Root cause

When config parameters were removed from APVTS (to hide from DAW automation lists), the host was no longer notified of state changes. The default `updateHostDisplay()` flags (`latencyChanged`, `parameterInfoChanged`, `programChanged`) don't mark the session dirty — only `nonParameterStateChanged` does.

## Files changed

- `Source/PluginEditor.cpp` — 6 call sites: 4 onChange handlers (algorithm, HRTF profile, output format, input format) + 2 auto-snap algorithm stores
- `Source/PluginProcessor.cpp` — 3 OSC handlers (`/algorithm`, `/hrtfprofile`, `/outputformat`)
- `CLAUDE.md` — version registry update (v1.0.2 / O102)

## Test plan

- [x] Build v1.0.2 and test in REAPER
- [x] Change output format → REAPER shows unsaved indicator
- [x] Change HRTF profile → REAPER shows unsaved indicator
- [x] Change algorithm → REAPER shows unsaved indicator
- [x] 242/245 tests pass (1 pre-existing failure, 2 expected failures)

Closes #94

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>