### PR TITLE
Re-sign plugin bundles after plist patching (issue #120)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,8 @@ bash scripts/build_version.sh <commit-hash> v1.0.Z O10Z
 - v1.0.3 / O103 — fix direction toggle for Bounce, Line, Random (issue #100, commit 9dd6266)
 - v1.0.5 / O105 — reset phase vocoder on preset change chirp (issue #99, commit a9df52a)
 - v1.0.6 / O106 — transport fade-in to prevent scrub/seek click (issue #103, commit 7901a0a)
-- Next available: **v1.0.7 / O107**
+- v1.0.9 / O109 — re-sign bundles after plist patching for Ableton VST3 visibility (issue #120)
+- Next available: **v1.0.10 / O110**
 
 ### Running tests
 

--- a/scripts/build_version.sh
+++ b/scripts/build_version.sh
@@ -126,6 +126,19 @@ if [ -f "${VST3_INSTALLED_PLIST}" ]; then
     /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier ${UNIQUE_BUNDLE_ID}" "${VST3_INSTALLED_PLIST}"
 fi
 
+# Step 9c: Re-sign bundles after plist patching (issue #120)
+# Patching Info.plist invalidates the JUCE ad-hoc signature; Ableton rejects unsigned VST3.
+AU_INSTALLED_BUNDLE="$HOME/Library/Audio/Plug-Ins/Components/${PLUGIN_NAME}.component"
+VST3_INSTALLED_BUNDLE="$HOME/Library/Audio/Plug-Ins/VST3/${PLUGIN_NAME}.vst3"
+if [ -d "${AU_INSTALLED_BUNDLE}" ]; then
+    codesign --force --deep --sign - "${AU_INSTALLED_BUNDLE}"
+    echo "  AU re-signed (ad-hoc)"
+fi
+if [ -d "${VST3_INSTALLED_BUNDLE}" ]; then
+    codesign --force --deep --sign - "${VST3_INSTALLED_BUNDLE}"
+    echo "  VST3 re-signed (ad-hoc)"
+fi
+
 # Step 10: Final validation of installed plugins
 echo ""
 echo "=== Validation ==="
@@ -139,7 +152,9 @@ AU_BIN_INSTALLED="${AU_INSTALLED}/Contents/MacOS/${PLUGIN_NAME}"
 if [ -f "${AU_BIN_INSTALLED}" ]; then
     AU_SUB=$(/usr/libexec/PlistBuddy -c "Print :AudioComponents:0:subtype" "${AU_INSTALLED}/Contents/Info.plist" 2>/dev/null)
     AU_ARCH=$(file "${AU_BIN_INSTALLED}" | grep -o 'arm64\|x86_64')
-    echo "  AU:   OK (subtype=${AU_SUB}, arch=${AU_ARCH})"
+    AU_SIGNED="unsigned"
+    if codesign --verify --deep --strict "${AU_INSTALLED}" 2>/dev/null; then AU_SIGNED="signed"; fi
+    echo "  AU:   OK (subtype=${AU_SUB}, arch=${AU_ARCH}, ${AU_SIGNED})"
     if [ "${AU_SUB}" != "${PLUGIN_CODE}" ]; then
         echo "  ERROR: AU subtype '${AU_SUB}' does not match expected '${PLUGIN_CODE}'"
         PASS=false
@@ -153,7 +168,12 @@ fi
 VST3_BIN_INSTALLED="${VST3_INSTALLED}/Contents/MacOS/${PLUGIN_NAME}"
 if [ -f "${VST3_BIN_INSTALLED}" ]; then
     VST3_ARCH=$(file "${VST3_BIN_INSTALLED}" | grep -o 'arm64\|x86_64')
-    echo "  VST3: OK (arch=${VST3_ARCH})"
+    if codesign --verify --deep --strict "${VST3_INSTALLED}" 2>/dev/null; then
+        echo "  VST3: OK (arch=${VST3_ARCH}, signed)"
+    else
+        echo "  VST3: OK (arch=${VST3_ARCH}, UNSIGNED — may not appear in Ableton)"
+        PASS=false
+    fi
 else
     echo "  VST3: FAILED — binary missing"
     PASS=false


### PR DESCRIPTION
## Summary
- Fixes VST3 plugins past v0.9 not appearing in Ableton's browser
- `build_version.sh` step 9b patches `Info.plist` after building, invalidating the JUCE ad-hoc code signature — Ableton silently rejects unsigned VST3 bundles
- Adds step 9c to re-sign both AU and VST3 with `codesign --force --deep --sign -` after plist patching
- Adds `codesign --verify` to validation block so future builds fail if signing is broken

## Test plan
- [x] Built as v1.0.9 / O109 — validation confirms `signed` for both AU and VST3
- [x] VST3 v1.0.9 visible in Ableton's plugin browser and loads successfully

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)