### PR TITLE
Fix knob text input always clamping to max (issue #119)

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -204,8 +204,16 @@ juce::AudioProcessorValueTreeState::ParameterLayout
             return juce::String (juce::CharPointer_UTF8 ("-\xe2\x88\x9e dB"));
         return juce::String (value, 1) + " dB";
     };
+    auto parseDbInf = [](const juce::String& text) {
+        if (text.containsChar (0x221E) || text.contains ("inf"))  // ∞
+            return -100.0f;
+        return text.getFloatValue();
+    };
     auto fmtPct01 = [](float value, int) {
         return juce::String (juce::roundToInt (value * 100.0f)) + "%";
+    };
+    auto parsePct01 = [](const juce::String& text) {
+        return text.getFloatValue() / 100.0f;
     };
     auto fmtPct100 = [](float value, int) {
         if (value < 10.0f) return juce::String (value, 1) + "%";
@@ -215,6 +223,11 @@ juce::AudioProcessorValueTreeState::ParameterLayout
         if (value >= 1000.0f)
             return juce::String (value / 1000.0f, 1) + " kHz";
         return juce::String (juce::roundToInt (value)) + " Hz";
+    };
+    auto parseFreq = [](const juce::String& text) {
+        if (text.containsIgnoreCase ("kHz") || text.containsIgnoreCase ("khz"))
+            return text.getFloatValue() * 1000.0f;
+        return text.getFloatValue();
     };
     auto fmtDeg = [](float value, int) {
         return juce::String (value, 1) + juce::String::charToString (0x00B0);
@@ -228,12 +241,19 @@ juce::AudioProcessorValueTreeState::ParameterLayout
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("delayTime", 1), "Delay Time",
         juce::NormalisableRange<float> (1.0f, 2000.0f, 0.1f, 0.3f), 500.0f,
-        juce::AudioParameterFloatAttributes().withStringFromValueFunction (
-            [](float value, int) {
-                if (value >= 1000.0f)
-                    return juce::String (value / 1000.0f, 2) + " s";
-                return juce::String (juce::roundToInt (value)) + " ms";
-            })));
+        juce::AudioParameterFloatAttributes()
+            .withStringFromValueFunction (
+                [](float value, int) {
+                    if (value >= 1000.0f)
+                        return juce::String (value / 1000.0f, 2) + " s";
+                    return juce::String (juce::roundToInt (value)) + " ms";
+                })
+            .withValueFromStringFunction (
+                [](const juce::String& text) {
+                    if (text.containsIgnoreCase ("s") && ! text.containsIgnoreCase ("ms"))
+                        return text.getFloatValue() * 1000.0f;
+                    return text.getFloatValue();
+                })));
 
     // G2: Delay Sync (was "Tempo Sync")
     params.push_back (std::make_unique<juce::AudioParameterBool> (
@@ -268,7 +288,9 @@ juce::AudioProcessorValueTreeState::ParameterLayout
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("feedback", 5), "Feedback",
         juce::NormalisableRange<float> (0.0f, 1.0f, 0.01f), 0.3f,
-        juce::AudioParameterFloatAttributes().withLabel ("%").withStringFromValueFunction (fmtPct01)));
+        juce::AudioParameterFloatAttributes().withLabel ("%")
+            .withStringFromValueFunction (fmtPct01)
+            .withValueFromStringFunction (parsePct01)));
 
     // G6: Filter On (was "Filter Enabled" — moved before filter params, enable→configure)
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
@@ -279,7 +301,9 @@ juce::AudioProcessorValueTreeState::ParameterLayout
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("filterHP", 7), "High-Pass Frequency",
         juce::NormalisableRange<float> (20.0f, 5000.0f, 1.0f, 0.3f), 50.0f,
-        juce::AudioParameterFloatAttributes().withStringFromValueFunction (fmtFreq)));
+        juce::AudioParameterFloatAttributes()
+            .withStringFromValueFunction (fmtFreq)
+            .withValueFromStringFunction (parseFreq)));
 
     // G8: High-Pass Resonance (was "HP Resonance")
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
@@ -292,7 +316,9 @@ juce::AudioProcessorValueTreeState::ParameterLayout
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("filterLP", 9), "Low-Pass Frequency",
         juce::NormalisableRange<float> (200.0f, 20000.0f, 1.0f, 0.3f), 5000.0f,
