### PR TITLE
Fix E20: remove OSC Receive params from undo stack

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -2304,8 +2304,11 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
     oscToggleButton = std::make_unique<IndicatorToggle> ("RECEIVE", Colours_OSD::accentGreen,
                                                           osdLookAndFeel->jetbrainsMedium);
     addAndMakeVisible (*oscToggleButton);
-    oscToggleAttach = std::make_unique<ButtonAttachment> (processorRef.apvts, "admOscEnabled",
-                                                          *oscToggleButton);
+    oscToggleButton->setToggleState (processorRef.getOscReceiveEnabled(), juce::dontSendNotification);
+    oscToggleButton->onClick = [this]
+    {
+        processorRef.setOscReceiveEnabled (oscToggleButton->getToggleState());
+    };
 
     // v0.6: Editable OSC port label (single-click to edit, Enter to commit)
     oscPortLabel.setText (juce::String (processorRef.getOscReceivePort()), juce::dontSendNotification);
@@ -2353,6 +2356,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
     // --- v0.7: ADM-OSC Send toggle (IndicatorToggle) -------------------------
     oscSendToggleButton = std::make_unique<IndicatorToggle> ("SEND", Colours_OSD::accentGreen,
                                                               osdLookAndFeel->jetbrainsMedium);
+    oscSendToggleButton->setToggleState (processorRef.getOscSendEnabled(), juce::dontSendNotification);
     oscSendToggleButton->onClick = [this]
     {
         processorRef.setOscSendEnabled (oscSendToggleButton->getToggleState());

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -663,7 +663,7 @@ private:
     std::unique_ptr<ComboBoxAttachment> objTrajectoryDirAttach;  // v0.8
 
     // v0.6: ADM-OSC toggle attachment
-    std::unique_ptr<ButtonAttachment> oscToggleAttach;
+    // oscToggleAttach removed — oscReceiveEnabled is now non-APVTS (issue E20)
 
     void selectObject (int index);
     void updateObjectButtonColours();

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -386,11 +386,8 @@ juce::AudioProcessorValueTreeState::ParameterLayout
         juce::NormalisableRange<float> (0.0f, 100.0f, 0.1f), 0.0f,
         juce::AudioParameterFloatAttributes().withLabel ("%").withStringFromValueFunction (fmtPct100)));
 
-    // G18: OSC Receive (true=enabled, false=disabled; default OFF)
-    // [non-automatable: never automated, issue #122]
-    params.push_back (std::make_unique<juce::AudioParameterBool> (
-        juce::ParameterID ("admOscEnabled", 18), "OSC Receive", false,
-        juce::AudioParameterBoolAttributes().withAutomatable (false)));
+    // G18: OSC Receive moved to non-APVTS member (oscReceiveEnabled) — issue E20
+    // Removing from APVTS keeps it out of the DAW undo stack.
 
     // G19–G24: Global Tap Offsets (promoted from OSC-only atomics to APVTS)
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
@@ -1576,16 +1573,15 @@ void OpenSpatialDelayProcessor::timerCallback()
     }
 
     // --- v0.6: ADM-OSC connection management (edge-detect enable/disable) ---
-    bool admEnabled = cachedParam_admOscEnabled != nullptr
-                      && cachedParam_admOscEnabled->load() >= 0.5f;
-    if (admEnabled && ! prevAdmOscEnabled)
+    // oscReceiveEnabled is a plain member (not APVTS) so it stays out of the DAW undo stack (issue E20)
+    if (oscReceiveEnabled && ! prevOscReceiveEnabled)
     {
         // Transition OFF→ON: connect
         oscConnected = oscReceiver.connect (oscReceivePort);
         if (oscConnected)
             oscReceiver.addListener (this);
     }
-    else if (! admEnabled && prevAdmOscEnabled)
+    else if (! oscReceiveEnabled && prevOscReceiveEnabled)
     {
         // Transition ON→OFF: disconnect
         oscReceiver.disconnect();
@@ -1595,10 +1591,10 @@ void OpenSpatialDelayProcessor::timerCallback()
         for (int t = 0; t < MAX_OBJECTS; ++t)
             oscOverrideActive[t].store (false, std::memory_order_relaxed);
     }
