### PR TITLE
Add low-frequency shelf compensation for KEMAR HRTF profile (issue #89)

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1149,9 +1149,25 @@ void BinauralRenderer::setProfile (int profileIndex)
         std::memset (itdBufferR[i], 0, sizeof (itdBufferR[i]));
     }
 
+    // v1.0.11 (issue #89, Phase 3): Enable LF bypass for profiles with bass-deficient IRs.
+    // Profiles 1 (MIT KEMAR), 3 (CIPIC), 4 (HUTUBS) have short IRs that can't represent bass.
+    // Profiles 2 (SADIE) and 5 (Bernschuetz) are excluded — no low-end issues.
+    lfBypassActive = (profileIndex == 1 || profileIndex == 3 || profileIndex == 4);
+    if (lfBypassActive)
+    {
+        // 1st-order one-pole LP coefficient: alpha = 1 - exp(-2*pi*fc/sr)
+        lfBypassAlpha = 1.0f - std::exp (-juce::MathConstants<float>::twoPi
+                                          * kLFBypassCrossoverHz
+                                          / static_cast<float> (currentSampleRate));
+    }
+    // NOTE: Do NOT clear lfLPStateIn here — this renderer was previously active
+    // and its LP state is warm from audio processing. Clearing it would create a
+    // bass dropout during the renderer-level crossfade (issue #90 regression).
+
     DBG ("BinauralRenderer: Profile " + juce::String (profileIndex)
          + " loaded — IR=" + juce::String (irLen)
          + ", normGain=" + juce::String (storedNormGain, 4)
+         + ", lfBypass=" + juce::String (lfBypassActive ? "ON" : "OFF")
          + " (per-source direct binaural)");
 }
 
@@ -1244,6 +1260,31 @@ void BinauralRenderer::renderSourceBuffers (const float* const* sourceBufs,
         sourceConvL[src].process (sourceBufs[src], convTmpL.data(), numSamples);
         sourceConvR[src].process (sourceBufs[src], convTmpR.data(), numSamples);
 
+        // v1.0.11 (issue #89, Phase 3): LF bypass for short-IR profiles.
+        // Short HRIRs naturally attenuate bass (can't represent < ~300 Hz).
+        // Extract bass from mono input via 1st-order LP and add it equally to
+        // both convolved channels at reduced gain (normGain) to avoid level
+        // increase during profile transitions. No HP on convolved output needed
+        // — the short HRIR already has negligible bass.
+        if (lfBypassActive)
+        {
+            float a = lfBypassAlpha;
+            float lpState = lfLPStateIn[src];
+            float bassGain = storedNormGain * 0.5f;  // Gentle bass fill, avoid level increase
+
+            for (int s = 0; s < numSamples; ++s)
+            {
+                float monoIn = sourceBufs[src][s];
+                lpState += a * (monoIn - lpState);
+
+                float bass = lpState * bassGain;
+                convTmpL[static_cast<size_t> (s)] += bass;
+                convTmpR[static_cast<size_t> (s)] += bass;
+            }
+
+            lfLPStateIn[src] = lpState;
+        }
+
         // v1.0: Apply ITD as fractional-sample delay if using aligned HRIRs.
         // ITD is smoothly interpolated per-sample from currentITD to targetITD
         // to prevent timing discontinuities during rapid position changes.
@@ -1316,6 +1357,7 @@ void BinauralRenderer::reset()
         itdWritePos[i] = 0;
         std::memset (itdBufferL[i], 0, sizeof (itdBufferL[i]));
         std::memset (itdBufferR[i], 0, sizeof (itdBufferR[i]));
+        lfLPStateIn[i] = 0.0f;
     }
 }
 
@@ -1335,6 +1377,7 @@ void BinauralRenderer::invalidateSources()
         itdWritePos[i] = 0;
         std::memset (itdBufferL[i], 0, sizeof (itdBufferL[i]));
         std::memset (itdBufferR[i], 0, sizeof (itdBufferR[i]));