-        juce::AudioParameterFloatAttributes().withStringFromValueFunction (fmtFreq)));
+        juce::AudioParameterFloatAttributes()
+            .withStringFromValueFunction (fmtFreq)
+            .withValueFromStringFunction (parseFreq)));
 
     // G10: Low-Pass Resonance (was "LP Resonance")
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
@@ -305,19 +331,25 @@ juce::AudioProcessorValueTreeState::ParameterLayout
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("dryWet", 11), "Dry/Wet",
         juce::NormalisableRange<float> (0.0f, 1.0f, 0.01f), 0.5f,
-        juce::AudioParameterFloatAttributes().withLabel ("%").withStringFromValueFunction (fmtPct01)));
+        juce::AudioParameterFloatAttributes().withLabel ("%")
+            .withStringFromValueFunction (fmtPct01)
+            .withValueFromStringFunction (parsePct01)));
 
     // G12: Input Gain (-100 dB shown as -∞ to +40 dB)
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("inputGain", 12), "Input Gain",
         juce::NormalisableRange<float> (-100.0f, 40.0f, 0.1f, 3.0f), 0.0f,
-        juce::AudioParameterFloatAttributes().withStringFromValueFunction (fmtDbInf)));
+        juce::AudioParameterFloatAttributes()
+            .withStringFromValueFunction (fmtDbInf)
+            .withValueFromStringFunction (parseDbInf)));
 
     // G13: Output Gain (-100 dB shown as -∞ to +12 dB)
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("outputGain", 13), "Output Gain",
         juce::NormalisableRange<float> (-100.0f, 12.0f, 0.1f, 3.0f), 0.0f,
-        juce::AudioParameterFloatAttributes().withStringFromValueFunction (fmtDbInf)));
+        juce::AudioParameterFloatAttributes()
+            .withStringFromValueFunction (fmtDbInf)
+            .withValueFromStringFunction (parseDbInf)));
 
     // Issue #68: Algorithm, HRTF Profile, Output Format, and Input Format removed from APVTS.
     // They are now stored as raw std::atomic<int> members (configAlgorithm, configHrtfProfile,
@@ -423,7 +455,9 @@ juce::AudioProcessorValueTreeState::ParameterLayout
         params.push_back (std::make_unique<juce::AudioParameterFloat> (
             id ("dopplerAmount", 4), name ("Doppler Amount"),
             juce::NormalisableRange<float> (0.0f, 1.0f, 0.01f), 0.0f,
-            juce::AudioParameterFloatAttributes().withLabel ("%").withStringFromValueFunction (fmtPct01)));
+            juce::AudioParameterFloatAttributes().withLabel ("%")
+                .withStringFromValueFunction (fmtPct01)
+                .withValueFromStringFunction (parsePct01)));
 
         // T7: Tap Pitch Shift
         params.push_back (std::make_unique<juce::AudioParameterFloat> (


### PR DESCRIPTION
## Summary

- Adds `valueFromStringFunction` parsers to all parameters that had custom `stringFromValueFunction` formatters but no inverse, causing typed text input to be misinterpreted by JUCE's default parser.
- **Root cause:** Parameters like Feedback (internal range 0.0–1.0, displayed as 0–100%) used `fmtPct01` to multiply by 100 for display, but typing "50" was parsed as raw 50.0, which clamped to the max of 1.0 (100%).

## Parameters fixed

| Parameter | Issue | Parser added |
|-----------|-------|-------------|
| Feedback, Dry/Wet, per-tap Doppler | Typing any value → 100% | `÷ 100` (inverse of `fmtPct01`) |
| HP/LP Filter Frequency | "5 kHz" → 5 Hz | `kHz` detection → `× 1000` |
| Input/Output Gain | "-∞" not parseable | `∞`/`inf` → `-100.0` dB |
| Delay Time | "1.5 s" → 1.5 ms | `s` (not `ms`) detection → `× 1000` |

## Test plan

- [x] Built as v1.0.3 / O103, AU + VST3 validated
- [ ] Type "50" into Feedback knob → should show 50%, not 100%
- [ ] Type "1" into Feedback → should show 1%
- [ ] Type "5 kHz" into LP filter → should set 5000 Hz
- [ ] Type "-∞" into Output Gain → should set silence

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)