### PR TITLE
Fix azimuth knobs rotating counter-clockwise on mousewheel (#157)

### DIFF
--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -117,17 +117,9 @@ public:
 
     void mouseWheelMove (const juce::MouseEvent& e, const juce::MouseWheelDetails& wheel) override
     {
-        if (reversed)
-        {
-            auto rw = wheel;
-            rw.deltaX = -wheel.deltaX;
-            rw.deltaY = -wheel.deltaY;
-            juce::Slider::mouseWheelMove (e, rw);
-        }
-        else
-        {
-            juce::Slider::mouseWheelMove (e, wheel);
-        }
+        // Proportion overrides already handle the reversed value mapping,
+        // so pass mousewheel through without negating deltas (fixes #157)
+        juce::Slider::mouseWheelMove (e, wheel);
     }
 
 private:


### PR DESCRIPTION
## Summary
- Removed delta negation in `ReverseSlider::mouseWheelMove()` — the proportion overrides already handle the reversed value mapping, so negating wheel deltas was double-inverting the input
- Per-tap AZIM and Global AZIM knobs now rotate clockwise on mousewheel up, matching all other knobs

Closes #157

## Test plan
- [x] Verified in REAPER with v1.0.21 build — mousewheel on AZIM knobs now matches all other knobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)