### PR TITLE
Fix Ableton automation + crash + AU compatibility (issue #122)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,8 @@ bash scripts/build_version.sh <commit-hash> v1.0.Z O10Z
 - v1.0.6 / O106 — transport fade-in to prevent scrub/seek click (issue #103, commit 7901a0a)
 - v1.0.8 / O108 — fix Ableton crash + automation reset (issue #122, commit 0d3cc53)
 - v1.0.9 / O109 — re-sign bundles after plist patching for Ableton VST3 visibility (issue #120)
-- Next available: **v1.0.10 / O110**
+- v1.0.10 / O110 — reduce automatable params to 64 for Ableton auto-populate (issue #122, commit 99543ac)
+- Next available: **v1.0.11 / O111**
 
 ### Running tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ bash scripts/build_version.sh <commit-hash> v1.0.Z O10Z
 - v1.0.6 / O106 — transport fade-in to prevent scrub/seek click (issue #103, commit 7901a0a)
 - v1.0.8 / O108 — fix Ableton crash + automation reset (issue #122, commit 0d3cc53)
 - v1.0.9 / O109 — re-sign bundles after plist patching for Ableton VST3 visibility (issue #120)
-- v1.0.10 / O110 — reduce automatable params to 64 for Ableton auto-populate (issue #122, commit 99543ac)
+- v1.0.10 / O110 — reduce automatable params to 64 for Ableton auto-populate (issue #122, commit 4adfd1d)
 - Next available: **v1.0.11 / O111**
 
 ### Running tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,8 @@ bash scripts/build_version.sh <commit-hash> v1.0.Z O10Z
 - v1.0.3 / O103 — fix direction toggle for Bounce, Line, Random (issue #100, commit 9dd6266)
 - v1.0.5 / O105 — reset phase vocoder on preset change chirp (issue #99, commit a9df52a)
 - v1.0.6 / O106 — transport fade-in to prevent scrub/seek click (issue #103, commit 7901a0a)
-- Next available: **v1.0.7 / O107**
+- v1.0.8 / O108 — fix Ableton crash + automation reset (issue #122, commit 0d3cc53)
+- Next available: **v1.0.9 / O109**
 
 ### Running tests
 

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -2045,7 +2045,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         {
             int paramIdx = selectedId - 1;  // IDs are 1-based, param indices are 0-based
             processorRef.configAlgorithm.store (paramIdx, std::memory_order_relaxed);
-            processorRef.updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withNonParameterStateChanged (true));
+            processorRef.markConfigStateDirty();
         }
     };
     {
@@ -2060,7 +2060,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
                                              juce::dontSendNotification);
         hrtfProfileBox.onChange = [this] {
             processorRef.configHrtfProfile.store (hrtfProfileBox.getSelectedItemIndex(), std::memory_order_relaxed);
-            processorRef.updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withNonParameterStateChanged (true));
+            processorRef.markConfigStateDirty();
         };
     }
     // v0.7: syncMode reworked to 3-state (Straight/Dotted/Triplet)
@@ -2086,7 +2086,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
                                               juce::dontSendNotification);
         outputFormatBox.onChange = [this] {
             processorRef.configOutputFormat.store (outputFormatBox.getSelectedItemIndex(), std::memory_order_relaxed);
-            processorRef.updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withNonParameterStateChanged (true));
+            processorRef.markConfigStateDirty();
         };
     }
 
@@ -2501,7 +2501,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
                                         juce::dontSendNotification);
     inputFormatBox.onChange = [this] {
         processorRef.configInputFormat.store (inputFormatBox.getSelectedItemIndex(), std::memory_order_relaxed);
-        processorRef.updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withNonParameterStateChanged (true));
+        processorRef.markConfigStateDirty();
     };
 
     // Header dropdown labels: JetBrains Mono Medium 7.5px, wide kerning
@@ -3119,13 +3119,13 @@ void OpenSpatialDelayEditor::timerCallback()
         {
             algoIdx = 6;  // Equal Power
             processorRef.configAlgorithm.store (algoIdx, std::memory_order_relaxed);
-            processorRef.updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withNonParameterStateChanged (true));
+            processorRef.markConfigStateDirty();
         }
         else if (! isStereoVariant && algoIdx > 5)
         {
             algoIdx = 4;  // VBAP
             processorRef.configAlgorithm.store (algoIdx, std::memory_order_relaxed);
-            processorRef.updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withNonParameterStateChanged (true));
+            processorRef.markConfigStateDirty();
         }
 
         // Sync combo selection from parameter (IDs are param index + 1)

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -255,9 +255,10 @@ juce::AudioProcessorValueTreeState::ParameterLayout
                     return text.getFloatValue();
                 })));
 
