### PR TITLE
Reset phase vocoder on preset change (issue #99)

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -4147,6 +4147,10 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
         auto& rend = binauralRenderers[activeRendererIndex.load (std::memory_order_acquire)];
         rend.invalidateSources();
 
+        // Reset pitch shifters — stale phase/accumulator state causes chirp (issue #99)
+        for (int i = 0; i < MAX_OBJECTS; ++i)
+            pvPitchShifters[i].reset();
+
         // Snap ALL smoothers to target — no ramps during fade-in
         smoothedDelayTime.setCurrentAndTargetValue (smoothedDelayTime.getTargetValue());
         smoothedDryWet.setCurrentAndTargetValue (smoothedDryWet.getTargetValue());


### PR DESCRIPTION
## Summary
- Fixes residual chirp on preset changes (#99, #84 regression)
- The preset crossfade reconfigure block reset delay buffers, Doppler, filters, and HRTF — but not the phase vocoder pitch shifters
- Stale ring buffers and phase history in `pvPitchShifters[]` leaked into the fade-in, producing a brief chirp
- Added `pvPitchShifters[i].reset()` loop in the reconfigure block, matching the existing transport-start pattern

## Test plan
- [x] Built as v1.0.5 / O105 and tested in REAPER
- [x] Switched between presets during playback — no chirp artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)