-    prevAdmOscEnabled = admEnabled;
+    prevOscReceiveEnabled = oscReceiveEnabled;
 
     // --- v0.6: OSC override timeout (500ms since last receive → release override) ---
-    if (admEnabled)
+    if (oscReceiveEnabled)
     {
         double now = juce::Time::getMillisecondCounterHiRes();
         for (int t = 0; t < MAX_OBJECTS; ++t)
@@ -1820,7 +1816,7 @@ OpenSpatialDelayProcessor::OpenSpatialDelayProcessor()
     cachedParam_feedback        = apvts.getRawParameterValue ("feedback");
     cachedParam_inputGain       = apvts.getRawParameterValue ("inputGain");
     cachedParam_outputGain      = apvts.getRawParameterValue ("outputGain");
-    cachedParam_admOscEnabled   = apvts.getRawParameterValue ("admOscEnabled");
+    // admOscEnabled removed from APVTS — now oscReceiveEnabled member (issue E20)
     // issue #68: Cache global tap offset APVTS pointers
     cachedParam_globalTapAzimuth   = apvts.getRawParameterValue ("globalTapAzimuth");
     cachedParam_globalTapElevation = apvts.getRawParameterValue ("globalTapElevation");
@@ -1881,6 +1877,12 @@ OpenSpatialDelayProcessor::~OpenSpatialDelayProcessor()
 //==============================================================================
 // v0.6: OSC port change — reconnect if currently connected
 //==============================================================================
+void OpenSpatialDelayProcessor::setOscReceiveEnabled (bool enabled)
+{
+    oscReceiveEnabled = enabled;
+    // Connection lifecycle handled in processBlock via edge-detect
+}
+
 void OpenSpatialDelayProcessor::setOscReceivePort (int port)
 {
     if (port == oscReceivePort)
@@ -5544,6 +5546,7 @@ void OpenSpatialDelayProcessor::getStateInformation (juce::MemoryBlock& destData
     state.setProperty ("configHrtfProfile", configHrtfProfile.load (std::memory_order_relaxed), nullptr);
     state.setProperty ("configOutputFormat", configOutputFormat.load (std::memory_order_relaxed), nullptr);
     state.setProperty ("configInputFormat", configInputFormat.load (std::memory_order_relaxed), nullptr);
+    state.setProperty ("oscReceiveEnabled", oscReceiveEnabled, nullptr);  // v1.0: persist OSC receive enable (issue E20)
     state.setProperty ("oscReceivePort", oscReceivePort, nullptr);  // v0.6: persist OSC port
     state.setProperty ("globalDrawerOpen", globalDrawerOpen, nullptr);  // v1.0: persist drawer state
     state.setProperty ("currentPresetIndex", currentPresetIndex, nullptr);  // v0.6: persist preset selection
@@ -6118,8 +6121,17 @@ void OpenSpatialDelayProcessor::setStateInformation (const void* data, int sizeI
         tree.setProperty ("configAlgorithm", newAlgo, nullptr);
     }
 
-    // v0.6: Restore OSC receive port (non-APVTS property)
-    oscReceivePort = static_cast<int> (tree.getProperty ("oscReceivePort", 4002));
+    // v0.6: Restore OSC receive settings (non-APVTS properties, issue E20)
+    // Only restore on first call (project load) — skip on undo/redo to keep
+    // OSC receive settings out of the DAW undo stack.
+    if (! oscReceiveStateLoaded)
+    {
+        oscReceivePort = static_cast<int> (tree.getProperty ("oscReceivePort", 4002));
+        bool savedReceiveEnabled = static_cast<bool> (tree.getProperty ("oscReceiveEnabled", false));
+        if (savedReceiveEnabled)
+            setOscReceiveEnabled (true);
+        oscReceiveStateLoaded = true;
+    }
     globalDrawerOpen = static_cast<bool> (tree.getProperty ("globalDrawerOpen", false));
 
     // v0.6: Restore preset index (non-APVTS property)

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -678,7 +678,9 @@ public:
                ? oscOverrideActive[objectIndex].load (std::memory_order_relaxed) : false;
     }
 
-    // v0.6: OSC port configuration (editable from editor)
+    // v0.6: OSC receive configuration (editable from editor)
+    bool getOscReceiveEnabled() const { return oscReceiveEnabled; }
+    void setOscReceiveEnabled (bool enabled);
     int getOscReceivePort() const { return oscReceivePort; }
     void setOscReceivePort (int port);
 
@@ -864,8 +866,9 @@ private:
     int  oscReceivePort = 4002;                         // Default ADM-OSC receive port
     bool globalDrawerOpen = false;                      // v1.0: global tap drawer visibility
     bool oscConnected = false;                          // Current connection state
-    bool prevAdmOscEnabled = false;                     // Edge-detect for enable/disable transitions
-    std::atomic<float>* cachedParam_admOscEnabled = nullptr;
+    bool oscReceiveEnabled = false;                     // v1.0: OSC Receive enable (non-APVTS, issue E20)
+    bool prevOscReceiveEnabled = false;                 // Edge-detect for enable/disable transitions
+    bool oscReceiveStateLoaded = false;                 // E20: guard against undo restoring OSC receive settings
 
     //--- SPATIAL MEDIA LIBRARY: ADM-OSC Send state ---
     juce::OSCSender oscSender;

--- a/Tests/ParameterCountTests.cpp
+++ b/Tests/ParameterCountTests.cpp
@@ -3,12 +3,13 @@
 
 // Issue #68: Verify parameter count, naming, automatability, and ordering.
 // These tests catch regressions from parameter layout changes.
+// Issue E20: admOscEnabled removed from APVTS → 143 params (was 144), 79 non-automatable (was 80).
 
-TEST_CASE ("Parameter count is exactly 144", "[params]")
+TEST_CASE ("Parameter count is exactly 143", "[params]")
 {
     auto proc = std::make_unique<OpenSpatialDelayProcessor>();
     auto& params = proc->getParameters();
-    CHECK (params.size() == 144);
+    CHECK (params.size() == 143);
 }
 
 TEST_CASE ("All parameters have non-empty names", "[params]")
@@ -21,9 +22,10 @@ TEST_CASE ("All parameters have non-empty names", "[params]")
     }
 }
 