-    // G2: Delay Sync (was "Tempo Sync")
+    // G2: Delay Sync (was "Tempo Sync")  [non-automatable: toggle state, issue #122]
     params.push_back (std::make_unique<juce::AudioParameterBool> (
-        juce::ParameterID ("tempoSync", 2), "Delay Sync", false));
+        juce::ParameterID ("tempoSync", 2), "Delay Sync", false,
+        juce::AudioParameterBoolAttributes().withAutomatable (false)));
 
     // G3: Delay Division (was "Note Division")
     // Value = number of 16th notes. Range: 0.5 (1/32) to 32 (2/1)
@@ -279,10 +280,11 @@ juce::AudioProcessorValueTreeState::ParameterLayout
                 return juce::String (sixteenths, 1) + "/16";
             })));
 
-    // G4: Sync Mode
+    // G4: Sync Mode  [non-automatable: state selector, issue #122]
     params.push_back (std::make_unique<juce::AudioParameterChoice> (
         juce::ParameterID ("syncMode", 4), "Sync Mode",
-        juce::StringArray { "Straight", "Dotted", "Triplet" }, 0));
+        juce::StringArray { "Straight", "Dotted", "Triplet" }, 0,
+        juce::AudioParameterChoiceAttributes().withAutomatable (false)));
 
     // G5: Feedback
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
@@ -293,9 +295,11 @@ juce::AudioProcessorValueTreeState::ParameterLayout
             .withValueFromStringFunction (parsePct01)));
 
     // G6: Filter On (was "Filter Enabled" — moved before filter params, enable→configure)
+    // [non-automatable: toggle state, issue #122]
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("filterEnabled", 6), "Filter On",
-        juce::NormalisableRange<float> (0.0f, 1.0f, 1.0f), 0.0f));
+        juce::NormalisableRange<float> (0.0f, 1.0f, 1.0f), 0.0f,
+        juce::AudioParameterFloatAttributes().withAutomatable (false)));
 
     // G7: High-Pass Frequency (was "High-Pass Filter" — HP grouped before LP)
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
@@ -305,11 +309,11 @@ juce::AudioProcessorValueTreeState::ParameterLayout
             .withStringFromValueFunction (fmtFreq)
             .withValueFromStringFunction (parseFreq)));
 
-    // G8: High-Pass Resonance (was "HP Resonance")
+    // G8: High-Pass Resonance (was "HP Resonance")  [non-automatable: issue #122]
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("filterHPQ", 8), "High-Pass Resonance",
         juce::NormalisableRange<float> (0.5f, 8.0f, 0.01f, 0.4f), 0.707f,
-        juce::AudioParameterFloatAttributes().withStringFromValueFunction (
+        juce::AudioParameterFloatAttributes().withAutomatable (false).withStringFromValueFunction (
             [](float value, int) { return juce::String (value, 2); })));
 
     // G9: Low-Pass Frequency (was "Low-Pass Filter")
@@ -320,11 +324,11 @@ juce::AudioProcessorValueTreeState::ParameterLayout
             .withStringFromValueFunction (fmtFreq)
             .withValueFromStringFunction (parseFreq)));
 
-    // G10: Low-Pass Resonance (was "LP Resonance")
+    // G10: Low-Pass Resonance (was "LP Resonance")  [non-automatable: issue #122]
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("filterLPQ", 10), "Low-Pass Resonance",
         juce::NormalisableRange<float> (0.5f, 8.0f, 0.01f, 0.4f), 0.707f,
-        juce::AudioParameterFloatAttributes().withStringFromValueFunction (
+        juce::AudioParameterFloatAttributes().withAutomatable (false).withStringFromValueFunction (
             [](float value, int) { return juce::String (value, 2); })));
 
     // G11: Dry/Wet