+        lfLPStateIn[i] = 0.0f;
     }
 }
 

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -750,6 +750,77 @@ int HRTFDatabase::detectOnset (const float* ir, int length, float thresholdFract
     return 0;
 }
 
+void HRTFDatabase::correctLowFrequency (float* ir, int irLength, int fftOrder,
+                                         float sampleRate, float* workBuf,
+                                         float lfCutoffHz, float hfCutoffHz)
+{
+    if (ir == nullptr || irLength <= 0 || fftOrder <= 0)
+        return;
+
+    const int N = 1 << fftOrder;
+    juce::dsp::FFT fft (fftOrder);
+
+    auto* cBuf = reinterpret_cast<std::complex<float>*> (workBuf);
+
+    // Step 1: Copy IR into complex buffer, zero-pad
+    for (int i = 0; i < N; ++i)
+        cBuf[i] = (i < irLength) ? std::complex<float> (ir[i], 0.0f)
+                                 : std::complex<float> (0.0f, 0.0f);
+
+    // Step 2: Forward FFT
+    fft.perform (cBuf, cBuf, false);
+
+    // Step 3: Identify frequency bin ranges
+    float binHz = sampleRate / static_cast<float> (N);
+    int lfBin = static_cast<int> (lfCutoffHz / binHz);
+    int hfBin = static_cast<int> (hfCutoffHz / binHz);
+
+    if (lfBin < 1) lfBin = 1;
+    if (hfBin <= lfBin) hfBin = lfBin + 1;
+    if (hfBin > N / 2) hfBin = N / 2;
+
+    // Step 4: Compute mean magnitude in the reference range (100-300 Hz)
+    float sumMag = 0.0f;
+    int magCount = 0;
+    for (int k = lfBin; k < hfBin; ++k)
+    {
+        sumMag += std::abs (cBuf[k]);
+        ++magCount;
+    }
+    float meanMag = (magCount > 0) ? sumMag / static_cast<float> (magCount) : 0.0f;
+
+    // Step 5: Magnitude-only correction below lfCutoff.
+    // Scale each bin's magnitude up to meanMag while preserving its original phase.
+    // This avoids the phase discontinuities between adjacent positions that caused
+    // glitches when full phase extrapolation was used (same issue as min-phase, #47).
+    for (int k = 0; k < lfBin; ++k)
+    {
+        float currentMag = std::abs (cBuf[k]);
+        if (currentMag < 1e-20f)
+        {
+            // Bin has essentially zero energy — set to meanMag with zero phase
+            cBuf[k] = std::complex<float> (meanMag, 0.0f);
+        }
+        else
+        {
+            // Scale magnitude up to meanMag, preserve original phase
+            float scale = meanMag / currentMag;
+            cBuf[k] *= scale;
+        }
+
+        // Mirror to negative frequencies (conjugate symmetry for real output)
+        if (k > 0 && (N - k) < N)
+            cBuf[N - k] = std::conj (cBuf[k]);
+    }
+
+    // Step 6: Inverse FFT
+    fft.perform (cBuf, cBuf, true);
+
+    // Step 7: Copy back to IR (real part only, original length)
+    for (int i = 0; i < irLength; ++i)
+        ir[i] = cBuf[i].real();
+}
+
 //==============================================================================
 // PartitionedConvolver implementation — overlap-save FFT convolution
 //==============================================================================
@@ -1149,25 +1220,36 @@ void BinauralRenderer::setProfile (int profileIndex)
         std::memset (itdBufferR[i], 0, sizeof (itdBufferR[i]));
     }
 
