### PR TITLE
Fix E14: OSC settings not persisted on save/reopen

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1880,6 +1880,7 @@ OpenSpatialDelayProcessor::~OpenSpatialDelayProcessor()
 void OpenSpatialDelayProcessor::setOscReceiveEnabled (bool enabled)
 {
     oscReceiveEnabled = enabled;
+    markConfigStateDirty();  // E14: notify DAW so state is re-captured on save
     // Connection lifecycle handled in processBlock via edge-detect
 }
 
@@ -1889,6 +1890,7 @@ void OpenSpatialDelayProcessor::setOscReceivePort (int port)
         return;
 
     oscReceivePort = port;
+    markConfigStateDirty();  // E14: notify DAW so state is re-captured on save
 
     // If currently connected, reconnect on the new port
     if (oscConnected)
@@ -1910,6 +1912,7 @@ void OpenSpatialDelayProcessor::setOscSendEnabled (bool enabled)
         return;
 
     oscSendEnabled = enabled;
+    markConfigStateDirty();  // E14: notify DAW so state is re-captured on save
     if (enabled)
     {
         oscSendConnected = oscSender.connect (oscSendIP, oscSendPort);
@@ -1926,6 +1929,7 @@ void OpenSpatialDelayProcessor::setOscSendPort (int port)
     if (port == oscSendPort)
         return;
     oscSendPort = port;
+    markConfigStateDirty();  // E14: notify DAW so state is re-captured on save
     if (oscSendEnabled)
     {
         oscSender.disconnect();
@@ -1938,6 +1942,7 @@ void OpenSpatialDelayProcessor::setOscSendIP (const juce::String& ip)
     if (ip == oscSendIP)
         return;
     oscSendIP = ip;
+    markConfigStateDirty();  // E14: notify DAW so state is re-captured on save
     if (oscSendEnabled)
     {
         oscSender.disconnect();
@@ -6137,12 +6142,16 @@ void OpenSpatialDelayProcessor::setStateInformation (const void* data, int sizeI
     // v0.6: Restore preset index (non-APVTS property)
     currentPresetIndex = static_cast<int> (tree.getProperty ("currentPresetIndex", 0));
 
-    // v0.7: Restore OSC Send settings
-    oscSendPort = static_cast<int> (tree.getProperty ("oscSendPort", 4003));
-    oscSendIP   = tree.getProperty ("oscSendIP", "127.0.0.1").toString();
-    bool savedSendEnabled = static_cast<bool> (tree.getProperty ("oscSendEnabled", false));
-    if (savedSendEnabled)
-        setOscSendEnabled (true);
+    // v0.7: Restore OSC Send settings (E14: guard against undo restoring send settings)
+    if (! oscSendStateLoaded)
+    {
+        oscSendPort = static_cast<int> (tree.getProperty ("oscSendPort", 4003));
+        oscSendIP   = tree.getProperty ("oscSendIP", "127.0.0.1").toString();
+        bool savedSendEnabled = static_cast<bool> (tree.getProperty ("oscSendEnabled", false));
+        if (savedSendEnabled)
+            setOscSendEnabled (true);
+        oscSendStateLoaded = true;
+    }
 
     apvts.replaceState (tree);
 }

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -873,6 +873,7 @@ private:
     //--- SPATIAL MEDIA LIBRARY: ADM-OSC Send state ---
     juce::OSCSender oscSender;
     bool oscSendEnabled = false;
+    bool oscSendStateLoaded = false;                    // E14: guard against undo restoring OSC send settings
     bool oscSendConnected = false;
     int  oscSendPort = 4003;
     juce::String oscSendIP = "127.0.0.1";


### PR DESCRIPTION
## Summary
- All 5 OSC setters (`setOscSendIP`, `setOscSendPort`, `setOscSendEnabled`, `setOscReceiveEnabled`, `setOscReceivePort`) now call `markConfigStateDirty()` so the DAW re-captures state via `updateHostDisplay()`
- Added `oscSendStateLoaded` guard in `setStateInformation` (mirrors `oscReceiveStateLoaded`) to protect Send settings from undo/redo resets

## Test plan
- [x] Build v1.0.22, load in REAPER
- [x] Change OSC Send IP, Port, and Enabled — save, close, reopen — all restored
- [x] Receive Port and Enabled still restore correctly
- [x] 290/291 tests pass (1 pre-existing bus layout failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)