@@ -355,13 +359,16 @@ juce::AudioProcessorValueTreeState::ParameterLayout
     // They are now stored as raw std::atomic<int> members (configAlgorithm, configHrtfProfile,
     // configOutputFormat, configInputFormat) to hide them from DAW automation lists.
 
-    // G14: Air Absorption
+    // G14: Air Absorption  [non-automatable: toggle state, issue #122]
     params.push_back (std::make_unique<juce::AudioParameterBool> (
-        juce::ParameterID ("airAbsorption", 14), "Air Absorption", false));
+        juce::ParameterID ("airAbsorption", 14), "Air Absorption", false,
+        juce::AudioParameterBoolAttributes().withAutomatable (false)));
 
     // G15: Wobble On (was "Wobble Enabled" — moved before wobble params, enable→configure)
+    // [non-automatable: toggle state, issue #122]
     params.push_back (std::make_unique<juce::AudioParameterBool> (
-        juce::ParameterID ("wobbleEnabled", 15), "Wobble On", false));
+        juce::ParameterID ("wobbleEnabled", 15), "Wobble On", false,
+        juce::AudioParameterBoolAttributes().withAutomatable (false)));
 
     // G16: Wobble Amount
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
@@ -376,8 +383,10 @@ juce::AudioProcessorValueTreeState::ParameterLayout
         juce::AudioParameterFloatAttributes().withLabel ("%").withStringFromValueFunction (fmtPct100)));
 
     // G18: OSC Receive (true=enabled, false=disabled; default OFF)
+    // [non-automatable: never automated, issue #122]
     params.push_back (std::make_unique<juce::AudioParameterBool> (
-        juce::ParameterID ("admOscEnabled", 18), "OSC Receive", false));
+        juce::ParameterID ("admOscEnabled", 18), "OSC Receive", false,
+        juce::AudioParameterBoolAttributes().withAutomatable (false)));
 
     // G19–G24: Global Tap Offsets (promoted from OSC-only atomics to APVTS)
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
@@ -428,9 +437,10 @@ juce::AudioProcessorValueTreeState::ParameterLayout
         // Initial spatial spread is applied in constructor after APVTS creation.
         float defaultAz = 0.0f;
 
-        // T1: Tap On (was "Object N Enabled")
+        // T1: Tap On (was "Object N Enabled")  [non-automatable: toggle state, issue #122]
         params.push_back (std::make_unique<juce::AudioParameterBool> (
-            id ("enabled", 0), name ("On"), defaultEnabled));
+            id ("enabled", 0), name ("On"), defaultEnabled,
+            juce::AudioParameterBoolAttributes().withAutomatable (false)));
 
         // T2: Per-tap Time — REMOVED (orphaned param, issue #68)
 
@@ -451,11 +461,11 @@ juce::AudioProcessorValueTreeState::ParameterLayout
             id ("distance", 3), name ("Distance"),
             juce::NormalisableRange<float> (0.0f, 1.0f, 0.01f), 0.5f));
 
-        // T6: Tap Doppler Amount
+        // T6: Tap Doppler Amount  [non-automatable: issue #122]
         params.push_back (std::make_unique<juce::AudioParameterFloat> (
             id ("dopplerAmount", 4), name ("Doppler Amount"),
             juce::NormalisableRange<float> (0.0f, 1.0f, 0.01f), 0.0f,
-            juce::AudioParameterFloatAttributes().withLabel ("%")
+            juce::AudioParameterFloatAttributes().withAutomatable (false).withLabel ("%")
                 .withStringFromValueFunction (fmtPct01)
                 .withValueFromStringFunction (parsePct01)));
 
@@ -466,28 +476,31 @@ juce::AudioProcessorValueTreeState::ParameterLayout
             juce::AudioParameterFloatAttributes().withStringFromValueFunction (
                 [](float value, int) { return juce::String (juce::roundToInt (value)) + " st"; })));
 
-        // T8: Tap Trajectory Shape
+        // T8: Tap Trajectory Shape  [non-automatable: state selector, issue #122]
         params.push_back (std::make_unique<juce::AudioParameterChoice> (
             id ("trajectoryShape", 6), name ("Trajectory Shape"),
             juce::StringArray { "None", "Bounce", "Circle", "Cross", "Figure-8", "Heart", "Helix",
-                                "Infinity", "Line", "Orbit", "Random", "Spiral", "Square", "Triangle" }, 0));
+                                "Infinity", "Line", "Orbit", "Random", "Spiral", "Square", "Triangle" }, 0,
+            juce::AudioParameterChoiceAttributes().withAutomatable (false)));
 
