### PR TITLE
Fix algorithm dropdown on preset change (issue #93)

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -3072,14 +3072,6 @@ void OpenSpatialDelayEditor::timerCallback()
                 algorithmBox.addItem ("XY Pair",      9);   // param index 8
                 algorithmBox.addItem ("MS Encode",    10);  // param index 9
                 algorithmBox.addItem ("Blumlein",     11);  // param index 10
-
-                // Auto-snap if current param is a surround algorithm
-                if (algoIdx < 6)
-                {
-                    processorRef.configAlgorithm.store (6, std::memory_order_relaxed);  // Equal Power
-                    processorRef.updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withNonParameterStateChanged (true));
-                    algoIdx = 6;
-                }
             }
             else  // Surround
             {
@@ -3090,15 +3082,22 @@ void OpenSpatialDelayEditor::timerCallback()
                 algorithmBox.addItem ("MDAP",         4);   // param index 3
                 algorithmBox.addItem ("VBAP",         5);   // param index 4
                 algorithmBox.addItem ("VBIP",         6);   // param index 5
-
-                // Auto-snap if current param is a stereo mode
-                if (algoIdx > 5)
-                {
-                    processorRef.configAlgorithm.store (4, std::memory_order_relaxed);  // VBAP
-                    processorRef.updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withNonParameterStateChanged (true));
-                    algoIdx = 4;
-                }
             }
+        }
+
+        // Validate algorithm against current output mode every tick
+        // (preset loading can write an out-of-range value)
+        if (isStereoVariant && algoIdx < 6)
+        {
+            algoIdx = 6;  // Equal Power
+            processorRef.configAlgorithm.store (algoIdx, std::memory_order_relaxed);
+            processorRef.updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withNonParameterStateChanged (true));
+        }
+        else if (! isStereoVariant && algoIdx > 5)
+        {
+            algoIdx = 4;  // VBAP
+            processorRef.configAlgorithm.store (algoIdx, std::memory_order_relaxed);
+            processorRef.updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withNonParameterStateChanged (true));
         }
 
         // Sync combo selection from parameter (IDs are param index + 1)

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1700,9 +1700,8 @@ void OpenSpatialDelayProcessor::loadPreset (int index)
     setBool   ("wobbleEnabled", preset->wobbleEnabled);
     setFloat  ("wobbleAmount", preset->wobbleAmount);
     setFloat  ("wobbleMorph",  preset->wobbleMorph);
-    configAlgorithm.store (preset->algorithm, std::memory_order_relaxed);
     configHrtfProfile.store (preset->hrtfProfile, std::memory_order_relaxed);
-    // NOTE: outputFormat, admOscEnabled, oscReceivePort are NOT modified by presets
+    // NOTE: configAlgorithm, outputFormat, admOscEnabled, oscReceivePort are NOT modified by presets
 
     // Per-tap params
     for (int i = 0; i < MAX_OBJECTS; ++i)


### PR DESCRIPTION
## Summary

- **Stop preset loading from overwriting algorithm selection** (`PluginProcessor.cpp:1703`) — `configAlgorithm` is an output-mode-dependent setting that should persist independently, like `outputFormat`. Presets no longer clobber the user's algorithm choice.
- **Move auto-snap validation to run every timer tick** (`PluginEditor.cpp`) — safety net so the combobox never shows a blank/invalid selection even if an out-of-range algorithm value is written.

Fixes #93

## Test plan
- [x] 242/245 tests pass (1 pre-existing failure in ConvolverGlitchTests, 2 expected failures)
- [ ] Manual: Stereo output — algorithm dropdown preserved after preset change
- [ ] Manual: Multichannel output — algorithm dropdown preserved after preset change
- [ ] Manual: Binaural output — continues to work as expected

## Build
v1.0.4 / O104 (commit 11ad896)

🤖 Generated with [Claude Code](https://claude.com/claude-code)