### PR TITLE
Fix onset detection + great-circle threshold for HRTF profiles (issue #89)

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -604,7 +604,9 @@ void HRTFDatabase::getAlignedHRIR (float azimuthRad, float elevationRad,
     // likely CIPIC/HUTUBS/Bernschuetz). Detect onset from the waveform
     // itself so the dual-slot crossfade blends time-aligned HRIRs.
     // SADIE II KU100 reports non-zero delays and bypasses this fallback.
-    if (shiftL == 0 && shiftR == 0)
+    // NOTE: Check raw float delays, not integer-truncated — SADIE reports
+    // fractional delays (e.g., 0.3/0.7) that truncate to int 0 but are valid.
+    if (delayL < 0.001f && delayR < 0.001f)
     {
         int onsetL = detectOnset (irL, irLength, 0.1f);
         int onsetR = detectOnset (irR, irLength, 0.1f);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -599,6 +599,23 @@ void HRTFDatabase::getAlignedHRIR (float azimuthRad, float elevationRad,
     int shiftL = static_cast<int> (delayL);
     int shiftR = static_cast<int> (delayR);
 
+    // v1.0.11 (issue #89): If SOFA reports zero delay for both channels,
+    // the ITD is baked into the HRIR waveform (confirmed for MIT KEMAR,
+    // likely CIPIC/HUTUBS/Bernschuetz). Detect onset from the waveform
+    // itself so the dual-slot crossfade blends time-aligned HRIRs.
+    // SADIE II KU100 reports non-zero delays and bypasses this fallback.
+    if (shiftL == 0 && shiftR == 0)
+    {
+        int onsetL = detectOnset (irL, irLength, 0.1f);
+        int onsetR = detectOnset (irR, irLength, 0.1f);
+        int minOnset = std::min (onsetL, onsetR);
+        shiftL = onsetL - minOnset;
+        shiftR = onsetR - minOnset;
+        // Report detected ITD for the ITD delay line in renderSourceBuffers()
+        delayL = static_cast<float> (onsetL);
+        delayR = static_cast<float> (onsetR);
+    }
+
     // Shift left channel: move samples backward by shiftL
     if (shiftL > 0 && shiftL < irLength)
     {
@@ -692,6 +709,39 @@ void HRTFDatabase::convertToMinPhase (float* ir, int irLength, int fftOrder, flo
     // Step 9: Copy first irLength samples back (real part only)
     for (int i = 0; i < irLength; ++i)
         ir[i] = cBuf[i].real();
+}
+
+int HRTFDatabase::detectOnset (const float* ir, int length, float thresholdFraction)
+{
+    if (ir == nullptr || length <= 0)
+        return 0;
+
+    // Find peak absolute value
+    float peak = 0.0f;
+    for (int i = 0; i < length; ++i)
+    {
+        float absVal = std::abs (ir[i]);
+        if (absVal > peak)
+            peak = absVal;
+    }
+
+    if (peak < 1e-20f)
+        return 0;  // Silent IR
+
+    // Scan forward for first sample exceeding threshold * peak
+    float thresh = thresholdFraction * peak;
+    for (int i = 0; i < length; ++i)
+    {
+        if (std::abs (ir[i]) >= thresh)
+        {
+            // Clamp: if onset is past halfway, IR has no clear leading edge
+            if (i > length / 2)
+                return 0;
+            return i;
+        }
+    }
+
+    return 0;
 }
 
 //==============================================================================

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1130,13 +1130,24 @@ void BinauralRenderer::updateSourceHRIR (int sourceIndex, float azRad, float elR
     if (sourceIndex < 0 || sourceIndex >= MAX_SOURCES || storedIRLength <= 0)
         return;
 
-    // v1.0.2: ~1° threshold (reduced from ~2°) — more frequent, smaller HRIR changes
-    // produce less audible spectral transitions during azimuth/elevation sweeps (issue #47)
+    // v1.0.11 (issue #89): Great-circle angular distance threshold replaces independent
+    // azimuth/elevation comparison. The old check treated 1° of azimuth equally at equator
+    // and pole, but at elevation 89° a 1° azimuth change is only ~0.017° of actual angular
+    // movement on the sphere. This caused constant HRIR switching at poles (zenith stuck
+    // centered, erratic nadir jumps). Great-circle distance naturally handles the pole
+    // singularity — azimuth changes near ±90° elevation produce near-zero angular distance.
     constexpr float THRESHOLD = 0.017f;  // ~1 degree in radians
-    if (sourceConvReady[sourceIndex]
-        && std::abs (azRad - cachedSourceAz[sourceIndex]) < THRESHOLD
-        && std::abs (elRad - cachedSourceEl[sourceIndex]) < THRESHOLD)
-        return;
+    if (sourceConvReady[sourceIndex])
+    {
+        float cachedAz = cachedSourceAz[sourceIndex];
+        float cachedEl = cachedSourceEl[sourceIndex];
+        float dot = std::cos (elRad) * std::cos (cachedEl) * std::cos (azRad - cachedAz)
+                  + std::sin (elRad) * std::sin (cachedEl);
+        dot = juce::jlimit (-1.0f, 1.0f, dot);
+        float angularDist = std::acos (dot);
+        if (angularDist < THRESHOLD)
+            return;
+    }
 
     // Query HRTF at exact source direction (realtime-safe: KD-tree lookup, no malloc)
     float delayL = 0.0f, delayR = 0.0f;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -307,6 +307,12 @@ public:
         without comb filtering (issue #47). workBuf must be >= fftSize * 2 floats. */
     static void convertToMinPhase (float* ir, int irLength, int fftOrder, float* workBuf);
 
+    /** Detect onset sample index of an IR using threshold of peak amplitude.
+        Returns the index of the first sample exceeding thresholdFraction * peakAbs.
+        Used to compute ITD when SOFA delay values are zero (ITD baked into waveform).
+        Returns 0 if no clear onset found or if onset > irLength/2. */
+    static int detectOnset (const float* ir, int length, float thresholdFraction = 0.1f);
+
 private:
     MYSOFA_EASY* easyHandle = nullptr;
     int irLength = 0;

--- a/Tests/ConvolverGlitchTests.cpp
+++ b/Tests/ConvolverGlitchTests.cpp
@@ -3281,3 +3281,171 @@ TEST_CASE ("Binaural HRTF — repeated profile cycling no volume swell (issue #9
         prevSS = ssPeak;
     }
 }
+
+// ============================================================================
+// Section: Onset-Detection ITD Alignment Tests (issue #89, Phase 1)
+// ============================================================================
+
+TEST_CASE ("detectOnset — unit: finds onset at correct position", "[issue89][onset][unit]")
+{
+    // Synthetic IR: silence for 5 samples, then a peak
+    std::vector<float> ir (64, 0.0f);
+    ir[5] = 0.8f;
+    ir[6] = 1.0f;
+    ir[7] = 0.5f;
+
+    int onset = HRTFDatabase::detectOnset (ir.data(), static_cast<int> (ir.size()), 0.1f);
+    // 10% of peak (1.0) = 0.1; first sample >= 0.1 is ir[5] = 0.8
+    CHECK (onset == 5);
+}
+
+TEST_CASE ("detectOnset — unit: returns 0 for silent IR", "[issue89][onset][unit]")
+{
+    std::vector<float> ir (64, 0.0f);
+    int onset = HRTFDatabase::detectOnset (ir.data(), static_cast<int> (ir.size()), 0.1f);
+    CHECK (onset == 0);
+}
+
+TEST_CASE ("detectOnset — unit: clamps onset past halfway", "[issue89][onset][unit]")
+{
+    // Peak is past halfway — no clear leading edge
+    std::vector<float> ir (64, 0.0f);
+    ir[40] = 1.0f;
+    int onset = HRTFDatabase::detectOnset (ir.data(), static_cast<int> (ir.size()), 0.1f);
+    CHECK (onset == 0);
+}
+
+TEST_CASE ("detectOnset — unit: immediate onset returns 0", "[issue89][onset][unit]")
+{
+    // Energy starts at sample 0
+    std::vector<float> ir (64, 0.0f);
+    ir[0] = 1.0f;
+    ir[1] = 0.5f;
+    int onset = HRTFDatabase::detectOnset (ir.data(), static_cast<int> (ir.size()), 0.1f);
+    CHECK (onset == 0);
+}
+
+TEST_CASE ("ITD onset detection — MIT KEMAR returns non-zero delays at az=90deg", "[issue89][onset][integration]")
+{
+    auto proc = createBinauralProcessor (1);  // MIT KEMAR (Studio Reference)
+
+    // Stabilize
+    processBlocksCapturingAll (*proc, 60);
+
+    // Set source hard left (az=90deg) — should produce maximum ITD
+    setParam (*proc, "object1_azimuth", 90.0f);
+
+    // Process several blocks to let ITD converge
+    for (int i = 0; i < 10; ++i)
+    {
+        juce::MidiBuffer midi;
+        juce::AudioBuffer<float> buffer (2, kBlockSize);
+        buffer.clear();
+        for (int s = 0; s < kBlockSize; ++s)
+        {
+            buffer.setSample (0, s, 0.5f);
+            buffer.setSample (1, s, 0.5f);
+        }
+        proc->processBlock (buffer, midi);
+    }
+
+    auto& renderer = proc->getActiveRenderer();
+    float tgtL = renderer.getTargetITDL (0);
+    float tgtR = renderer.getTargetITDR (0);
+
+    INFO ("MIT KEMAR at az=90deg: targetITD_L=" << tgtL << " targetITD_R=" << tgtR);
+
+    // With onset detection, at least one channel should have non-zero ITD.
+    // Before this fix, both were always 0 for KEMAR.
+    float maxITD = std::max (std::abs (tgtL), std::abs (tgtR));
+    CHECK (maxITD > 0.1f);  // At least ~2 microseconds of ITD at 48kHz
+}
+
+TEST_CASE ("ITD onset detection — SADIE bypasses fallback (non-zero SOFA delays)", "[issue89][onset][integration]")
+{
+    auto proc = createBinauralProcessor (2);  // SADIE II KU100 (Immersive)
+
+    // Stabilize
+    processBlocksCapturingAll (*proc, 60);
+
+    // Set source hard left
+    setParam (*proc, "object1_azimuth", 90.0f);
+
+    for (int i = 0; i < 10; ++i)
+    {
+        juce::MidiBuffer midi;
+        juce::AudioBuffer<float> buffer (2, kBlockSize);
+        buffer.clear();
+        for (int s = 0; s < kBlockSize; ++s)
+        {
+            buffer.setSample (0, s, 0.5f);
+            buffer.setSample (1, s, 0.5f);
+        }
+        proc->processBlock (buffer, midi);
+    }
+
+    auto& renderer = proc->getActiveRenderer();
+    float tgtL = renderer.getTargetITDL (0);
+    float tgtR = renderer.getTargetITDR (0);
+
+    INFO ("SADIE KU100 at az=90deg: targetITD_L=" << tgtL << " targetITD_R=" << tgtR);
+
+    // SADIE already has non-zero SOFA delays, so ITD should be valid
+    float maxITD = std::max (std::abs (tgtL), std::abs (tgtR));
+    CHECK (maxITD > 0.1f);
+}
+
+TEST_CASE ("ITD onset detection — symmetric positions produce symmetric delays", "[issue89][onset][integration]")
+{
+    auto proc = createBinauralProcessor (1);  // MIT KEMAR
+
+    // Stabilize
+    processBlocksCapturingAll (*proc, 60);
+
+    // Process at az=+90 (hard left)
+    setParam (*proc, "object1_azimuth", 90.0f);
+    for (int i = 0; i < 10; ++i)
+    {
+        juce::MidiBuffer midi;
+        juce::AudioBuffer<float> buffer (2, kBlockSize);
+        buffer.clear();
+        for (int s = 0; s < kBlockSize; ++s)
+        {
+            buffer.setSample (0, s, 0.5f);
+            buffer.setSample (1, s, 0.5f);
+        }
+        proc->processBlock (buffer, midi);
+    }
+
+    auto& renderer = proc->getActiveRenderer();
+    float leftL = renderer.getTargetITDL (0);
+    float leftR = renderer.getTargetITDR (0);
+
+    // Process at az=-90 (hard right)
+    setParam (*proc, "object1_azimuth", -90.0f);
+    for (int i = 0; i < 10; ++i)
+    {
+        juce::MidiBuffer midi;
+        juce::AudioBuffer<float> buffer (2, kBlockSize);
+        buffer.clear();
+        for (int s = 0; s < kBlockSize; ++s)
+        {
+            buffer.setSample (0, s, 0.5f);
+            buffer.setSample (1, s, 0.5f);
+        }
+        proc->processBlock (buffer, midi);
+    }
+
+    float rightL = renderer.getTargetITDL (0);
+    float rightR = renderer.getTargetITDR (0);
+
+    INFO ("Left: ITD_L=" << leftL << " ITD_R=" << leftR);
+    INFO ("Right: ITD_L=" << rightL << " ITD_R=" << rightR);
+
+    // At symmetric positions, L/R delays should roughly swap:
+    // at az=+90, ipsilateral ear (L) should have less delay than contralateral (R)
+    // at az=-90, it should be the reverse
+    // Allow tolerance since SOFA grids aren't perfectly symmetric
+    CHECK (std::abs (leftL - rightR) < 3.0f);
+    CHECK (std::abs (leftR - rightL) < 3.0f);
+}

--- a/Tests/ConvolverGlitchTests.cpp
+++ b/Tests/ConvolverGlitchTests.cpp
@@ -3449,3 +3449,106 @@ TEST_CASE ("ITD onset detection — symmetric positions produce symmetric delays
     CHECK (std::abs (leftL - rightR) < 3.0f);
     CHECK (std::abs (leftR - rightL) < 3.0f);
 }
+
+// ============================================================================
+// Section: Great-Circle Distance Threshold Tests (issue #89, Phase 2)
+// ============================================================================
+
+TEST_CASE ("Great-circle threshold — polar azimuth sweep is stable", "[issue89][greatcircle][integration]")
+{
+    // At elevation ~89°, azimuth changes should produce near-zero angular distance
+    // and NOT trigger constant HRIR updates. Before the fix, independent azimuth/elevation
+    // comparison treated every 1° azimuth change as significant even near the pole.
+    auto proc = createBinauralProcessor (1);  // MIT KEMAR
+
+    // Stabilize
+    processBlocksCapturingAll (*proc, 60);
+
+    // Set elevation near pole
+    setParam (*proc, "object1_elevation", 85.0f);
+
+    // Process a few blocks at initial azimuth to establish cached position
+    setParam (*proc, "object1_azimuth", 0.0f);
+    for (int i = 0; i < 5; ++i)
+    {
+        juce::MidiBuffer midi;
+        juce::AudioBuffer<float> buffer (2, kBlockSize);
+        buffer.clear();
+        for (int s = 0; s < kBlockSize; ++s)
+            buffer.setSample (0, s, 0.5f);
+        proc->processBlock (buffer, midi);
+    }
+
+    // Now sweep azimuth and check that output is stable (no glitches from
+    // constant HRIR switching). At 85° elevation, a 10° azimuth change is
+    // only ~0.87° of actual angular movement — below the 1° threshold.
+    std::vector<float> peakDiffs;
+    float prevSampleL = 0.0f;
+
+    for (int step = 0; step < 18; ++step)
+    {
+        float az = 10.0f * static_cast<float> (step);
+        setParam (*proc, "object1_azimuth", az);
+
+        juce::MidiBuffer midi;
+        juce::AudioBuffer<float> buffer (2, kBlockSize);
+        buffer.clear();
+        for (int s = 0; s < kBlockSize; ++s)
+            buffer.setSample (0, s, 0.5f);
+        proc->processBlock (buffer, midi);
+
+        // Check for large sample-to-sample jumps at block boundary
+        float firstSampleL = buffer.getSample (0, 0);
+        float diff = std::abs (firstSampleL - prevSampleL);
+        peakDiffs.push_back (diff);
+        prevSampleL = buffer.getSample (0, kBlockSize - 1);
+    }
+
+    // Count how many block boundaries had large discontinuities
+    int largeJumps = 0;
+    for (float d : peakDiffs)
+        if (d > 0.2f) ++largeJumps;
+
+    INFO ("Large jumps at polar azimuth sweep: " << largeJumps << " / " << peakDiffs.size());
+    // With great-circle threshold, most azimuth changes at 85° elevation should
+    // NOT trigger HRIR updates, so we expect very few discontinuities
+    CHECK (largeJumps <= 3);
+}
+
+TEST_CASE ("Great-circle threshold — equatorial sweep unchanged", "[issue89][greatcircle][integration]")
+{
+    // At elevation 0° (equator), behavior should be identical to the old threshold.
+    // Great-circle distance equals azimuth difference at the equator.
+    auto proc = createBinauralProcessor (1);  // MIT KEMAR
+
+    // Stabilize
+    processBlocksCapturingAll (*proc, 60);
+
+    setParam (*proc, "object1_elevation", 0.0f);
+
+    // Sweep azimuth in 2° steps (above the 1° threshold) — should trigger updates
+    int updateCount = 0;
+    float prevITDL = -999.0f;
+
+    for (int step = 0; step < 36; ++step)
+    {
+        float az = 2.0f * static_cast<float> (step);
+        setParam (*proc, "object1_azimuth", az);
+
+        juce::MidiBuffer midi;
+        juce::AudioBuffer<float> buffer (2, kBlockSize);
+        buffer.clear();
+        for (int s = 0; s < kBlockSize; ++s)
+            buffer.setSample (0, s, 0.5f);
+        proc->processBlock (buffer, midi);
+
+        float tgtL = proc->getActiveRenderer().getTargetITDL (0);
+        if (std::abs (tgtL - prevITDL) > 0.01f)
+            ++updateCount;
+        prevITDL = tgtL;
+    }
+
+    INFO ("HRIR updates during equatorial 2-degree sweep: " << updateCount);
+    // At equator with 2° steps, great-circle ≈ azimuth difference, so updates should fire
+    CHECK (updateCount >= 10);
+}


### PR DESCRIPTION
## Summary

- Add onset-detection ITD alignment for zero-delay HRTF datasets (Phase 1)
- Fix SADIE regression from fractional delay truncation
- Add great-circle distance threshold for HRIR updates near elevation poles (Phase 2)

## Changes

### Phase 1: Onset-Detection ITD Alignment
SOFA datasets like MIT KEMAR report delay=0 with ITD baked into the HRIR waveform, making `getAlignedHRIR()` a no-op. The dual-slot crossfade then blends HRIRs with different embedded onset times, causing comb filtering (warbling). SADIE II KU100 works because it reports non-zero delays.

`HRTFDatabase::detectOnset()` scans the HRIR waveform for onset when SOFA delays are zero, enabling proper time-alignment before crossfade. Guard uses raw float delays (`< 0.001f`) to avoid triggering on SADIE's valid fractional delays.

### Phase 2: Great-Circle Distance Threshold
The independent azimuth/elevation threshold in `updateSourceHRIR()` caused constant HRIR switching near ±90° elevation (zenith stuck centered, erratic nadir jumps). Replaced with great-circle angular distance which naturally handles the pole singularity.

## Test Results

| Symptom | Result |
|---------|--------|
| Warbling (Studio Reference) | Improved |
| Zenith stuck centered | **Big improvement** |
| Nadir erratic jumps | **Improved** (stable, minor right-ear bias from dataset coverage gap) |
| Immersive (SADIE) regression | None |

9 new tests, 0 regressions (264 total).

## Test plan
- [x] All existing ConvolverGlitchTests pass
- [x] A/B listening: Studio Reference warbling improved
- [x] A/B listening: Zenith behavior significantly improved
- [x] A/B listening: Nadir stabilized
- [x] A/B listening: Immersive (SADIE) unchanged
- [x] A/B listening: Spatial unchanged

Closes #89 (Phases 1+2; Phase 3 LF bypass deferred as optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)