-        // T9: Tap Trajectory Speed
+        // T9: Tap Trajectory Speed  [non-automatable: issue #122]
         params.push_back (std::make_unique<juce::AudioParameterFloat> (
             id ("trajectorySpeed", 7), name ("Trajectory Speed"),
             juce::NormalisableRange<float> (0.0f, 5.0f, 0.01f), 0.3f,
-            juce::AudioParameterFloatAttributes().withLabel ("Hz").withStringFromValueFunction (
+            juce::AudioParameterFloatAttributes().withAutomatable (false).withLabel ("Hz").withStringFromValueFunction (
                 [](float value, int) { return juce::String (value, 2) + " Hz"; })));
 
-        // T10: Tap Trajectory Direction
+        // T10: Tap Trajectory Direction  [non-automatable: state toggle, issue #122]
         params.push_back (std::make_unique<juce::AudioParameterChoice> (
             id ("trajectoryDirection", 8), name ("Trajectory Direction"),
-            juce::StringArray { "Forward", "Reverse" }, 0));
+            juce::StringArray { "Forward", "Reverse" }, 0,
+            juce::AudioParameterChoiceAttributes().withAutomatable (false)));
 
-        // T11: Tap Input Channel
+        // T11: Tap Input Channel  [non-automatable: state selector, issue #122]
         params.push_back (std::make_unique<juce::AudioParameterChoice> (
             id ("inputChannel", 9), name ("Input Channel"),
-            juce::StringArray { "L+R", "L", "R" }, 0));
+            juce::StringArray { "L+R", "L", "R" }, 0,
+            juce::AudioParameterChoiceAttributes().withAutomatable (false)));
     }
 
     return { params.begin(), params.end() };

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -2059,16 +2059,37 @@ void OpenSpatialDelayProcessor::rebuildCategorizedOrder()
 //==============================================================================
 bool OpenSpatialDelayProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
 {
-    // v1.0.3: Accept any layout the host proposes (issue #111).
-    // This is the IEM Plugin Suite / SPARTA approach for multichannel VST3 support.
-    // VST3 hosts (REAPER, Cubase) use the channel count from getBusInfo() to allocate
-    // channels, then call setBusArrangements() with host-chosen arrangements that may
-    // not match our predefined set. Accepting everything lets the host provide whatever
-    // channel count the track supports. Output format selection and channel routing are
-    // handled internally via resolveEffectiveFormat() and the output format dropdown.
-    // processBlock only reads input channels 0-1 regardless of bus width.
-    juce::ignoreUnused (layouts);
-    return true;
+    // Input can be mono or stereo (stereo will be summed to mono internally)
+    auto inputSet = layouts.getMainInputChannelSet();
+    if (inputSet != juce::AudioChannelSet::mono() &&
+        inputSet != juce::AudioChannelSet::stereo())
+    {
+        // VST3 symmetric layout support (issue #111): REAPER/Cubase require
+        // input == output channel counts for VST3 bus negotiation. Accept
+        // multichannel input when it matches the output set — extra input
+        // channels are ignored in processBlock (only channels 0-1 are read).
+        if (inputSet != layouts.getMainOutputChannelSet())
+            return false;
+    }
+
+    // v0.2: Stable set of output bus layouts. DO NOT ADD NEW ENTRIES HERE.
+    // Adding entries causes DAWs to renegotiate bus layouts during playback,
+    // which triggers prepareToPlay() mid-session and zeros the delay buffer.
+    // See docs/BUS_LAYOUT_BUG.md for full explanation.
+    //
+    // New output formats (5.0, 7.0, 5.1.2, Ambisonics, etc.) are handled
+    // INTERNALLY via the output format dropdown — they render to whatever
+    // channels the bus provides without needing DAW-level bus support.
+    auto outputSet = layouts.getMainOutputChannelSet();
+    if (outputSet == juce::AudioChannelSet::stereo())              return true;
+    if (outputSet == juce::AudioChannelSet::quadraphonic())        return true;
+    if (outputSet == juce::AudioChannelSet::create5point1())       return true;
+    if (outputSet == juce::AudioChannelSet::create7point1())       return true;
+    if (outputSet == juce::AudioChannelSet::create7point1point4()) return true;
+    if (outputSet == juce::AudioChannelSet::create9point1point6()) return true;
+    if (outputSet == juce::AudioChannelSet::octagonal())           return true;
+    if (outputSet == juce::AudioChannelSet::discreteChannels (50)) return true;
+    return false;
 }
 
 //==============================================================================

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -309,11 +309,11 @@ juce::AudioProcessorValueTreeState::ParameterLayout
             .withStringFromValueFunction (fmtFreq)
             .withValueFromStringFunction (parseFreq)));
 
