### PR TITLE
Fix developer name in DAW: SpatialMediaLibrary → Spatial Media Lab

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ else()
 endif()
 
 juce_add_plugin(OpenSpatialDelay
-    COMPANY_NAME "SpatialMediaLibrary"
+    COMPANY_NAME "Spatial Media Lab"
     IS_SYNTH FALSE
     NEEDS_MIDI_INPUT FALSE
     NEEDS_MIDI_OUTPUT FALSE
@@ -230,7 +230,7 @@ if(BUILD_OSD_TESTS)
         JucePlugin_IsMidiEffect=0
         JucePlugin_ManufacturerCode=0x536d6c69
         JucePlugin_PluginCode=0x4f733130
-        JucePlugin_Manufacturer="SpatialMediaLibrary"
+        JucePlugin_Manufacturer="Spatial Media Lab"
         JucePlugin_Version=1.0.0
         JucePlugin_VersionString="1.0.0"
         JucePlugin_VersionCode=0x10000
@@ -252,8 +252,8 @@ if(BUILD_OSD_TESTS)
         JucePlugin_AUExportPrefix=OSDTestAU
         JucePlugin_AUExportPrefixQuoted="OSDTestAU"
         JucePlugin_AUManufacturerCode=JucePlugin_ManufacturerCode
-        JucePlugin_CFBundleIdentifier=com.SpatialMediaLibrary.OpenSpatialDelay
-        JucePlugin_AAXIdentifier=com.SpatialMediaLibrary.OpenSpatialDelay
+        JucePlugin_CFBundleIdentifier=com.spatialmedialab.OpenSpatialDelay
+        JucePlugin_AAXIdentifier=com.spatialmedialab.OpenSpatialDelay
         JucePlugin_AAXManufacturerCode=JucePlugin_ManufacturerCode
         JucePlugin_AAXProductId=JucePlugin_PluginCode
         JucePlugin_AAXCategory=0
@@ -316,7 +316,7 @@ target_compile_definitions(screenshot_tool PRIVATE
     JucePlugin_IsMidiEffect=0
     JucePlugin_ManufacturerCode=0x536d6c69
     JucePlugin_PluginCode=0x4f733130
-    JucePlugin_Manufacturer="SpatialMediaLibrary"
+    JucePlugin_Manufacturer="Spatial Media Lab"
     JucePlugin_Version=1.0.0
     JucePlugin_VersionString="1.0.0"
     JucePlugin_VersionCode=0x10000
@@ -338,8 +338,8 @@ target_compile_definitions(screenshot_tool PRIVATE
     JucePlugin_AUExportPrefix=OSDScreenshotAU
     JucePlugin_AUExportPrefixQuoted="OSDScreenshotAU"
     JucePlugin_AUManufacturerCode=JucePlugin_ManufacturerCode
-    JucePlugin_CFBundleIdentifier=com.SpatialMediaLibrary.OpenSpatialDelay
-    JucePlugin_AAXIdentifier=com.SpatialMediaLibrary.OpenSpatialDelay
+    JucePlugin_CFBundleIdentifier=com.spatialmedialab.OpenSpatialDelay
+    JucePlugin_AAXIdentifier=com.spatialmedialab.OpenSpatialDelay
     JucePlugin_AAXManufacturerCode=JucePlugin_ManufacturerCode
     JucePlugin_AAXProductId=JucePlugin_PluginCode
     JucePlugin_AAXCategory=0

--- a/scripts/build_version.sh
+++ b/scripts/build_version.sh
@@ -54,7 +54,7 @@ sed -i '' "s/PRODUCT_NAME \"OpenSpatialDelay v1.0\"/PRODUCT_NAME \"${PLUGIN_NAME
 
 # v1.0.7: Compute unique bundle ID suffix for post-build plist patching (issue #62)
 BUNDLE_SUFFIX=$(echo "${VERSION}" | tr '.' '-')  # e.g., v1.0.7 → v1-0-7
-UNIQUE_BUNDLE_ID="com.SpatialMediaLibrary.OpenSpatialDelay.${BUNDLE_SUFFIX}"
+UNIQUE_BUNDLE_ID="com.spatialmedialab.OpenSpatialDelay.${BUNDLE_SUFFIX}"
 
 # Step 3: Patch install script with version-specific name
 sed -i '' "s/PLUGIN_NAME=\"OpenSpatialDelay v1.0\"/PLUGIN_NAME=\"${PLUGIN_NAME}\"/" scripts/install_plugins.sh


### PR DESCRIPTION
## Summary
- Fixes developer/manufacturer name displayed in DAWs from `SpatialMediaLibrary` (the suite name, no spaces) to `Spatial Media Lab` (the correct company name)
- Updates `COMPANY_NAME`, `JucePlugin_Manufacturer`, bundle IDs (`com.SpatialMediaLibrary` → `com.spatialmedialab`), and `build_version.sh`
- Leaves `PLUGIN_MANUFACTURER_CODE Smli` (internal 4-char code) and SPECIFICATION.md suite code identifiers unchanged

## Test plan
- [x] Build succeeds (AU + VST3)
- [x] All 292 tests pass (110,209 assertions)
- [ ] Verify DAW plugin browser shows "Spatial Media Lab" as developer name

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)