### PR TITLE
Unify global knob text input styling (issue #128)

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1672,14 +1672,10 @@ void GlobalTapDrawerComponent::setupKnob (juce::Slider& s, juce::Label& l,
                                            const juce::String& name,
                                            float min, float max, float step, int knobIdx)
 {
-    s.setSliderStyle (juce::Slider::RotaryVerticalDrag);
-    s.setTextBoxStyle (juce::Slider::TextBoxBelow, false, 58, 11);
+    styleSlider (s, lookAndFeel);
     s.setRange (min, max, step);
     s.setValue (0.0);
     s.setColour (juce::Slider::thumbColourId, Colours_OSD::accentGlobal);
-    s.setColour (juce::Slider::textBoxTextColourId, Colours_OSD::accentGlobalDim);
-    s.setColour (juce::Slider::textBoxOutlineColourId, juce::Colours::transparentBlack);
-    s.setColour (juce::Slider::textBoxBackgroundColourId, juce::Colours::transparentBlack);
     s.setDoubleClickReturnValue (true, 0.0);
     knobPanel.addAndMakeVisible (s);  // add to knobPanel, not directly to drawer
 
@@ -1847,7 +1843,7 @@ void GlobalTapDrawerComponent::layoutKnobs()
 {
     // Layout knobs inside the knobPanel (always at full panel size)
     int knobSize = 38;
-    int textBoxH = 11;
+    int textBoxH = 12;
     int labelH = 12;
     int dividerGap = 10;
     int totalH = knobPanel.getHeight();


### PR DESCRIPTION
## Summary
- Refactored `GlobalTapDrawerComponent::setupKnob()` to delegate to shared `styleSlider()`, fixing text color, dimensions, LookAndFeel, and keyboard focus to match all other knobs
- Updated `layoutKnobs()` text box height (11→12) to match new dimensions
- Silver/ice knob arc color and label color preserved

Closes #128

## Test plan
- [x] All 252 tests pass (1 pre-existing flaky failure unrelated)
- [x] Versioned build: `OpenSpatialDelay v1.0.4` (O104)
- [ ] Visual check: global knob text inputs match per-tap knob text inputs in color and size
- [ ] Functional check: global knobs apply delta offsets, azimuth wraps, double-click resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)