### PR TITLE
Fix scrub/seek click with transport fade-in (issue #103)

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -2474,6 +2474,11 @@ void OpenSpatialDelayProcessor::prepareToPlay (double sampleRate, int samplesPer
     presetTransitionState = PresetTransitionState::Idle;
     presetTransitionGain = 1.0f;
 
+    // v1.0.6: Transport fade-in — same 5ms ramp for scrub/seek click prevention (issue #103)
+    transportFadeStep = 1.0f / (0.005f * static_cast<float> (sampleRate));
+    transportFadeGain = 1.0f;
+    transportFadeActive = false;
+
     // Initialize modular 3D audio core
     computeAmbiDecodeMatrix();        // Pre-compute 3rd-order decode matrix for virtual speakers
 
@@ -3820,6 +3825,11 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
                         pvPitchShifters[i].reset();
                         dopplerDelayAccum[i] = 0.0f;
                     }
+
+                    // v1.0.6: Mute output and fade back in over 5ms to mask
+                    // delay buffer discontinuity after scrub/seek (issue #103)
+                    transportFadeGain = 0.0f;
+                    transportFadeActive = true;
                 }
 
                 wasPlaying = isPlaying;
@@ -4247,6 +4257,15 @@ void OpenSpatialDelayProcessor::processBlock (juce::AudioBuffer<float>& buffer,
                 tGain = presetTransitionGain;
                 if (presetTransitionGain >= 1.0f)
                     presetTransitionState = PresetTransitionState::Idle;
+            }
+
+            // v1.0.6: Transport fade-in after scrub/seek (issue #103)
+            if (transportFadeActive)
+            {
+                transportFadeGain = std::min (1.0f, transportFadeGain + transportFadeStep);
+                tGain *= transportFadeGain;
+                if (transportFadeGain >= 1.0f)
+                    transportFadeActive = false;
             }
 
             float dw       = perSampleDW[si];

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -919,6 +919,11 @@ private:
     bool wasPlaying = false;
     juce::int64 expectedNextSample = 0;
 
+    // v1.0.6: Transport fade-in — masks delay buffer discontinuity after scrub/seek (issue #103)
+    float transportFadeGain = 1.0f;
+    float transportFadeStep = 0.0f;  // 1/(0.005*sampleRate), set in prepareToPlay
+    bool  transportFadeActive = false;
+
     // v1.0.1: Thread-safe preset reset — loadPreset() (message thread) stores pending
     // state here; processBlock() (audio thread) applies it, eliminating the data race
     // that caused intermittent WSOLA/Doppler corruption on preset changes (issue #42).


### PR DESCRIPTION
## Summary

- Adds a 5ms fade-in envelope to the output stage that activates on transport jump or start, preventing the audible click caused by reading stale delay buffer data at a discontinuous position after scrubbing or seeking.
- Mirrors the existing `PresetTransitionState` fade pattern — same 5ms ramp duration, same multiplication point in the per-sample output loop.
- Stacks correctly with preset transition fades (both multiply into `tGain`).

## Changes

**`PluginProcessor.h`** — 3 new member variables:
- `transportFadeGain` (current envelope value)
- `transportFadeStep` (per-sample increment, set in `prepareToPlay`)
- `transportFadeActive` (whether fade-in is in progress)

**`PluginProcessor.cpp`** — 3 locations:
1. `prepareToPlay()`: Initializes `transportFadeStep = 1/(0.005 * sampleRate)`
2. Transport detection block: On `transportStarted || transportJumped`, sets gain to 0 and activates fade
3. Output stage per-sample loop: Ramps `transportFadeGain` from 0→1, multiplied into `tGain`

## Test plan

- [x] Unit tests pass (252 tests, 249 passed, 1 pre-existing failure, 2 expected failures)
- [x] Built as v1.0.6 / O106 via `build_version.sh`
- [x] Manual REAPER test: scrubbing does not cause click when scrub completes
- [x] Manual REAPER test: jumping around timeline while transport is playing — no pops or clicks
- [x] Confirmed scrubbing does not feed audio into the delay line; only playing transport feeds audio

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)