### PR TITLE
Fix global tap drawer knobs resetting on UI close/reopen (#95)

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1910,11 +1910,29 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
     addAndMakeVisible (globalTapDrawer);
     globalTapDrawer.toFront (false);
     globalTapDrawer.setOpen (processorRef.getGlobalDrawerOpen());
+    // issue #95: Restore drawer knob values from APVTS params on editor (re)creation.
+    // The globalTapAzimuth/etc. APVTS params hold the absolute knob value (written below
+    // in onGlobalDelta) and survive save/restore via apvts.replaceState.
+    {
+        static const char* tapParamIds[] = { "globalTapAzimuth", "globalTapElevation", "globalTapDistance",
+                                             "globalTapPitch",   "globalTapDoppler",   "globalTapSpeed" };
+        for (int i = 0; i < GlobalTapDrawerComponent::kNumKnobs; ++i)
+        {
+            if (auto* p = processorRef.apvts.getRawParameterValue (tapParamIds[i]))
+                globalTapDrawer.setKnobValueSilent (i, p->load());
+        }
+    }
     globalTapDrawer.onGlobalDelta = [this] (int idx, float delta) {
         applyGlobalTapDelta (idx, delta);
-        // Sync to processor atomics for OSC Send broadcast
-        processorRef.globalTapOffset[idx].store (
-            static_cast<float> (globalTapDrawer.getKnobValue (idx)), std::memory_order_relaxed);
+        // Sync absolute knob value to processor atomic (for OSC Send)
+        float absVal = static_cast<float> (globalTapDrawer.getKnobValue (idx));
+        processorRef.globalTapOffset[idx].store (absVal, std::memory_order_relaxed);
+        // issue #95: Also write to APVTS param so the value is saved with the session.
+        // Without this, globalTapAzimuth etc. stay at 0.0 and knobs reset on UI reopen.
+        static const char* tapParamIds[] = { "globalTapAzimuth", "globalTapElevation", "globalTapDistance",
+                                             "globalTapPitch",   "globalTapDoppler",   "globalTapSpeed" };
+        if (auto* param = processorRef.apvts.getParameter (tapParamIds[idx]))
+            param->setValueNotifyingHost (param->convertTo0to1 (absVal));
     };
     globalTapDrawer.onToggle = [this] {
         processorRef.setGlobalDrawerOpen (globalTapDrawer.isOpen());
@@ -2502,8 +2520,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
     presetPrevButton.onClick = [this]
     {
         globalTapDrawer.resetToCenter();
-        for (int i = 0; i < OpenSpatialDelayProcessor::kNumGlobalTapOffsets; ++i)
-            processorRef.globalTapOffset[i].store (0.0f, std::memory_order_relaxed);
+        resetGlobalTapAPVTSParams();
         processorRef.loadPreviousPreset();
         updatePresetButtonText();
     };
@@ -2512,8 +2529,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
     presetNextButton.onClick = [this]
     {
         globalTapDrawer.resetToCenter();
-        for (int i = 0; i < OpenSpatialDelayProcessor::kNumGlobalTapOffsets; ++i)
-            processorRef.globalTapOffset[i].store (0.0f, std::memory_order_relaxed);
+        resetGlobalTapAPVTSParams();
         processorRef.loadNextPreset();
         updatePresetButtonText();
     };
@@ -2640,8 +2656,7 @@ void OpenSpatialDelayEditor::showPresetMenu()
             if (result > 0)
             {
                 globalTapDrawer.resetToCenter();
-                for (int i = 0; i < OpenSpatialDelayProcessor::kNumGlobalTapOffsets; ++i)
-                    processorRef.globalTapOffset[i].store (0.0f, std::memory_order_relaxed);
+                resetGlobalTapAPVTSParams();
                 processorRef.loadPreset (result - 1);
                 updatePresetButtonText();
             }
@@ -2840,6 +2855,19 @@ void OpenSpatialDelayEditor::applyGlobalTapDelta (int knobIndex, float delta)
 
         // convertTo0to1 handles NormalisableRange clamping for non-wrapping params
         param->setValueNotifyingHost (param->convertTo0to1 (newVal));
+    }
+}
+
+// issue #95: Zero out APVTS global tap params + processor atomics on preset change
+void OpenSpatialDelayEditor::resetGlobalTapAPVTSParams()
+{
+    static const char* tapParamIds[] = { "globalTapAzimuth", "globalTapElevation", "globalTapDistance",
+                                         "globalTapPitch",   "globalTapDoppler",   "globalTapSpeed" };
+    for (int i = 0; i < OpenSpatialDelayProcessor::kNumGlobalTapOffsets; ++i)
+    {
+        processorRef.globalTapOffset[i].store (0.0f, std::memory_order_relaxed);
+        if (auto* param = processorRef.apvts.getParameter (tapParamIds[i]))
+            param->setValueNotifyingHost (param->convertTo0to1 (0.0f));
     }
 }
 

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -545,6 +545,7 @@ private:
     SpatialMapComponent spatialMap;
     GlobalTapDrawerComponent globalTapDrawer;  // v1.0: collapsible global offset knobs
     void applyGlobalTapDelta (int knobIndex, float delta);  // v1.0: IEM-style delta application