-    // G8: High-Pass Resonance (was "HP Resonance")  [non-automatable: issue #122]
+    // G8: High-Pass Resonance (was "HP Resonance")
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("filterHPQ", 8), "High-Pass Resonance",
         juce::NormalisableRange<float> (0.5f, 8.0f, 0.01f, 0.4f), 0.707f,
-        juce::AudioParameterFloatAttributes().withAutomatable (false).withStringFromValueFunction (
+        juce::AudioParameterFloatAttributes().withStringFromValueFunction (
             [](float value, int) { return juce::String (value, 2); })));
 
     // G9: Low-Pass Frequency (was "Low-Pass Filter")
@@ -324,11 +324,11 @@ juce::AudioProcessorValueTreeState::ParameterLayout
             .withStringFromValueFunction (fmtFreq)
             .withValueFromStringFunction (parseFreq)));
 
-    // G10: Low-Pass Resonance (was "LP Resonance")  [non-automatable: issue #122]
+    // G10: Low-Pass Resonance (was "LP Resonance")
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("filterLPQ", 10), "Low-Pass Resonance",
         juce::NormalisableRange<float> (0.5f, 8.0f, 0.01f, 0.4f), 0.707f,
-        juce::AudioParameterFloatAttributes().withAutomatable (false).withStringFromValueFunction (
+        juce::AudioParameterFloatAttributes().withStringFromValueFunction (
             [](float value, int) { return juce::String (value, 2); })));
 
     // G11: Dry/Wet
@@ -412,12 +412,12 @@ juce::AudioProcessorValueTreeState::ParameterLayout
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("globalTapDoppler", 23), "Global Tap Doppler",
         juce::NormalisableRange<float> (-100.0f, 100.0f, 0.1f), 0.0f,
-        juce::AudioParameterFloatAttributes().withLabel ("%").withStringFromValueFunction (fmtPct100)));
+        juce::AudioParameterFloatAttributes().withAutomatable (false).withLabel ("%").withStringFromValueFunction (fmtPct100)));
 
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("globalTapSpeed", 24), "Global Tap Speed",
         juce::NormalisableRange<float> (-5.0f, 5.0f, 0.01f), 0.0f,
-        juce::AudioParameterFloatAttributes().withLabel ("Hz").withStringFromValueFunction (
+        juce::AudioParameterFloatAttributes().withAutomatable (false).withLabel ("Hz").withStringFromValueFunction (
             [](float value, int) { return juce::String (value, 2) + " Hz"; })));
 
     // --- Per-tap parameters (issue #68: "Object N" → "Tap 0N") ---------------

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1468,6 +1468,10 @@ void OpenSpatialDelayProcessor::timerCallback()
         }
     }
 
+    // Issue #122: Debounced updateHostDisplay — at most once per 60Hz tick
+    // instead of on every UI dropdown / OSC config change (fixes Ableton automation reset)
+    if (configStateDirty.exchange (false, std::memory_order_relaxed))
+        updateHostDisplay (ChangeDetails().withNonParameterStateChanged (true));
 }
 
 // #############################################################################
