### PR TITLE
Fix Global Tap knob UI sync after DAW undo (#164)

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1360,7 +1360,11 @@ void SpatialMapComponent::mouseDown (const juce::MouseEvent& e)
 {
     draggedObject = findObjectAt (e.position);
     if (draggedObject >= 0)
+    {
         listeners.call ([this](Listener& l) { l.objectSelected (draggedObject); });
+        // Issue E15: Signal drag start for gesture wrapping (undo grouping)
+        if (onDragStarted) onDragStarted (draggedObject);
+    }
 }
 
 void SpatialMapComponent::mouseDrag (const juce::MouseEvent& e)
@@ -1377,6 +1381,14 @@ void SpatialMapComponent::mouseDrag (const juce::MouseEvent& e)
     listeners.call ([this, azDeg, dist](Listener& l) {
         l.objectPositionChanged (draggedObject, azDeg, dist);
     });
+}
+
+void SpatialMapComponent::mouseUp (const juce::MouseEvent&)
+{
+    // Issue E15: Signal drag end for gesture wrapping (undo grouping)
+    if (draggedObject >= 0 && onDragEnded)
+        onDragEnded (draggedObject);
+    draggedObject = -1;
 }
 
 //==============================================================================
@@ -1603,6 +1615,10 @@ void FilterGraphComponent::mouseDown (const juce::MouseEvent& e)
 
     dragStartY = static_cast<float> (e.y);
     dragStartQ = (currentDrag == HP) ? hpQ : lpQ;
+
+    // Issue E15: Signal drag start for gesture wrapping (undo grouping)
+    if (currentDrag != None && onFilterDragStarted)
+        onFilterDragStarted();
 }
 
 void FilterGraphComponent::mouseDrag (const juce::MouseEvent& e)
@@ -1639,6 +1655,9 @@ void FilterGraphComponent::mouseDrag (const juce::MouseEvent& e)
 
 void FilterGraphComponent::mouseUp (const juce::MouseEvent&)
 {
+    // Issue E15: Signal drag end for gesture wrapping (undo grouping)
+    if (currentDrag != None && onFilterDragEnded)
+        onFilterDragEnded();
     currentDrag = None;
 }
 
@@ -1708,6 +1727,9 @@ void GlobalTapDrawerComponent::setupKnob (juce::Slider& s, juce::Label& l,
         if (onGlobalDelta && std::abs (delta) > 1e-6f)
             onGlobalDelta (knobIdx, delta);
     };
+    // Issue E15: Signal drag start/end for gesture wrapping (undo grouping)
+    s.onDragStart = [this, knobIdx] { if (onDragStarted) onDragStarted (knobIdx); };
+    s.onDragEnd   = [this, knobIdx] { if (onDragEnded)  onDragEnded (knobIdx); };
     prevValues[knobIdx] = static_cast<float> (s.getValue());  // sync tracking to initial value
 
     l.setText (name, juce::dontSendNotification);
@@ -1948,6 +1970,19 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
     // --- Spatial map ---------------------------------------------------------
     addAndMakeVisible (spatialMap);
     spatialMap.addListener (this);
+    // Issue E15: Gesture wrapping for spatial map drag (undo grouping)
+    spatialMap.onDragStarted = [this] (int objectIndex) {
+        auto prefix = "object" + juce::String (objectIndex + 1) + "_";
+        activeSpatialGestureParams[0] = processorRef.apvts.getParameter (prefix + "azimuth");
+        activeSpatialGestureParams[1] = processorRef.apvts.getParameter (prefix + "distance");
+        for (auto* p : activeSpatialGestureParams)
+            if (p != nullptr) p->beginChangeGesture();
+    };
+    spatialMap.onDragEnded = [this] (int /*objectIndex*/) {
+        for (auto* p : activeSpatialGestureParams)
+            if (p != nullptr) p->endChangeGesture();
+        activeSpatialGestureParams = { nullptr, nullptr };
+    };
     spatialMap.setProcessor (&processorRef);
 
     // --- Global tap drawer (overlays left edge of spatial map) ---------------
@@ -1966,6 +2001,41 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
                 globalTapDrawer.setKnobValueSilent (i, p->load());
         }
     }