-    // v1.0.11 (issue #89, Phase 3): Enable LF bypass for profiles with bass-deficient IRs.
-    // Profiles 1 (MIT KEMAR), 3 (CIPIC), 4 (HUTUBS) have short IRs that can't represent bass.
-    // Profiles 2 (SADIE) and 5 (Bernschuetz) are excluded — no low-end issues.
-    lfBypassActive = (profileIndex == 1 || profileIndex == 3 || profileIndex == 4);
-    if (lfBypassActive)
+    // v1.0.11 (issue #89, Phase 3): Low-shelf bass compensation for MIT KEMAR.
+    // KEMAR has a 24 dB deficit at 50 Hz and 6 dB at 100 Hz (measurement limitation).
+    // Design a low-shelf biquad filter to boost post-convolution output.
+    // Applied per-source to the convolved signal — bass remains spatialized since
+    // it amplifies whatever LF the HRTF captured at each direction.
+    lfShelfActive = (profileIndex == 1);  // Only MIT KEMAR needs compensation
+    if (lfShelfActive)
     {
-        // 1st-order one-pole LP coefficient: alpha = 1 - exp(-2*pi*fc/sr)
-        lfBypassAlpha = 1.0f - std::exp (-juce::MathConstants<float>::twoPi
-                                          * kLFBypassCrossoverHz
-                                          / static_cast<float> (currentSampleRate));
+        // Low-shelf: +12 dB at 200 Hz, Q=0.7 (gentle slope)
+        auto coeffs = juce::dsp::IIR::Coefficients<float>::makeLowShelf (
+            currentSampleRate, 200.0f, 0.7f, juce::Decibels::decibelsToGain (12.0f));
+        lfShelfB[0] = coeffs->coefficients[0];
+        lfShelfB[1] = coeffs->coefficients[1];
+        lfShelfB[2] = coeffs->coefficients[2];
+        lfShelfA[0] = 1.0f;  // a0 normalized
+        lfShelfA[1] = coeffs->coefficients[3];
+        lfShelfA[2] = coeffs->coefficients[4];
+
+        // Clear filter state
+        for (int i = 0; i < MAX_SOURCES; ++i)
+        {
+            lfShelfStateL[i][0] = lfShelfStateL[i][1] = 0.0f;
+            lfShelfStateR[i][0] = lfShelfStateR[i][1] = 0.0f;
+        }
     }
-    // NOTE: Do NOT clear lfLPStateIn here — this renderer was previously active
-    // and its LP state is warm from audio processing. Clearing it would create a
-    // bass dropout during the renderer-level crossfade (issue #90 regression).
 
     DBG ("BinauralRenderer: Profile " + juce::String (profileIndex)
          + " loaded — IR=" + juce::String (irLen)
          + ", normGain=" + juce::String (storedNormGain, 4)
-         + ", lfBypass=" + juce::String (lfBypassActive ? "ON" : "OFF")
+         + ", lfShelf=" + juce::String (lfShelfActive ? "ON" : "OFF")
          + " (per-source direct binaural)");
 }
 