+    void resetGlobalTapAPVTSParams();                       // issue #95: zero APVTS + atomics on preset change
     void syncGlobalTapOffsetsFromOSC();                     // v1.0: processor → editor OSC sync
 
     // Global controls — ordered by signal flow

--- a/Tests/IntegrationTests.cpp
+++ b/Tests/IntegrationTests.cpp
@@ -456,3 +456,44 @@ TEST_CASE ("State -- OSC settings survive roundtrip", "[state]")
         REQUIRE (proc->getOscReceivePort() == 5555);
     }
 }
+
+TEST_CASE ("State -- global tap APVTS params survive roundtrip (issue #95)", "[state]")
+{
+    juce::MemoryBlock stateData;
+
+    // Simulate what the editor's onGlobalDelta callback now does:
+    // write absolute knob values to the APVTS global tap params.
+    {
+        auto proc = std::make_unique<Proc>();
+        proc->prepareToPlay (kSampleRate, kBlockSize);
+
+        setParam (*proc, "globalTapAzimuth",   45.0f);
+        setParam (*proc, "globalTapElevation", -30.0f);
+        setParam (*proc, "globalTapDistance",    0.5f);
+        setParam (*proc, "globalTapPitch",     -12.0f);
+        setParam (*proc, "globalTapDoppler",    50.0f);
+        setParam (*proc, "globalTapSpeed",       2.5f);
+
+        proc->getStateInformation (stateData);
+    }
+
+    // Restore on a fresh processor — APVTS params should have the saved values
+    {
+        auto proc = std::make_unique<Proc>();
+        proc->prepareToPlay (kSampleRate, kBlockSize);
+        proc->setStateInformation (stateData.getData(), static_cast<int> (stateData.getSize()));
+
+        REQUIRE (proc->apvts.getRawParameterValue ("globalTapAzimuth")->load()
+                 == Catch::Approx (45.0f).margin (0.2f));
+        REQUIRE (proc->apvts.getRawParameterValue ("globalTapElevation")->load()
+                 == Catch::Approx (-30.0f).margin (0.2f));
+        REQUIRE (proc->apvts.getRawParameterValue ("globalTapDistance")->load()
+                 == Catch::Approx (0.5f).margin (0.02f));
+        REQUIRE (proc->apvts.getRawParameterValue ("globalTapPitch")->load()
+                 == Catch::Approx (-12.0f).margin (1.0f));
+        REQUIRE (proc->apvts.getRawParameterValue ("globalTapDoppler")->load()
+                 == Catch::Approx (50.0f).margin (0.2f));
+        REQUIRE (proc->apvts.getRawParameterValue ("globalTapSpeed")->load()
+                 == Catch::Approx (2.5f).margin (0.02f));
+    }
+}


### PR DESCRIPTION
## Summary

- Global tap drawer knobs (AZIM, ELEV, DIST, PITCH, DOPPLER, SPEED) now persist across UI close/reopen and DAW session save/restore
- Root cause: `onGlobalDelta` callback never wrote absolute knob values to APVTS params, so they were always saved as 0.0
- Preset change paths now zero both atomics and APVTS params via `resetGlobalTapAPVTSParams()`

## Test plan

- [x] New integration test: global tap APVTS params survive state roundtrip
- [x] Full test suite passes (245 cases)
- [x] Manual REAPER test: set non-default drawer knob values → close/reopen UI → values preserved
- [x] v1.0.2 / O102 build confirmed resolved

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)