-// Issue #122: 80 params marked non-automatable to stay within Ableton's 64-param
+// Issue #122: 79 params marked non-automatable to stay within Ableton's 64-param
 // auto-populate threshold. Automatable: 16 global + 4 per-tap × 12 = 64.
-TEST_CASE ("64 automatable + 80 non-automatable", "[params]")
+// Issue E20: admOscEnabled (non-automatable) removed from APVTS → 79 non-automatable.
+TEST_CASE ("64 automatable + 79 non-automatable", "[params]")
 {
     auto proc = std::make_unique<OpenSpatialDelayProcessor>();
     int automatable = 0, nonAutomatable = 0;
@@ -35,7 +37,7 @@ TEST_CASE ("64 automatable + 80 non-automatable", "[params]")
             ++nonAutomatable;
     }
     CHECK (automatable == 64);
-    CHECK (nonAutomatable == 80);
+    CHECK (nonAutomatable == 79);
 }
 
 TEST_CASE ("Global params appear before per-tap params", "[params]")
@@ -43,18 +45,19 @@ TEST_CASE ("Global params appear before per-tap params", "[params]")
     auto proc = std::make_unique<OpenSpatialDelayProcessor>();
     auto& params = proc->getParameters();
 
-    // First 24 params are globals; index 24 should be "Tap 01 On"
-    REQUIRE (params.size() >= 25);
+    // First 23 params are globals; index 23 should be "Tap 01 On"
+    // (was 24 before admOscEnabled removed from APVTS in issue E20)
+    REQUIRE (params.size() >= 24);
     CHECK (params[0]->getName (256) == "Delay Time");
     CHECK (params[1]->getName (256) == "Delay Sync");
     CHECK (params[4]->getName (256) == "Feedback");
     CHECK (params[10]->getName (256) == "Dry/Wet");
-    CHECK (params[23]->getName (256) == "Global Tap Speed");
+    CHECK (params[22]->getName (256) == "Global Tap Speed");
 