@@ -1260,29 +1342,27 @@ void BinauralRenderer::renderSourceBuffers (const float* const* sourceBufs,
         sourceConvL[src].process (sourceBufs[src], convTmpL.data(), numSamples);
         sourceConvR[src].process (sourceBufs[src], convTmpR.data(), numSamples);
 
-        // v1.0.11 (issue #89, Phase 3): LF bypass for short-IR profiles.
-        // Short HRIRs naturally attenuate bass (can't represent < ~300 Hz).
-        // Extract bass from mono input via 1st-order LP and add it equally to
-        // both convolved channels at reduced gain (normGain) to avoid level
-        // increase during profile transitions. No HP on convolved output needed
-        // — the short HRIR already has negligible bass.
-        if (lfBypassActive)
+        // v1.0.11 (issue #89, Phase 3): Low-shelf bass boost for KEMAR.
+        // Amplifies the residual LF content in the convolved output. Bass stays
+        // spatialized because the boost is applied to the per-direction HRTF output.
+        if (lfShelfActive)
         {
-            float a = lfBypassAlpha;
-            float lpState = lfLPStateIn[src];
-            float bassGain = storedNormGain * 0.5f;  // Gentle bass fill, avoid level increase
-
             for (int s = 0; s < numSamples; ++s)
             {
-                float monoIn = sourceBufs[src][s];
-                lpState += a * (monoIn - lpState);
+                // Transposed Direct Form II biquad — left channel
+                float xL = convTmpL[static_cast<size_t> (s)];
+                float yL = lfShelfB[0] * xL + lfShelfStateL[src][0];
+                lfShelfStateL[src][0] = lfShelfB[1] * xL - lfShelfA[1] * yL + lfShelfStateL[src][1];
+                lfShelfStateL[src][1] = lfShelfB[2] * xL - lfShelfA[2] * yL;
+                convTmpL[static_cast<size_t> (s)] = yL;
 
-                float bass = lpState * bassGain;
-                convTmpL[static_cast<size_t> (s)] += bass;
-                convTmpR[static_cast<size_t> (s)] += bass;
+                // Right channel
+                float xR = convTmpR[static_cast<size_t> (s)];
+                float yR = lfShelfB[0] * xR + lfShelfStateR[src][0];
+                lfShelfStateR[src][0] = lfShelfB[1] * xR - lfShelfA[1] * yR + lfShelfStateR[src][1];
+                lfShelfStateR[src][1] = lfShelfB[2] * xR - lfShelfA[2] * yR;
+                convTmpR[static_cast<size_t> (s)] = yR;
             }
-
-            lfLPStateIn[src] = lpState;
         }
 
         // v1.0: Apply ITD as fractional-sample delay if using aligned HRIRs.
@@ -1357,7 +1437,8 @@ void BinauralRenderer::reset()
         itdWritePos[i] = 0;
         std::memset (itdBufferL[i], 0, sizeof (itdBufferL[i]));
         std::memset (itdBufferR[i], 0, sizeof (itdBufferR[i]));
-        lfLPStateIn[i] = 0.0f;
+        lfShelfStateL[i][0] = lfShelfStateL[i][1] = 0.0f;
+        lfShelfStateR[i][0] = lfShelfStateR[i][1] = 0.0f;
     }
 }
 
@@ -1377,7 +1458,8 @@ void BinauralRenderer::invalidateSources()
         itdWritePos[i] = 0;
         std::memset (itdBufferL[i], 0, sizeof (itdBufferL[i]));
         std::memset (itdBufferR[i], 0, sizeof (itdBufferR[i]));
-        lfLPStateIn[i] = 0.0f;
+        lfShelfStateL[i][0] = lfShelfStateL[i][1] = 0.0f;
+        lfShelfStateR[i][0] = lfShelfStateR[i][1] = 0.0f;
     }
 }
 

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -313,6 +313,16 @@ public:
         Returns 0 if no clear onset found or if onset > irLength/2. */
     static int detectOnset (const float* ir, int length, float thresholdFraction = 0.1f);
 
+    /** Apply low-frequency correction to an HRIR in-place (Xie 2009 method).
+        Below lfCutoffHz: magnitude is set to the mean of the lfCutoffHz-to-hfCutoffHz
+        range, and phase is linearly extrapolated from that range. This restores
+        physically plausible bass response for datasets with weak LF content (e.g.,
+        MIT KEMAR). workBuf must be >= fftSize * 2 floats. */
+    static void correctLowFrequency (float* ir, int irLength, int fftOrder,
+                                      float sampleRate, float* workBuf,
+                                      float lfCutoffHz = 100.0f,
+                                      float hfCutoffHz = 300.0f);
+
 private:
     MYSOFA_EASY* easyHandle = nullptr;
     int irLength = 0;
@@ -501,16 +511,18 @@ private:
     int itdWritePos[MAX_SOURCES] = {};
     bool itdActive = false;  // true when using aligned HRIRs (non-Simple profiles)
 
