### PR TITLE
Grey out Algorithm box for Ambisonics output (issue #143)

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -728,8 +728,10 @@ void OSDLookAndFeel::drawComboBox (juce::Graphics& g, int width, int height, boo
 void OSDLookAndFeel::positionComboBoxText (juce::ComboBox& box, juce::Label& label)
 {
     // Reserve 20px for arrow when enabled; use full width when disabled (no arrow)
-    int rightPad = box.isEnabled() ? 20 : 4;
-    label.setBounds (1, 1, box.getWidth() - rightPad, box.getHeight() - 2);
+    if (box.isEnabled())
+        label.setBounds (1, 1, box.getWidth() - 20, box.getHeight() - 2);
+    else
+        label.setBounds (0, 1, box.getWidth(), box.getHeight() - 2);
     label.setFont (getComboBoxFont (box));
 }
 
@@ -3109,6 +3111,7 @@ void OpenSpatialDelayEditor::timerCallback()
         algorithmBox.setEnabled (false);
         algorithmBox.setAlpha (0.5f);
         algorithmBox.setText ("Ambisonics Encode", juce::dontSendNotification);
+
     }
     else
     {

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -699,7 +699,7 @@ void OSDLookAndFeel::getIdealPopupMenuItemSize (const juce::String& text, bool i
 
 void OSDLookAndFeel::drawComboBox (juce::Graphics& g, int width, int height, bool /*isButtonDown*/,
                                    int /*buttonX*/, int /*buttonY*/, int /*buttonW*/, int /*buttonH*/,
-                                   juce::ComboBox& /*box*/)
+                                   juce::ComboBox& box)
 {
     auto bounds = juce::Rectangle<float> (0, 0, (float) width, (float) height);
 
@@ -711,15 +711,18 @@ void OSDLookAndFeel::drawComboBox (juce::Graphics& g, int width, int height, boo
     g.setColour (findColour (juce::ComboBox::outlineColourId));
     g.drawRoundedRectangle (bounds.reduced (0.5f), 4.0f, 1.0f);
 
-    // Small dropdown arrow
-    float arrowX = (float) width - 12.0f;
-    float arrowY = (float) height * 0.5f;
-    juce::Path arrow;
-    arrow.addTriangle (arrowX - 3.0f, arrowY - 1.5f,
-                       arrowX + 3.0f, arrowY - 1.5f,
-                       arrowX,        arrowY + 2.5f);
-    g.setColour (findColour (juce::ComboBox::arrowColourId));
-    g.fillPath (arrow);
+    // Small dropdown arrow — hidden when combo is disabled (e.g. Ambisonics mode)
+    if (box.isEnabled())
+    {
+        float arrowX = (float) width - 12.0f;
+        float arrowY = (float) height * 0.5f;
+        juce::Path arrow;
+        arrow.addTriangle (arrowX - 3.0f, arrowY - 1.5f,
+                           arrowX + 3.0f, arrowY - 1.5f,
+                           arrowX,        arrowY + 2.5f);
+        g.setColour (findColour (juce::ComboBox::arrowColourId));
+        g.fillPath (arrow);
+    }
 }
 
 void OSDLookAndFeel::positionComboBoxText (juce::ComboBox& box, juce::Label& label)
@@ -3104,6 +3107,7 @@ void OpenSpatialDelayEditor::timerCallback()
         algorithmBox.setVisible (true);
         algorithmLabel.setVisible (true);
         algorithmBox.setEnabled (false);
+        algorithmBox.setAlpha (0.5f);
         algorithmBox.setText ("Ambisonics Encode", juce::dontSendNotification);
     }
     else
@@ -3111,6 +3115,7 @@ void OpenSpatialDelayEditor::timerCallback()
         algorithmBox.setVisible (true);
         algorithmLabel.setVisible (true);
         algorithmBox.setEnabled (true);
+        algorithmBox.setAlpha (1.0f);
 
         // Rebuild combo items only when format category changes
         if (fmtCategory != lastAlgoCategoryShown)

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -727,9 +727,9 @@ void OSDLookAndFeel::drawComboBox (juce::Graphics& g, int width, int height, boo
 
 void OSDLookAndFeel::positionComboBoxText (juce::ComboBox& box, juce::Label& label)
 {
-    // Reserve only 20px for arrow (our triangle is 6px wide centered at width-12)
-    // instead of JUCE's default 30px — fixes "Figure-8" truncation
-    label.setBounds (1, 1, box.getWidth() - 20, box.getHeight() - 2);
+    // Reserve 20px for arrow when enabled; use full width when disabled (no arrow)
+    int rightPad = box.isEnabled() ? 20 : 4;
+    label.setBounds (1, 1, box.getWidth() - rightPad, box.getHeight() - 2);
     label.setFont (getComboBoxFont (box));
 }
 

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -3111,7 +3111,11 @@ void OpenSpatialDelayEditor::timerCallback()
         algorithmBox.setEnabled (false);
         algorithmBox.setAlpha (0.5f);
         algorithmBox.setText ("Ambisonics Encode", juce::dontSendNotification);
-
+        if (fmtCategory != lastAlgoCategoryShown)
+        {
+            lastAlgoCategoryShown = fmtCategory;
+            algorithmBox.resized();   // re-trigger positionComboBoxText for full-width label
+        }
     }
     else
     {
@@ -3145,6 +3149,8 @@ void OpenSpatialDelayEditor::timerCallback()
                 algorithmBox.addItem ("VBAP",         5);   // param index 4
                 algorithmBox.addItem ("VBIP",         6);   // param index 5
             }
+
+            algorithmBox.resized();   // restore arrow-reserved label width
         }
 
         // Validate algorithm against current output mode every tick


### PR DESCRIPTION
## Summary

- Hide the dropdown triangle arrow on the Algorithm combo box when Ambisonics output is selected
- Apply 50% alpha dimming to visually indicate the control is read-only
- Use full label width (no arrow padding) so "Ambisonics Encode" text renders without cramping
- Force `positionComboBoxText()` re-invocation on format category transitions via `resized()`, working around JUCE's `enablementChanged()` not calling `resized()`

Closes #143

## Test plan

- [ ] Select any Ambisonics output format (FOA–6OA) — Algorithm box should appear greyed out with "Ambisonics Encode" text, no dropdown arrow, text not cramped
- [ ] Switch to Stereo or Surround output — Algorithm dropdown should restore to full opacity with arrow and selectable items
- [ ] Switch to Binaural — Algorithm box should be hidden entirely
- [ ] Cycle between all three categories (Binaural → Ambi → Stereo → Surround) to verify transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)