@@ -1574,6 +1578,10 @@ OpenSpatialDelayProcessor::OpenSpatialDelayProcessor()
 
 OpenSpatialDelayProcessor::~OpenSpatialDelayProcessor()
 {
+    // Issue #122: Stop 60Hz timer before any member destruction to prevent
+    // use-after-free in timerCallback() during plugin deletion
+    stopTimer();
+
     // v0.6: Disconnect OSC receiver before destruction
     oscReceiver.disconnect();
     oscReceiver.removeListener (this);
@@ -2540,6 +2548,9 @@ void OpenSpatialDelayProcessor::prepareToPlay (double sampleRate, int samplesPer
 
 void OpenSpatialDelayProcessor::releaseResources()
 {
+    // Issue #122: Stop timer early — DAW calls this before destruction
+    stopTimer();
+
     delayBufferL.clear();
     delayBufferR.clear();
     monoInputBuffer.clear();
@@ -5108,9 +5119,9 @@ void OpenSpatialDelayProcessor::oscMessageReceived (const juce::OSCMessage& mess
         else if (property == "/drywet")        handleOSCParam ("dryWet", val);
         else if (property == "/inputgain")     handleOSCParam ("inputGain", val);
         else if (property == "/outputgain")    handleOSCParam ("outputGain", val);
-        else if (property == "/algorithm")    { configAlgorithm.store (juce::roundToInt (val), std::memory_order_relaxed); updateHostDisplay (ChangeDetails().withNonParameterStateChanged (true)); }
-        else if (property == "/hrtfprofile")  { configHrtfProfile.store (juce::roundToInt (val), std::memory_order_relaxed); updateHostDisplay (ChangeDetails().withNonParameterStateChanged (true)); }
-        else if (property == "/outputformat") { configOutputFormat.store (juce::roundToInt (val), std::memory_order_relaxed); updateHostDisplay (ChangeDetails().withNonParameterStateChanged (true)); }
+        else if (property == "/algorithm")    { configAlgorithm.store (juce::roundToInt (val), std::memory_order_relaxed); markConfigStateDirty(); }
+        else if (property == "/hrtfprofile")  { configHrtfProfile.store (juce::roundToInt (val), std::memory_order_relaxed); markConfigStateDirty(); }
+        else if (property == "/outputformat") { configOutputFormat.store (juce::roundToInt (val), std::memory_order_relaxed); markConfigStateDirty(); }
         else if (property == "/air")           handleOSCParam ("airAbsorption", val);
         else if (property == "/wobble")        handleOSCParam ("wobbleEnabled", val);
         else if (property == "/wobbleamount")  handleOSCParam ("wobbleAmount", val);

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -652,6 +652,10 @@ public:
     std::atomic<int> configOutputFormat { 0 };
     std::atomic<int> configInputFormat { 0 };
 
+    // Issue #122: Debounce updateHostDisplay — set by editor/OSC, flushed in timerCallback
+    std::atomic<bool> configStateDirty { false };
+    void markConfigStateDirty() { configStateDirty.store (true, std::memory_order_relaxed); }
+
     // v0.7: OSC Send accessors for editor
     bool isOscSendConnected() const { return oscSendConnected; }
     bool getOscSendEnabled() const { return oscSendEnabled; }

--- a/Tests/ParameterCountTests.cpp
+++ b/Tests/ParameterCountTests.cpp
@@ -21,7 +21,9 @@ TEST_CASE ("All parameters have non-empty names", "[params]")
     }
 }
 
-TEST_CASE ("144 automatable + 0 non-automatable", "[params]")
+// Issue #122: 80 params marked non-automatable to stay within Ableton's 64-param
+// auto-populate threshold. Automatable: 16 global + 4 per-tap × 12 = 64.
+TEST_CASE ("64 automatable + 80 non-automatable", "[params]")
 {
     auto proc = std::make_unique<OpenSpatialDelayProcessor>();
     int automatable = 0, nonAutomatable = 0;
@@ -32,8 +34,8 @@ TEST_CASE ("144 automatable + 0 non-automatable", "[params]")
         else
             ++nonAutomatable;
     }
-    CHECK (automatable == 144);
-    CHECK (nonAutomatable == 0);
+    CHECK (automatable == 64);
+    CHECK (nonAutomatable == 80);
 }
 
 TEST_CASE ("Global params appear before per-tap params", "[params]")

--- a/scripts/build_version.sh
+++ b/scripts/build_version.sh
@@ -33,6 +33,19 @@ cd "${BUILD_DIR}"
 git checkout "${COMMIT}" -- . 2>/dev/null
 git submodule update --init --recursive 2>/dev/null
 
+# Issue #122: Patch JUCE VST3 wrapper — guard restartComponent against flags=0
+# to prevent Ableton from resetting its Configure parameter state.
+VST3_WRAPPER="JUCE/modules/juce_audio_plugin_client/juce_audio_plugin_client_VST3.cpp"
+if grep -q 'if (auto\* handler = componentHandler.get())' "${VST3_WRAPPER}" 2>/dev/null; then
+    sed -i '' '/flags &= ~pluginShouldBeMarkedDirtyFlag;/{
+N
+s/\n.*if (auto\* handler = componentHandler.get())/\
+\
+        if (flags != 0)\
+            if (auto* handler = componentHandler.get())/
+}' "${VST3_WRAPPER}"
+fi
+
 # Step 2: Patch CMakeLists.txt with version-specific name, plugin code, and bundle ID
 sed -i '' "s/PLUGIN_CODE Os10/PLUGIN_CODE ${PLUGIN_CODE}/" CMakeLists.txt
 sed -i '' "s/PRODUCT_NAME \"OpenSpatialDelay v1.0\"/PRODUCT_NAME \"${PLUGIN_NAME}\"/" CMakeLists.txt

