### PR TITLE
Shared FFT cache for multi-instance stability (issue #131)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ bash scripts/build_version.sh <commit-hash> v1.0.Z O10Z
 - v1.0.10 / O110 — reduce automatable params to 64 for Ableton auto-populate (issue #122, commit 4adfd1d)
 - v1.0.7 / O107 — 4-layer tape wobble emulation (issue #92, commit 893acb2)
 - v1.0.14 / O114 — shared LookAndFeel + visibility throttle for multi-instance crash (issue #131)
-- Next available: **v1.0.15 / O115**
+- v1.0.17 / O117 — shared FFT cache for multi-instance vDSP stability (issue #131, commit e8ee6ec)
+- Next available: **v1.0.18 / O118**
 
 ### Running tests
 

--- a/Source/PhaseVocoderPitchShifter.h
+++ b/Source/PhaseVocoderPitchShifter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <JuceHeader.h>
+#include "SharedFFTCache.h"
 #include <cmath>
 #include <cstring>
 #include <algorithm>
@@ -29,8 +30,8 @@ public:
     static constexpr int kNumBins   = kFFTSize / 2 + 1;      // 1025
 
     PhaseVocoderPitchShifter()
-        : fft (kFFTOrder)
     {
+        fft = getSharedFFTCache().getOrCreate (kFFTOrder);
         // v1.0.8: Generate periodic Hann window (N denominator, not N-1).
         // JUCE's WindowingFunction::hann uses symmetric (N-1), which creates a
         // ~-66 dB COLA ripple at the hop rate (93.75 Hz @ 48kHz/512 hop).
@@ -168,7 +169,7 @@ private:
     static constexpr float kPi         = 3.14159265358979323846f;
     static constexpr float kTwoPi      = 2.0f * kPi;
 
-    juce::dsp::FFT fft;
+    std::shared_ptr<juce::dsp::FFT> fft;  // Shared via process-global FFT cache (issue #131)
     float windowData[kFFTSize] = {};  // Periodic Hann window (generated in constructor)
 
     // Input ring buffer (stores last kFFTSize samples)
@@ -268,7 +269,7 @@ private:
         // =====================================================================
         // 2. Forward FFT
         // =====================================================================
-        fft.performRealOnlyForwardTransform (fftData);
+        fft->performRealOnlyForwardTransform (fftData);
 
         // =====================================================================
         // 3. Analysis: compute magnitude and instantaneous frequency per bin
@@ -448,7 +449,7 @@ private:
         // =====================================================================
         // 7. Inverse FFT
         // =====================================================================
-        fft.performRealOnlyInverseTransform (fftData);
+        fft->performRealOnlyInverseTransform (fftData);
 
         // =====================================================================
         // 8. Apply synthesis window and overlap-add

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -645,7 +645,7 @@ void HRTFDatabase::convertToMinPhase (float* ir, int irLength, int fftOrder, flo
     if (irLength <= 0 || fftOrder <= 0) return;
 
     const int N = 1 << fftOrder;  // FFT size (must be >= 2 * irLength)
-    juce::dsp::FFT fft (fftOrder);
+    auto fftPtr = getSharedFFTCache().getOrCreate (fftOrder);
 
     // workBuf layout: N Complex<float> = N * 2 floats
     auto* cBuf = reinterpret_cast<std::complex<float>*> (workBuf);
@@ -655,7 +655,7 @@ void HRTFDatabase::convertToMinPhase (float* ir, int irLength, int fftOrder, flo
         cBuf[i] = (i < irLength) ? std::complex<float> (ir[i], 0.0f) : std::complex<float> (0.0f, 0.0f);
 
     // Step 2: Forward FFT
-    fft.perform (cBuf, cBuf, false);
+    fftPtr->perform (cBuf, cBuf, false);
 
     // Step 3: Compute log-magnitude (real cepstrum input)
     for (int k = 0; k < N; ++k)
@@ -666,7 +666,7 @@ void HRTFDatabase::convertToMinPhase (float* ir, int irLength, int fftOrder, flo
     }
 
     // Step 4: IFFT to get real cepstrum
-    fft.perform (cBuf, cBuf, true);
+    fftPtr->perform (cBuf, cBuf, true);
 
     // Step 5: Apply minimum-phase window to cepstrum
     // c_mp[0] unchanged, c_mp[1..N/2-1] doubled, c_mp[N/2] unchanged, c_mp[N/2+1..N-1] zeroed
@@ -677,7 +677,7 @@ void HRTFDatabase::convertToMinPhase (float* ir, int irLength, int fftOrder, flo
         cBuf[n] = std::complex<float> (0.0f, 0.0f);
 
     // Step 6: Forward FFT
-    fft.perform (cBuf, cBuf, false);
+    fftPtr->perform (cBuf, cBuf, false);
 
     // Step 7: Exponentiate to get minimum-phase spectrum
     for (int k = 0; k < N; ++k)
@@ -691,7 +691,7 @@ void HRTFDatabase::convertToMinPhase (float* ir, int irLength, int fftOrder, flo
     }
 
     // Step 8: IFFT to get minimum-phase IR
-    fft.perform (cBuf, cBuf, true);
+    fftPtr->perform (cBuf, cBuf, true);
 
     // Step 9: Copy first irLength samples back (real part only)
     for (int i = 0; i < irLength; ++i)
@@ -702,22 +702,28 @@ void HRTFDatabase::convertToMinPhase (float* ir, int irLength, int fftOrder, flo
 // PartitionedConvolver implementation — overlap-save FFT convolution
 //==============================================================================
 
-// Process-global lock for vDSP FFT setup create/destroy (issue #137).
-// Apple's vDSP FFT setup functions are not documented as thread-safe.
-// JUCE already protects FFTW with a CriticalSection but omits vDSP.
-// With multiple plugin instances, concurrent setup create/destroy from the
-// timer thread can race with FFT operations on the audio thread, corrupting
-// vDSP's internal allocator state (manifests as free_list_checksum_botch).
-static juce::CriticalSection& getVDSPSetupLock()
+// Process-global FFT cache (issue #131).  Apple's vDSP shares internal
+// twiddle factor memory across FFT setups of the same order.  Destroying the
+// last setup of a given order frees the shared table even while another
+// thread's vDSP_fft_zrip is reading from it.  The cache creates each order
+// once and holds a permanent shared_ptr so the vDSP twiddle tables are never
+// freed while the process is alive.  Individual convolvers also hold
+// shared_ptrs, providing redundant safety.
+std::shared_ptr<juce::dsp::FFT> SharedFFTCache::getOrCreate (int fftOrder)
 {
-    static juce::CriticalSection cs;
-    return cs;
+    juce::SpinLock::ScopedLockType sl (lock);
+    auto it = cache.find (fftOrder);
+    if (it != cache.end())
+        return it->second;
+    auto ptr = std::make_shared<juce::dsp::FFT> (fftOrder);
+    cache[fftOrder] = ptr;
+    return ptr;
 }
 
-PartitionedConvolver::~PartitionedConvolver()
+SharedFFTCache& getSharedFFTCache()
 {
-    juce::ScopedLock sl (getVDSPSetupLock());
-    fft.reset();
+    static SharedFFTCache instance;
+    return instance;
 }
 
 void PartitionedConvolver::prepare (int maxBlockSize, int irLength_)
@@ -737,10 +743,7 @@ void PartitionedConvolver::prepare (int maxBlockSize, int irLength_)
     fftSize = 1 << fftOrder;
 
     if (orderChanged)
-    {
-        juce::ScopedLock sl (getVDSPSetupLock());
-        fft = std::make_unique<juce::dsp::FFT> (fftOrder);
-    }
+        fft = getSharedFFTCache().getOrCreate (fftOrder);
 
     // v1.0.5: Allocate dual convolution slots (issue #50)
     for (int s = 0; s < 2; ++s)
@@ -1009,8 +1012,11 @@ void BinauralRenderer::prepare (double sampleRate, int maxBlockSize)
     currentSampleRate = sampleRate;
     currentBlockSize = maxBlockSize;
 
-    convTmpL.resize (static_cast<size_t> (maxBlockSize), 0.0f);
-    convTmpR.resize (static_cast<size_t> (maxBlockSize), 0.0f);
+    // Pre-allocate to max(blockSize, 512) to cover typical IR lengths
+    // and avoid audio-thread allocation in renderSourceBuffers / updateSourceHRIR.
+    size_t preAllocSize = static_cast<size_t> (std::max (maxBlockSize, 512));
+    convTmpL.resize (preAllocSize, 0.0f);
+    convTmpR.resize (preAllocSize, 0.0f);
 }
 
 void BinauralRenderer::setProfile (int profileIndex)
@@ -1124,6 +1130,7 @@ void BinauralRenderer::updateSourceHRIR (int sourceIndex, float azRad, float elR
     // Ensure work buffers are large enough for IR
     if ((int) tmpL.size() < storedIRLength)
     {
+        jassertfalse;  // Audio thread allocation — should have been pre-allocated in prepare()
         tmpL.resize (static_cast<size_t> (storedIRLength));
         tmpR.resize (static_cast<size_t> (storedIRLength));
     }
@@ -1168,6 +1175,7 @@ void BinauralRenderer::renderSourceBuffers (const float* const* sourceBufs,
 
     if (convTmpL.size() < static_cast<size_t> (numSamples))
     {
+        jassertfalse;  // Audio thread allocation — should have been pre-allocated in prepare()
         convTmpL.resize (static_cast<size_t> (numSamples));
         convTmpR.resize (static_cast<size_t> (numSamples));
     }
@@ -2601,6 +2609,10 @@ void OpenSpatialDelayProcessor::prepareToPlay (double sampleRate, int samplesPer
     // HRTF convolution: prepare both renderers (double-buffered)
     binauralRenderers[0].prepare (sampleRate, samplesPerBlock);
     binauralRenderers[1].prepare (sampleRate, samplesPerBlock);
+
+    // Pre-allocate renderer crossfade buffers (issue #131: avoid audio-thread allocation)
+    xfadeWetL_.resize (static_cast<size_t> (samplesPerBlock), 0.0f);
+    xfadeWetR_.resize (static_cast<size_t> (samplesPerBlock), 0.0f);
 
     // v0.5: Contiguous per-source accumulation buffers for direct binaural
     sourceAccumBufStorage.resize (static_cast<size_t> (MAX_OBJECTS * samplesPerBlock), 0.0f);

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -2,6 +2,7 @@
 #include <JuceHeader.h>
 #include <array>
 #include <vector>
+#include "SharedFFTCache.h"
 #include "PresetData.h"
 #include "PhaseVocoderPitchShifter.h"
 #include "DopplerVelocity.h"
@@ -322,7 +323,6 @@ class PartitionedConvolver
 {
 public:
     PartitionedConvolver() = default;
-    ~PartitionedConvolver();
 
     /** Prepare the convolver for a given max block size and IR length. */
     void prepare (int maxBlockSize, int irLength);
@@ -347,7 +347,7 @@ public:
     bool isPrepared() const { return fftSize > 0; }
 
 private:
-    std::unique_ptr<juce::dsp::FFT> fft;  // Owned via unique_ptr for locked destruction (issue #137)
+    std::shared_ptr<juce::dsp::FFT> fft;  // Shared via process-global FFT cache (issue #131)
     int fftOrder = 1;
     int fftSize = 0;                 // 2^fftOrder
     int irLen = 0;

--- a/Source/SharedFFTCache.h
+++ b/Source/SharedFFTCache.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <JuceHeader.h>
+#include <map>
+#include <memory>
+
+//==============================================================================
+// Process-global FFT cache — prevents vDSP twiddle table use-after-free
+// when multiple plugin instances create/destroy FFT setups concurrently.
+// vDSP shares internal twiddle factor memory across setups of the same order;
+// destroying the last setup frees the shared table even if another thread's
+// vDSP_fft_zrip is reading from it.  The cache creates once, never destroys.
+// (issue #131)
+//==============================================================================
+struct SharedFFTCache
+{
+    juce::SpinLock lock;
+    std::map<int, std::shared_ptr<juce::dsp::FFT>> cache;
+    std::shared_ptr<juce::dsp::FFT> getOrCreate (int fftOrder);
+};
+
+SharedFFTCache& getSharedFFTCache();

--- a/Tests/ConvolverGlitchTests.cpp
+++ b/Tests/ConvolverGlitchTests.cpp
@@ -87,6 +87,25 @@ static void setParam (Proc& proc, const juce::String& paramId, float value)
 }
 
 // ============================================================================
+// Section 1b: SharedFFTCache Unit Tests (issue #131)
+// ============================================================================
+
+TEST_CASE ("SharedFFTCache — returns same instance for same order", "[fft][issue131]")
+{
+    auto& cache = getSharedFFTCache();
+    auto fft1 = cache.getOrCreate (11);
+    auto fft2 = cache.getOrCreate (11);
+    REQUIRE (fft1.get() == fft2.get());
+
+    auto fft3 = cache.getOrCreate (10);
+    REQUIRE (fft3.get() != fft1.get());
+
+    // Different order also cached
+    auto fft4 = cache.getOrCreate (10);
+    REQUIRE (fft4.get() == fft3.get());
+}
+
+// ============================================================================
 // Section 2: PartitionedConvolver Unit Tests
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- **Process-global `SharedFFTCache`** creates each FFT order once and holds a permanent `shared_ptr`, ensuring Apple vDSP twiddle factor tables are never freed while the process is alive
- **Pre-allocates audio-thread buffers** (`convTmpL/R`, `xfadeWetL_/R_`) in `prepare()`/`prepareToPlay()` to eliminate audio-thread heap allocation
- **Covers all FFT users**: `PartitionedConvolver`, `PhaseVocoderPitchShifter`, and `HRTFDatabase::convertToMinPhase`

## Root Cause

Apple's `vDSP_create_fftsetup` shares internal twiddle factor memory across setups of the same order via reference counting. The prior fix (#137) locked create/destroy but not `vDSP_fft_zrip` (perform), leaving a race between timer-thread FFT destruction and audio-thread FFT operations across plugin instances. With 10 instances, up to 600 vDSP setups shared one twiddle table — destroying any one could free it while another thread reads from it.

## Test plan

- [x] 256 unit tests pass (2 pre-existing spectral flux failures unchanged)
- [x] SharedFFTCache unit test verifies same-order caching and cross-order isolation
- [x] 12 instances across 3 tracks in REAPER — stable, ~6% CPU
- [x] 16 instances across 7 tracks in REAPER — stable, ~10% CPU
- [x] Left running for several minutes with no crash
- [x] Built as v1.0.17 / O117

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)