### PR TITLE
Fix OSC Send IP field IPv4 validation (#163)

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -2375,12 +2375,32 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         if (auto* ed = oscSendIPLabel.getCurrentTextEditor())
         {
             ed->setJustification (juce::Justification::centred);
+            ed->setInputFilter (new juce::TextEditor::LengthAndCharacterRestriction (15, "0123456789."), true);
             ed->setHighlightedRegion ({ 0, oscSendIPLabel.getText().length() });
         }
     };
     oscSendIPLabel.onTextChange = [this]
     {
-        processorRef.setOscSendIP (oscSendIPLabel.getText().trim());
+        auto text = oscSendIPLabel.getText().trim();
+        auto octets = juce::StringArray::fromTokens (text, ".", "");
+        bool valid = (octets.size() == 4);
+        if (valid)
+        {
+            for (auto& o : octets)
+            {
+                int val = o.getIntValue();
+                if (o.isEmpty() || o.length() > 3 || val < 0 || val > 255
+                    || (o.length() > 1 && o[0] == '0'))
+                {
+                    valid = false;
+                    break;
+                }
+            }
+        }
+        if (valid)
+            processorRef.setOscSendIP (text);
+        else
+            oscSendIPLabel.setText (processorRef.getOscSendIP(), juce::dontSendNotification);
     };
     addAndMakeVisible (oscSendIPLabel);
 


### PR DESCRIPTION
## Summary
- Added `InputFilter` to OSC Send IP field restricting input to digits and periods (max 15 chars)
- Added IPv4 validation on commit: 4 octets, each 0–255, no leading zeros
- Invalid input reverts to last valid IP address

## Test plan
- [x] Build v1.0.23 verified (AU + VST3)
- [x] 290/291 tests pass (1 pre-existing unrelated failure)
- [x] Manual testing confirmed fix in DAW

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>