--- a/scripts/build_version.sh
+++ b/scripts/build_version.sh
@@ -35,15 +35,10 @@ git submodule update --init --recursive 2>/dev/null
 
 # Issue #122: Patch JUCE VST3 wrapper — guard restartComponent against flags=0
 # to prevent Ableton from resetting its Configure parameter state.
+# The JUCE source uses \r\n line endings, so use perl for reliable matching.
 VST3_WRAPPER="JUCE/modules/juce_audio_plugin_client/juce_audio_plugin_client_VST3.cpp"
-if grep -q 'if (auto\* handler = componentHandler.get())' "${VST3_WRAPPER}" 2>/dev/null; then
-    sed -i '' '/flags &= ~pluginShouldBeMarkedDirtyFlag;/{
-N
-s/\n.*if (auto\* handler = componentHandler.get())/\
-\
-        if (flags != 0)\
-            if (auto* handler = componentHandler.get())/
-}' "${VST3_WRAPPER}"
+if grep -q 'handler->restartComponent (flags)' "${VST3_WRAPPER}" 2>/dev/null; then
+    perl -i -p0e 's/(flags &= ~pluginShouldBeMarkedDirtyFlag;\r?\n\r?\n)\s*(if \(auto\* handler = componentHandler\.get\(\)\)\r?\n\s*handler->restartComponent \(flags\);)/$1        if (flags != 0)\r\n            if (auto* handler = componentHandler.get())\r\n                handler->restartComponent (flags);/s' "${VST3_WRAPPER}"
 fi
 
 # Step 2: Patch CMakeLists.txt with version-specific name, plugin code, and bundle ID


### PR DESCRIPTION
## Summary

- **Fix crash on plugin deletion**: add `stopTimer()` to destructor and `releaseResources()` to prevent use-after-free from the 60Hz timer callback
- **Fix Ableton automation**: reduce automatable params from 144 → 64 via `withAutomatable(false)` to stay within Ableton's auto-populate threshold
- **Fix AU Ableton compatibility**: restore explicit bus layouts (stereo, quad, 5.1, 7.1, etc.) — the blanket `return true` from issue #111 caused AU to report wildcard channels that Ableton can't negotiate
- **Guard `restartComponent(0)`**: patch JUCE VST3 wrapper via build script to prevent Ableton from resetting its Configure state

### Automatable parameters (64)

**Global (16):** Delay Time, Division, Feedback, HP/LP Frequency, HP/LP Resonance, Dry/Wet, Input/Output Gain, Wobble Amount/Morph, Global Tap Az/El/Dist/Pitch

**Per-tap × 12 (48):** Azimuth, Elevation, Distance, Pitch Shift

### Non-automatable (80)

**Global (8):** Delay Sync, Sync Mode, Filter On, Air Absorption, Wobble On, OSC Receive, Global Tap Doppler, Global Tap Speed

**Per-tap × 12 (72):** On, Doppler, Trajectory Shape/Speed/Direction, Input Channel

## Test plan

- [x] 252 unit tests pass (pre-existing failures unchanged)
- [x] Parameter count test: 64 automatable + 80 non-automatable = 144 total
- [x] VST3 loads in Ableton 12.3.6 — all 64 params auto-populate
- [x] AU loads in Ableton 12.3.6 — compatible audio format
- [x] Plugin deletion in Ableton — no crash
- [x] REAPER shows all 144 parameters

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)