### PR TITLE
Fix negative zero display on global drawer knobs

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1675,6 +1675,11 @@ void GlobalTapDrawerComponent::setupKnob (juce::Slider& s, juce::Label& l,
     s.setSliderStyle (juce::Slider::RotaryVerticalDrag);
     s.setTextBoxStyle (juce::Slider::TextBoxBelow, false, 58, 11);
     s.setRange (min, max, step);
+    s.textFromValueFunction = [&s](double value) {
+        if (value == 0.0) value = 0.0;  // normalize IEEE 754 negative zero
+        int dec = s.getNumDecimalPlacesToDisplay();
+        return dec > 0 ? juce::String (value, dec) : juce::String (juce::roundToInt (value));
+    };
     s.setValue (0.0);
     s.setColour (juce::Slider::thumbColourId, Colours_OSD::accentGlobal);
     s.setColour (juce::Slider::textBoxTextColourId, Colours_OSD::accentGlobalDim);

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1684,6 +1684,7 @@ void GlobalTapDrawerComponent::setupKnob (juce::Slider& s, juce::Label& l,
         return text;
     };
     s.setValue (0.0);
+    s.updateText();  // force text refresh through textFromValueFunction (issue #126)
     s.setColour (juce::Slider::thumbColourId, Colours_OSD::accentGlobal);
     s.setColour (juce::Slider::textBoxTextColourId, Colours_OSD::accentGlobalDim);
     s.setColour (juce::Slider::textBoxOutlineColourId, juce::Colours::transparentBlack);

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1676,9 +1676,12 @@ void GlobalTapDrawerComponent::setupKnob (juce::Slider& s, juce::Label& l,
     s.setTextBoxStyle (juce::Slider::TextBoxBelow, false, 58, 11);
     s.setRange (min, max, step);
     s.textFromValueFunction = [&s](double value) {
-        if (value == 0.0) value = 0.0;  // normalize IEEE 754 negative zero
         int dec = s.getNumDecimalPlacesToDisplay();
-        return dec > 0 ? juce::String (value, dec) : juce::String (juce::roundToInt (value));
+        juce::String text = dec > 0 ? juce::String (value, dec)
+                                     : juce::String (juce::roundToInt (value));
+        if (text[0] == '-' && text.getDoubleValue() == 0.0)
+            return text.substring (1);
+        return text;
     };
     s.setValue (0.0);
     s.setColour (juce::Slider::thumbColourId, Colours_OSD::accentGlobal);


### PR DESCRIPTION
## Summary

Fixes #126 — Global SPEED and DIST knobs displayed "-0.00" at the zero position.

- Add `textFromValueFunction` to all global drawer knobs that strips the minus sign when the formatted text reads as zero
- Call `updateText()` after installing the formatter to fix stale text on first load

## Root cause

Two issues combined:

1. **IEEE 754 negative zero from range snapping:** JUCE's `setRange(-1, 1, 0.01)` internally computes `-1.0 + 0.01 × round(100) = -1.0 + 1.0 = -0.0`. The default string formatter renders this as `"-0.00"`.

2. **Stale text on first load (DIST only):** `setRange()` renders the initial text *before* `textFromValueFunction` is installed. The subsequent `setValue(0.0)` is a no-op because `-0.0 == 0.0` in IEEE 754, so JUCE skips the text update. SPEED didn't have this problem because `setTextValueSuffix(" Hz")` happened to force a text refresh after `setupKnob`.

## Test plan

- [x] Build v1.0.2 — AU + VST3 compile clean
- [x] Existing test suite passes (255 cases, 252 passed, 1 pre-existing failure, 2 expected failures)
- [x] SPEED knob shows "0.00 Hz" at zero on first load
- [x] DIST knob shows "0.00" at zero on first load
- [x] Both knobs display correctly after adjust-and-reset
- [x] Tested in REAPER (AU and VST3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)