### PR TITLE
Factory Preset: POG in Space (#187)

### DIFF
--- a/Source/PresetData.cpp
+++ b/Source/PresetData.cpp
@@ -719,7 +719,7 @@ const PresetData factoryPresets[NUM_FACTORY_PRESETS] =
     // 44: POG in Space — EHX POG-inspired spatial harmonizer, diagonal 3D cross
     {
         "POG in Space", "Creative + Experimental",
-        1.1f, false, 4.0f, 0, 0.0f, 20000.0f, 20.0f, 0.707f, 0.707f, 1.0f, 1.3f, 0.0f,
+        1.1f, false, 4.0f, 0, 0.0f, 20000.0f, 20.0f, 0.707f, 0.707f, 1.0f, 1.0f, 0.0f,
         false, false, false, 0.0f, 0.0f, 1, 0,
         {
             { true,    0.0f,    0.0f, 0.25f, 0.0f,   0.0f, 0, 1.0f, 0, 0 /*L+R*/ },  // Unison: center

--- a/Source/PresetData.cpp
+++ b/Source/PresetData.cpp
@@ -722,11 +722,11 @@ const PresetData factoryPresets[NUM_FACTORY_PRESETS] =
         1.1f, false, 4.0f, 0, 0.0f, 20000.0f, 20.0f, 0.707f, 0.707f, 1.0f, 1.3f, 0.0f,
         false, false, false, 0.0f, 0.0f, 1, 0,
         {
-            { true,    0.0f,    0.0f, 0.25f, 0.0f,   0.0f, 0, 1.0f, 0, 1 /*L*/ },  // Unison: center
+            { true,    0.0f,    0.0f, 0.25f, 0.0f,   0.0f, 0, 1.0f, 0, 0 /*L+R*/ },  // Unison: center
             { true,   45.0f,   45.0f, 0.5f,  0.0f,  12.0f, 0, 1.0f, 0, 1 /*L*/ },  // +12st: upper-right
-            { true,  -22.5f,   22.5f, 0.5f,  0.0f,   7.0f, 0, 1.0f, 0, 1 /*L*/ },  // +7st: upper-left
+            { true,  -22.5f,   22.5f, 0.5f,  0.0f,   7.0f, 0, 1.0f, 0, 2 /*R*/ },  // +7st: upper-left
             { true,   22.5f,  -22.5f, 0.5f,  0.0f,  -5.0f, 0, 1.0f, 0, 1 /*L*/ },  // -5st: lower-right
-            { true,  -45.0f,  -45.0f, 0.5f,  0.0f, -12.0f, 0, 1.0f, 0, 1 /*L*/ },  // -12st: lower-left
+            { true,  -45.0f,  -45.0f, 0.5f,  0.0f, -12.0f, 0, 1.0f, 0, 2 /*R*/ },  // -12st: lower-left
             {}, {}, {}, {}, {}, {}, {}
         }
     },

--- a/Source/PresetData.cpp
+++ b/Source/PresetData.cpp
@@ -716,17 +716,18 @@ const PresetData factoryPresets[NUM_FACTORY_PRESETS] =
             {}, {}, {}, {}, {}, {}
         }
     },
-    // 44: Stereo Split — L input left, R input right
+    // 44: POG in Space — EHX POG-inspired spatial harmonizer, diagonal 3D cross
     {
-        "Stereo Split", "Creative + Experimental",
-        400.0f, false, 4.0f, 0, 0.45f, 10000.0f, 100.0f, 0.707f, 0.707f, 0.5f, 0.0f, 0.0f,
-        false, true, false, 0.0f, 0.0f, 5 /*VBAP*/, 0,
+        "POG in Space", "Creative + Experimental",
+        1.1f, false, 4.0f, 0, 0.0f, 20000.0f, 20.0f, 0.707f, 0.707f, 1.0f, 1.3f, 0.0f,
+        false, false, false, 0.0f, 0.0f, 1, 0,
         {
-            { true, -90.0f,  10.0f, 0.4f, 0.0f, 0.0f, 0, 1.0f, 0, 2 /*R*/ },
-            { true, -45.0f,   0.0f, 0.5f, 0.0f, 0.0f, 0, 1.0f, 0, 2 /*R*/ },
-            { true,  45.0f,   0.0f, 0.5f, 0.0f, 0.0f, 0, 1.0f, 0, 1 /*L*/ },
-            { true,  90.0f,  10.0f, 0.4f, 0.0f, 0.0f, 0, 1.0f, 0, 1 /*L*/ },
-            {}, {}, {}, {}, {}, {}, {}, {}
+            { true,    0.0f,    0.0f, 0.25f, 0.0f,   0.0f, 0, 1.0f, 0, 1 /*L*/ },  // Unison: center
+            { true,   45.0f,   45.0f, 0.5f,  0.0f,  12.0f, 0, 1.0f, 0, 1 /*L*/ },  // +12st: upper-right
+            { true,  -22.5f,   22.5f, 0.5f,  0.0f,   7.0f, 0, 1.0f, 0, 1 /*L*/ },  // +7st: upper-left
+            { true,   22.5f,  -22.5f, 0.5f,  0.0f,  -5.0f, 0, 1.0f, 0, 1 /*L*/ },  // -5st: lower-right
+            { true,  -45.0f,  -45.0f, 0.5f,  0.0f, -12.0f, 0, 1.0f, 0, 1 /*L*/ },  // -12st: lower-left
+            {}, {}, {}, {}, {}, {}, {}
         }
     },
     // 45: Pitch Ladder — ascending per-tap pitch: +2 to +12 semitones


### PR DESCRIPTION
## Summary
- Replaces factory preset #44 (Stereo Split) with **POG in Space** — a spatial harmonizer inspired by the EHX POG pedal
- 5 pitch-shifted taps (−12, −5, 0, +7, +12 semitones) in a diagonal 3D cross at 1.1ms delay
- Tested and verified in build v1.0.26 / O126

Closes #187

## Test plan
- [x] Build compiles cleanly
- [x] 291/292 tests pass (1 pre-existing surround layout failure)
- [x] Preset loads in DAW, all 5 voices fuse into spatial chord
- [x] Input channels route correctly (L+R unison, alternating L/R on shifted taps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)