-    // v1.0.11 (issue #89, Phase 3): Low-frequency bypass for profiles with short IRs.
-    // Profiles 1 (MIT KEMAR), 3 (CIPIC), 4 (HUTUBS) have IRs too short to represent
-    // bass below ~300 Hz. Bass is extracted from mono input via 1st-order LP and added
-    // equally to both convolved channels. No HP needed — short HRIRs already have
-    // negligible bass, so there's no double-counting.
-    // Profiles 2 (SADIE) and 5 (Bernschuetz) are excluded — no bass issues.
-    static constexpr float kLFBypassCrossoverHz = 250.0f;
-    bool lfBypassActive = false;
-    float lfBypassAlpha = 0.0f;  // LP coefficient: alpha = 1 - exp(-2*pi*fc/sr)
-    float lfLPStateIn[MAX_SOURCES] = {};   // Per-source LP state (extract bass)
+    // v1.0.11 (issue #89, Phase 3): Low-shelf bass compensation for bass-deficient HRTFs.
+    // MIT KEMAR has a 24 dB deficit at 50 Hz (measurement limitation). A low-shelf
+    // filter boosts the convolver output below 200 Hz to compensate. Applied post-
+    // convolution (on the output), not per-HRIR, so it doesn't interfere with
+    // the dual-slot crossfade. Bass remains spatialized since it amplifies whatever
+    // LF content the HRTF did capture at each direction.
+    bool lfShelfActive = false;
+    // Per-source IIR state for 2nd-order low-shelf (biquad)
+    float lfShelfStateL[MAX_SOURCES][2] = {};  // z^-1, z^-2 for left channel
+    float lfShelfStateR[MAX_SOURCES][2] = {};  // z^-1, z^-2 for right channel
+    float lfShelfB[3] = {};  // feedforward coefficients
+    float lfShelfA[3] = {};  // feedback coefficients (a[0] = 1.0)
 
 };
 

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -501,6 +501,17 @@ private:
     int itdWritePos[MAX_SOURCES] = {};
     bool itdActive = false;  // true when using aligned HRIRs (non-Simple profiles)
 
+    // v1.0.11 (issue #89, Phase 3): Low-frequency bypass for profiles with short IRs.
+    // Profiles 1 (MIT KEMAR), 3 (CIPIC), 4 (HUTUBS) have IRs too short to represent
+    // bass below ~300 Hz. Bass is extracted from mono input via 1st-order LP and added
+    // equally to both convolved channels. No HP needed — short HRIRs already have
+    // negligible bass, so there's no double-counting.
+    // Profiles 2 (SADIE) and 5 (Bernschuetz) are excluded — no bass issues.
+    static constexpr float kLFBypassCrossoverHz = 250.0f;
+    bool lfBypassActive = false;
+    float lfBypassAlpha = 0.0f;  // LP coefficient: alpha = 1 - exp(-2*pi*fc/sr)
+    float lfLPStateIn[MAX_SOURCES] = {};   // Per-source LP state (extract bass)
+
 };
 
 // #############################################################################

--- a/Tests/ConvolverGlitchTests.cpp
+++ b/Tests/ConvolverGlitchTests.cpp
@@ -3552,3 +3552,126 @@ TEST_CASE ("Great-circle threshold — equatorial sweep unchanged", "[issue89][g
     // At equator with 2° steps, great-circle ≈ azimuth difference, so updates should fire
     CHECK (updateCount >= 10);
 }