+    // Issue E15: Begin gestures on all affected per-object params when a global knob drag starts
+    globalTapDrawer.onDragStarted = [this] (int knobIndex) {
+        static const char* suffixes[] = {
+            "azimuth", "elevation", "distance",
+            "pitchShift", "dopplerAmount", "trajectorySpeed"
+        };
+        if (knobIndex < 0 || knobIndex >= 6) return;
+        activeGlobalGestureParams.clear();
+        for (int i = 0; i < SpatialMapComponent::MAX_OBJECTS; ++i)
+        {
+            auto enabledId = "object" + juce::String (i + 1) + "_enabled";
+            if (processorRef.apvts.getRawParameterValue (enabledId)->load() < 0.5f)
+                continue;
+            auto paramId = "object" + juce::String (i + 1) + "_" + suffixes[knobIndex];
+            if (auto* param = processorRef.apvts.getParameter (paramId))
+            {
+                param->beginChangeGesture();
+                activeGlobalGestureParams.push_back (param);
+            }
+        }
+        // Also begin gesture on the globalTap APVTS param itself
+        static const char* tapParamIds[] = { "globalTapAzimuth", "globalTapElevation", "globalTapDistance",
+                                             "globalTapPitch",   "globalTapDoppler",   "globalTapSpeed" };
+        if (auto* param = processorRef.apvts.getParameter (tapParamIds[knobIndex]))
+        {
+            param->beginChangeGesture();
+            activeGlobalGestureParams.push_back (param);
+        }
+    };
+    // Issue E15: End gestures when global knob drag ends
+    globalTapDrawer.onDragEnded = [this] (int /*knobIndex*/) {
+        for (auto* param : activeGlobalGestureParams)
+            param->endChangeGesture();
+        activeGlobalGestureParams.clear();
+    };
     globalTapDrawer.onGlobalDelta = [this] (int idx, float delta) {
         applyGlobalTapDelta (idx, delta);
         // Sync absolute knob value to processor atomic (for OSC Send)
@@ -2175,7 +2245,11 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         if (newState) syncTripletButton->setToggleState (false, juce::dontSendNotification);
         int mode = newState ? 1 : 0;
         if (auto* param = processorRef.apvts.getParameter ("syncMode"))
+        {
+            param->beginChangeGesture();
             param->setValueNotifyingHost (param->convertTo0to1 ((float) mode));
+            param->endChangeGesture();
+        }
         repaint();
     };
     // Triplet button: toggle → set syncMode to 2 (Triplet) or 0 (Straight)
@@ -2185,7 +2259,11 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         if (newState) syncDottedButton->setToggleState (false, juce::dontSendNotification);
         int mode = newState ? 2 : 0;
         if (auto* param = processorRef.apvts.getParameter ("syncMode"))
+        {
+            param->beginChangeGesture();
             param->setValueNotifyingHost (param->convertTo0to1 ((float) mode));
+            param->endChangeGesture();
+        }
         repaint();
     };
 
@@ -2422,8 +2500,10 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         auto* fltParam = processorRef.apvts.getParameter ("filterEnabled");
         if (fltParam != nullptr)
         {
+            fltParam->beginChangeGesture();
             float current = processorRef.apvts.getRawParameterValue ("filterEnabled")->load();
             fltParam->setValueNotifyingHost (current < 0.5f ? 1.0f : 0.0f);
+            fltParam->endChangeGesture();
         }
     };
     addAndMakeVisible (*fltToggle);
@@ -2442,8 +2522,10 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         auto* param = processorRef.apvts.getParameter ("wobbleEnabled");
         if (param != nullptr)
         {
+            param->beginChangeGesture();
             float cur = processorRef.apvts.getRawParameterValue ("wobbleEnabled")->load();
             param->setValueNotifyingHost (cur > 0.5f ? 0.0f : 1.0f);
+            param->endChangeGesture();
         }
     };
     addAndMakeVisible (*modToggle);
@@ -2471,6 +2553,24 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         if (auto* param = processorRef.apvts.getParameter ("filterLPQ"))
             param->setValueNotifyingHost (param->convertTo0to1 (q));
         repaint();  // update painted readout
+    };
+    // Issue E15: Gesture wrapping for filter graph drag (undo grouping)
+    filterGraph.onFilterDragStarted = [this] {
+        activeFilterGestureParams.clear();
+        // Begin gestures on all 4 filter params — both freq and Q may change during a drag
+        for (const char* id : { "filterHP", "filterLP", "filterHPQ", "filterLPQ" })
+        {
+            if (auto* param = processorRef.apvts.getParameter (id))
+            {
+                param->beginChangeGesture();
+                activeFilterGestureParams.push_back (param);
+            }
+        }
+    };
+    filterGraph.onFilterDragEnded = [this] {
+        for (auto* param : activeFilterGestureParams)
+            param->endChangeGesture();
+        activeFilterGestureParams.clear();
     };
 
     // --- v0.7: Per-object pitch shift knob (bottom panel) --------------------