-    // Per-tap: index 24 = Tap 01 On, 34 = Tap 02 On, etc.
-    CHECK (params[24]->getName (256) == "Tap 01 On");
-    CHECK (params[34]->getName (256) == "Tap 02 On");
-    CHECK (params[44]->getName (256) == "Tap 03 On");
+    // Per-tap: index 23 = Tap 01 On, 33 = Tap 02 On, etc.
+    CHECK (params[23]->getName (256) == "Tap 01 On");
+    CHECK (params[33]->getName (256) == "Tap 02 On");
+    CHECK (params[43]->getName (256) == "Tap 03 On");
 }
 
 TEST_CASE ("Per-tap params are grouped by tap", "[params]")
@@ -62,19 +65,19 @@ TEST_CASE ("Per-tap params are grouped by tap", "[params]")
     auto proc = std::make_unique<OpenSpatialDelayProcessor>();
     auto& params = proc->getParameters();
 
-    // Tap 01: indices 24-33 (10 params)
-    CHECK (params[24]->getName (256) == "Tap 01 On");
-    CHECK (params[25]->getName (256) == "Tap 01 Azimuth");
-    CHECK (params[26]->getName (256) == "Tap 01 Elevation");
-    CHECK (params[27]->getName (256) == "Tap 01 Distance");
-    CHECK (params[28]->getName (256) == "Tap 01 Doppler Amount");
-    CHECK (params[29]->getName (256) == "Tap 01 Pitch Shift");
-    CHECK (params[30]->getName (256) == "Tap 01 Trajectory Shape");
-    CHECK (params[31]->getName (256) == "Tap 01 Trajectory Speed");
-    CHECK (params[32]->getName (256) == "Tap 01 Trajectory Direction");
-    CHECK (params[33]->getName (256) == "Tap 01 Input Channel");
+    // Tap 01: indices 23-32 (10 params)
+    CHECK (params[23]->getName (256) == "Tap 01 On");
+    CHECK (params[24]->getName (256) == "Tap 01 Azimuth");
+    CHECK (params[25]->getName (256) == "Tap 01 Elevation");
+    CHECK (params[26]->getName (256) == "Tap 01 Distance");
+    CHECK (params[27]->getName (256) == "Tap 01 Doppler Amount");
+    CHECK (params[28]->getName (256) == "Tap 01 Pitch Shift");
+    CHECK (params[29]->getName (256) == "Tap 01 Trajectory Shape");
+    CHECK (params[30]->getName (256) == "Tap 01 Trajectory Speed");
+    CHECK (params[31]->getName (256) == "Tap 01 Trajectory Direction");
+    CHECK (params[32]->getName (256) == "Tap 01 Input Channel");
 
-    // Tap 12: indices 134-143 (last 10 params)
-    CHECK (params[134]->getName (256) == "Tap 12 On");
-    CHECK (params[143]->getName (256) == "Tap 12 Input Channel");
+    // Tap 12: indices 133-142 (last 10 params)
+    CHECK (params[133]->getName (256) == "Tap 12 On");
+    CHECK (params[142]->getName (256) == "Tap 12 Input Channel");
 }

--- a/tools/screenshot_tool.cpp
+++ b/tools/screenshot_tool.cpp
@@ -247,8 +247,7 @@ int main (int argc, char* argv[])
     }
 
     // ── Enable OSC Receive for visual completeness in screenshots ──────
-    if (auto* p = processor.apvts.getParameter ("admOscEnabled"))
-        p->setValueNotifyingHost (1.0f);
+    processor.setOscReceiveEnabled (true);
 
     // ── Create editor ────────────────────────────────────────────────────
     auto* editorRaw = processor.createEditor();


### PR DESCRIPTION
## Summary
- Move `admOscEnabled` from APVTS to plain member to stop DAW undo tracking
- Guard `oscReceivePort` restoration against undo/redo in `setStateInformation()`
- Fix OSC Send Enable not restoring on project reopen (editor toggle not synced)

Closes #165

## Test plan
- [x] OSC Receive Enable: Cmd+Z does NOT undo
- [x] OSC Receive Port: Cmd+Z does NOT undo
- [x] OSC Send Enable persists across project save/reload
- [x] 290/291 tests pass (1 pre-existing surround failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)