+
+// ============================================================================
+// Section: LF Bypass Tests (issue #89, Phase 3)
+// ============================================================================
+
+TEST_CASE ("LF bypass — 100 Hz sine survives MIT KEMAR convolution", "[issue89][lfbypass][integration]")
+{
+    // MIT KEMAR has ~128-sample IRs that can't represent bass below ~344 Hz.
+    // Without LF bypass, a 100 Hz sine would be severely attenuated.
+    // With LF bypass, the bass passes through unscathed.
+    auto proc = createBinauralProcessor (1);  // MIT KEMAR (Studio Reference)
+
+    // Stabilize
+    processBlocksCapturingAll (*proc, 60);
+
+    // Set source to front (az=0, el=0) for cleanest measurement
+    setParam (*proc, "object1_azimuth", 0.0f);
+    setParam (*proc, "object1_elevation", 0.0f);
+    setParam (*proc, "dryWet", 1.0f);
+
+    // Generate 100 Hz sine and process through the plugin
+    constexpr float freq = 100.0f;
+    constexpr int numBlocks = 20;  // ~107ms — enough for filter to settle
+    float inputRMS = 0.0f;
+    float outputRMS = 0.0f;
+    int totalSamples = 0;
+
+    for (int b = 0; b < numBlocks; ++b)
+    {
+        juce::MidiBuffer midi;
+        juce::AudioBuffer<float> buffer (2, kBlockSize);
+        buffer.clear();
+
+        for (int s = 0; s < kBlockSize; ++s)
+        {
+            float phase = static_cast<float> (b * kBlockSize + s) / static_cast<float> (kSampleRate);
+            float sample = 0.5f * std::sin (juce::MathConstants<float>::twoPi * freq * phase);
+            buffer.setSample (0, s, sample);
+            buffer.setSample (1, s, sample);
+        }
+
+        // Measure input RMS (last few blocks only, after settling)
+        if (b >= numBlocks - 5)
+        {
+            for (int s = 0; s < kBlockSize; ++s)
+                inputRMS += buffer.getSample (0, s) * buffer.getSample (0, s);
+        }
+
+        proc->processBlock (buffer, midi);
+
+        // Measure output RMS (last few blocks only)
+        if (b >= numBlocks - 5)
+        {
+            for (int s = 0; s < kBlockSize; ++s)
+            {
+                float outL = buffer.getSample (0, s);
+                float outR = buffer.getSample (1, s);
+                outputRMS += (outL * outL + outR * outR) * 0.5f;
+            }
+            totalSamples += kBlockSize;
+        }
+    }
+
+    inputRMS = std::sqrt (inputRMS / static_cast<float> (totalSamples));
+    outputRMS = std::sqrt (outputRMS / static_cast<float> (totalSamples));
+
+    float dB = 20.0f * std::log10 (outputRMS / std::max (inputRMS, 1e-10f));
+    INFO ("100 Hz through MIT KEMAR: input RMS=" << inputRMS << " output RMS=" << outputRMS << " dB=" << dB);
+
+    // With LF bypass, output should be within 6 dB of input at 100 Hz
+    CHECK (dB > -6.0f);
+}
+
+TEST_CASE ("LF bypass — SADIE and Spatial unaffected (bypass inactive)", "[issue89][lfbypass][integration]")
+{
+    // SADIE (profile 2) and Spatial (profile 5) should NOT have LF bypass active.
+    // Verify by checking that the renderer reports lfBypassActive = false.
+    // We test this indirectly: process a 100 Hz sine through both and verify
+    // the output characteristics match what we'd expect from full HRTF convolution.
+
+    for (int profile : { 2, 5 })
+    {
+        auto proc = createBinauralProcessor (profile);
+        processBlocksCapturingAll (*proc, 60);
+
+        setParam (*proc, "object1_azimuth", 0.0f);
+        setParam (*proc, "object1_elevation", 0.0f);
+
+        // Process a few blocks of 100 Hz sine
+        float outputRMS = 0.0f;
+        constexpr int numBlocks = 20;
+
+        for (int b = 0; b < numBlocks; ++b)
+        {
+            juce::MidiBuffer midi;
+            juce::AudioBuffer<float> buffer (2, kBlockSize);
+            buffer.clear();
+            for (int s = 0; s < kBlockSize; ++s)
+            {
+                float phase = static_cast<float> (b * kBlockSize + s) / static_cast<float> (kSampleRate);
+                float sample = 0.5f * std::sin (juce::MathConstants<float>::twoPi * 100.0f * phase);
+                buffer.setSample (0, s, sample);
+                buffer.setSample (1, s, sample);
+            }
+            proc->processBlock (buffer, midi);
+
+            if (b >= numBlocks - 5)
+            {
+                for (int s = 0; s < kBlockSize; ++s)
+                {
+                    float outL = buffer.getSample (0, s);
+                    outputRMS += outL * outL;
+                }
+            }
+        }
+
+        outputRMS = std::sqrt (outputRMS / (5.0f * kBlockSize));
+        INFO ("Profile " << profile << " — 100 Hz output RMS=" << outputRMS);
+        // These profiles have long enough IRs to represent 100 Hz naturally,
+        // so output should be non-trivial even without LF bypass
+        CHECK (outputRMS > 0.001f);
+    }
+}