@@ -2923,11 +3023,24 @@ void OpenSpatialDelayEditor::resetGlobalTapAPVTSParams()
 {
     static const char* tapParamIds[] = { "globalTapAzimuth", "globalTapElevation", "globalTapDistance",
                                          "globalTapPitch",   "globalTapDoppler",   "globalTapSpeed" };
+    // Issue E15: Wrap in gestures so the host groups the reset as one undo entry
+    std::array<juce::RangedAudioParameter*, 6> gestures {};
+    for (int i = 0; i < OpenSpatialDelayProcessor::kNumGlobalTapOffsets; ++i)
+    {
+        gestures[static_cast<size_t> (i)] = processorRef.apvts.getParameter (tapParamIds[i]);
+        if (gestures[static_cast<size_t> (i)] != nullptr)
+            gestures[static_cast<size_t> (i)]->beginChangeGesture();
+    }
     for (int i = 0; i < OpenSpatialDelayProcessor::kNumGlobalTapOffsets; ++i)
     {
         processorRef.globalTapOffset[i].store (0.0f, std::memory_order_relaxed);
-        if (auto* param = processorRef.apvts.getParameter (tapParamIds[i]))
-            param->setValueNotifyingHost (param->convertTo0to1 (0.0f));
+        if (gestures[static_cast<size_t> (i)] != nullptr)
+            gestures[static_cast<size_t> (i)]->setValueNotifyingHost (gestures[static_cast<size_t> (i)]->convertTo0to1 (0.0f));
+    }
+    for (int i = 0; i < OpenSpatialDelayProcessor::kNumGlobalTapOffsets; ++i)
+    {
+        if (gestures[static_cast<size_t> (i)] != nullptr)
+            gestures[static_cast<size_t> (i)]->endChangeGesture();
     }
 }
 

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -3066,6 +3066,27 @@ void OpenSpatialDelayEditor::syncGlobalTapOffsetsFromOSC()
     }
 }
 
+// issue #164: Sync global tap knobs from APVTS on host undo / external param change.
+// Unlike syncGlobalTapOffsetsFromOSC(), this does NOT call applyGlobalTapDelta() —
+// per-object params are already correct after undo, we only need the UI + atomics.
+void OpenSpatialDelayEditor::syncGlobalTapKnobsFromAPVTS()
+{
+    static const char* tapParamIds[] = { "globalTapAzimuth", "globalTapElevation", "globalTapDistance",
+                                         "globalTapPitch",   "globalTapDoppler",   "globalTapSpeed" };
+    for (int i = 0; i < GlobalTapDrawerComponent::kNumKnobs; ++i)
+    {
+        auto* rawParam = processorRef.apvts.getRawParameterValue (tapParamIds[i]);
+        if (rawParam == nullptr) continue;
+        float apvtsVal = rawParam->load();
+        float knobVal  = globalTapDrawer.getKnobValue (i);
+        if (std::abs (apvtsVal - knobVal) > 1e-6f)
+        {
+            globalTapDrawer.setKnobValueSilent (i, apvtsVal);
+            processorRef.globalTapOffset[i].store (apvtsVal, std::memory_order_relaxed);
+        }
+    }
+}
+
 void OpenSpatialDelayEditor::syncForScreenshot()
 {
     updateMapFromParameters();
@@ -3342,6 +3363,9 @@ void OpenSpatialDelayEditor::timerCallback()
     {
         syncGlobalTapOffsetsFromOSC();
     }
+
+    // issue #164: Sync knobs from APVTS on host undo / external param change
+    syncGlobalTapKnobsFromAPVTS();
 
     repaint();
 }

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -552,6 +552,7 @@ private:
     void applyGlobalTapDelta (int knobIndex, float delta);  // v1.0: IEM-style delta application
     void resetGlobalTapAPVTSParams();                       // issue #95: zero APVTS + atomics on preset change
     void syncGlobalTapOffsetsFromOSC();                     // v1.0: processor → editor OSC sync
+    void syncGlobalTapKnobsFromAPVTS();                    // issue #164: sync knobs from APVTS on undo
 
     // Global controls — ordered by signal flow
     juce::Slider inputGainSlider, outputGainSlider;

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -23,6 +23,7 @@ public:
     void paint (juce::Graphics& g) override;
     void mouseDown (const juce::MouseEvent& e) override;
     void mouseDrag (const juce::MouseEvent& e) override;