--- a/Tests/ConvolverGlitchTests.cpp
+++ b/Tests/ConvolverGlitchTests.cpp
@@ -3557,11 +3557,10 @@ TEST_CASE ("Great-circle threshold — equatorial sweep unchanged", "[issue89][g
 // Section: LF Bypass Tests (issue #89, Phase 3)
 // ============================================================================
 
-TEST_CASE ("LF bypass — 100 Hz sine survives MIT KEMAR convolution", "[issue89][lfbypass][integration]")
+TEST_CASE ("LF shelf — 100 Hz improved through MIT KEMAR convolution", "[issue89][lfshelf][integration]")
 {
-    // MIT KEMAR has ~128-sample IRs that can't represent bass below ~344 Hz.
-    // Without LF bypass, a 100 Hz sine would be severely attenuated.
-    // With LF bypass, the bass passes through unscathed.
+    // MIT KEMAR has a 24 dB bass deficit at 50 Hz (measurement limitation).
+    // A +12 dB low-shelf at 200 Hz boosts the convolved output's LF content.
     auto proc = createBinauralProcessor (1);  // MIT KEMAR (Studio Reference)
 
     // Stabilize
@@ -3621,13 +3620,14 @@ TEST_CASE ("LF bypass — 100 Hz sine survives MIT KEMAR convolution", "[issue89
     float dB = 20.0f * std::log10 (outputRMS / std::max (inputRMS, 1e-10f));
     INFO ("100 Hz through MIT KEMAR: input RMS=" << inputRMS << " output RMS=" << outputRMS << " dB=" << dB);
 
-    // With LF bypass, output should be within 6 dB of input at 100 Hz
-    CHECK (dB > -6.0f);
+    // With +12 dB low-shelf, 100 Hz should be significantly boosted.
+    // Without shelf: ~-20 dB. With shelf: should be within ~10 dB of input.
+    CHECK (dB > -12.0f);
 }
 
-TEST_CASE ("LF bypass — SADIE and Spatial unaffected (bypass inactive)", "[issue89][lfbypass][integration]")
+TEST_CASE ("LF shelf — SADIE and Spatial unaffected (shelf inactive)", "[issue89][lfshelf][integration]")
 {
-    // SADIE (profile 2) and Spatial (profile 5) should NOT have LF bypass active.
+    // SADIE (profile 2) and Spatial (profile 5) should NOT have LF shelf active.
     // Verify by checking that the renderer reports lfBypassActive = false.
     // We test this indirectly: process a 100 Hz sine through both and verify
     // the output characteristics match what we'd expect from full HRTF convolution.


### PR DESCRIPTION
## Summary

- Add +12 dB low-shelf biquad at 200 Hz for MIT KEMAR post-convolution bass compensation (Phase 3)
- Replaces mono bass injection approach that caused phantom center artifacts

## Context

MIT KEMAR's 1994 measurement has a 24 dB bass deficit at 50 Hz — inherent to the measurement, not IR length (SOFA has 512 samples but 99.5% of energy is in first 128). The low-shelf amplifies whatever LF content the HRTF captured at each direction, keeping bass spatialized.

Phases 1 (onset ITD) and 2 (great-circle threshold) were merged in PR #140.

## Changes

- `BinauralRenderer`: low-shelf biquad state + coefficients, active only for profile 1
- `renderSourceBuffers()`: per-source biquad applied after convolution, before ITD
- `correctLowFrequency()`: Xie 2009 static method retained for future use
- Tests updated for shelf approach

## Test Results

- A/B tested: user confirmed "worked remarkably well"
- 270 tests, 0 regressions from Phase 3
- Profile switch tests pass (shelf doesn't affect overall level)
- SADIE and Spatial confirmed identical (shelf inactive)

## Test plan
- [x] All ConvolverGlitchTests pass
- [x] Profile switch volume swell tests pass
- [x] A/B listening: Studio Reference bass restored
- [x] A/B listening: Immersive unchanged
- [x] A/B listening: Spatial unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)