+    void mouseUp (const juce::MouseEvent& e) override;
 
     void setObjectState (int index, float azimuthDeg, float elevationDeg,
                          float distance, bool enabled);
@@ -31,6 +32,10 @@ public:
 
     void addListener (Listener* l)    { listeners.add (l); }
     void removeListener (Listener* l) { listeners.remove (l); }
+
+    // Callbacks: fired on object drag start/end — used for gesture wrapping (issue E15)
+    std::function<void (int objectIndex)> onDragStarted;
+    std::function<void (int objectIndex)> onDragEnded;
 
 private:
     struct ObjectInfo
@@ -272,6 +277,10 @@ public:
     /** Callback when user drags LP Q vertically. */
     std::function<void (float q)> onLPQChanged;
 
+    // Callbacks: fired on filter handle drag start/end — used for gesture wrapping (issue E15)
+    std::function<void()> onFilterDragStarted;
+    std::function<void()> onFilterDragEnded;
+
     /** Enable/disable the filter display (dims when off). */
     void setEnabled (bool enabled) { filterEnabled = enabled; repaint(); }
 
@@ -443,6 +452,9 @@ public:
     std::function<void (int knobIndex, float delta)> onGlobalDelta;
     // Callback: fired when drawer toggles open/close (called on each animation frame)
     std::function<void()> onToggle;
+    // Callbacks: fired on knob drag start/end — used for gesture wrapping (issue E15)
+    std::function<void (int knobIndex)> onDragStarted;
+    std::function<void (int knobIndex)> onDragEnded;
 
     static constexpr int kClosedWidth = 14;
     static constexpr int kOpenWidth   = 78;
@@ -679,6 +691,11 @@ private:
 
     // v0.9: Filter active state — driven by filterEnabled parameter
     bool filterIsActive = false;  // default OFF (matches filterEnabled param default)
+
+    // Issue E15: Gesture tracking for undo grouping
+    std::vector<juce::RangedAudioParameter*> activeGlobalGestureParams;   // Global Tap Drawer drag
+    std::array<juce::RangedAudioParameter*, 2> activeSpatialGestureParams { nullptr, nullptr }; // Spatial Map drag
+    std::vector<juce::RangedAudioParameter*> activeFilterGestureParams;   // Filter Graph drag
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (OpenSpatialDelayEditor)
 };

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -6163,6 +6163,20 @@ void OpenSpatialDelayProcessor::setStateInformation (const void* data, int sizeI
         setOscSendEnabled (true);
 
     apvts.replaceState (tree);
+
+    // issue #164: Sync global tap offset atomics from restored APVTS values.
+    // Without this, atomics are stale after undo and OSC Send uses old values.
+    // Do NOT set globalTapOffsetChanged — that would trigger syncGlobalTapOffsetsFromOSC
+    // which re-applies deltas to per-object params (incorrect for undo).
+    {
+        static const char* ids[] = { "globalTapAzimuth", "globalTapElevation", "globalTapDistance",
+                                     "globalTapPitch",   "globalTapDoppler",   "globalTapSpeed" };
+        for (int i = 0; i < kNumGlobalTapOffsets; ++i)
+        {
+            if (auto* p = apvts.getRawParameterValue (ids[i]))
+                globalTapOffset[i].store (p->load(), std::memory_order_relaxed);
+        }
+    }
 }
 
 //==============================================================================

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1973,6 +1973,32 @@ void OpenSpatialDelayProcessor::loadPreset (int index)
 
     const PresetData* preset = &allPresets[static_cast<size_t> (index)];
 
+    // Issue E15: Begin gestures on all params we're about to set, so the host
+    // groups the entire preset load into a single undo entry.
+    std::vector<juce::RangedAudioParameter*> presetGestures;
+    auto beginGesture = [&] (const juce::String& paramId) {
+        if (auto* p = apvts.getParameter (paramId))
+        {
+            p->beginChangeGesture();
+            presetGestures.push_back (p);
+        }
+    };
+
+    // Collect all params that will be set
+    for (const char* id : { "delayTime", "tempoSync", "noteDivision", "syncMode",
+                            "feedback", "filterLP", "filterHP", "filterLPQ", "filterHPQ",
+                            "dryWet", "inputGain", "outputGain", "airAbsorption",
+                            "filterEnabled", "wobbleEnabled", "wobbleAmount", "wobbleMorph" })
+        beginGesture (id);
+    for (int i = 0; i < MAX_OBJECTS; ++i)
+    {
+        auto prefix = "object" + juce::String (i + 1) + "_";
+        for (const char* suffix : { "enabled", "azimuth", "elevation", "distance",
+                                    "dopplerAmount", "pitchShift", "trajectoryShape",
+                                    "trajectorySpeed", "trajectoryDirection", "inputChannel" })
+            beginGesture (prefix + suffix);
+    }
+
     // Helpers — use convertTo0to1() to handle skewed NormalisableRanges correctly
     auto setFloat = [&] (const juce::String& paramId, float value) {
         if (auto* p = apvts.getParameter (paramId))
@@ -2029,6 +2055,10 @@ void OpenSpatialDelayProcessor::loadPreset (int index)
         setChoice (prefix + "trajectoryDirection", tap.trajectoryDirection);
         setChoice (prefix + "inputChannel",        tap.inputChannel);
     }
+
+    // Issue E15: End all gestures — host groups the entire preset load as one undo entry
+    for (auto* p : presetGestures)
+        p->endChangeGesture();
 
     // v1.0.1: Reset trajectory state FIRST so processBlock doesn't read stale
     // animated positions from the old preset while prevAzimuth already points to

--- a/Tests/IntegrationTests.cpp
+++ b/Tests/IntegrationTests.cpp
@@ -498,3 +498,35 @@ TEST_CASE ("State -- global tap APVTS params survive roundtrip (issue #95)", "[s
                  == Catch::Approx (2.5f).margin (0.02f));
     }
 }
+
+TEST_CASE ("State -- global tap atomics sync after setStateInformation (issue #164)", "[state]")
+{
+    juce::MemoryBlock stateData;
+
+    // Save state with non-zero global tap values
+    {
+        auto proc = std::make_unique<Proc>();
+        proc->prepareToPlay (kSampleRate, kBlockSize);
+        setParam (*proc, "globalTapAzimuth",   45.0f);
+        setParam (*proc, "globalTapElevation", -30.0f);
+        setParam (*proc, "globalTapDistance",    0.5f);
+        setParam (*proc, "globalTapPitch",     -12.0f);
+        setParam (*proc, "globalTapDoppler",    50.0f);
+        setParam (*proc, "globalTapSpeed",       2.5f);
+        proc->getStateInformation (stateData);
+    }
+
+    // Restore — atomics must match restored APVTS values (not stale zeros)
+    {
+        auto proc = std::make_unique<Proc>();
+        proc->prepareToPlay (kSampleRate, kBlockSize);
+        proc->setStateInformation (stateData.getData(), static_cast<int> (stateData.getSize()));
+
+        REQUIRE_THAT (proc->globalTapOffset[0].load(), Catch::Matchers::WithinAbs (45.0, 0.2));
+        REQUIRE_THAT (proc->globalTapOffset[1].load(), Catch::Matchers::WithinAbs (-30.0, 0.2));
+        REQUIRE_THAT (proc->globalTapOffset[2].load(), Catch::Matchers::WithinAbs (0.5, 0.02));
+        REQUIRE_THAT (proc->globalTapOffset[3].load(), Catch::Matchers::WithinAbs (-12.0, 1.0));
+        REQUIRE_THAT (proc->globalTapOffset[4].load(), Catch::Matchers::WithinAbs (50.0, 0.2));
+        REQUIRE_THAT (proc->globalTapOffset[5].load(), Catch::Matchers::WithinAbs (2.5, 0.02));
+    }
+}


### PR DESCRIPTION
## Summary
- Cherry-picks gesture wrapping from `d03573c` — wraps all programmatic `setValueNotifyingHost()` calls in `beginChangeGesture()`/`endChangeGesture()` for proper DAW undo grouping
- Adds `syncGlobalTapKnobsFromAPVTS()` — timer-based APVTS comparison that syncs knob UI + processor atomics after host undo without re-applying deltas to per-object params
- Syncs `globalTapOffset[]` atomics in `setStateInformation()` after `replaceState()`
- Adds test: global tap atomics sync after state restore

Closes #164

## Test plan
- [x] All 7 manual undo tests pass in REAPER (v1.0.21 / O121)
- [x] New automated test passes: `State -- global tap atomics sync after setStateInformation`
- [x] All 292 tests pass (1 pre-existing surround layout failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)