### PR TITLE
Issue #182/#200: Fix all remaining undo failures (v1.0.36)

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -2096,6 +2096,8 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
     delayTimeSlider.onDragEnd   = makeGestureEndHandler ("delayTime");
     feedbackSlider.onDragStart  = makeDragStartHandler();
     feedbackSlider.onDragEnd    = makeGestureEndHandler ("feedback");
+    noteDivisionSlider.onDragStart = makeDragStartHandler();
+    noteDivisionSlider.onDragEnd   = makeGestureEndHandler ("noteDivision");
     addKnob (filterHPSlider,   filterHPLabel,   "HP",       "filterHP",   filterHPAttach);
     addKnob (filterLPSlider,   filterLPLabel,   "LP",       "filterLP",   filterLPAttach);
     addKnob (dryWetSlider,     dryWetLabel,     "DRY/WET",  "dryWet",     dryWetAttach);
@@ -2245,11 +2247,26 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
     tempoSyncButton = std::make_unique<StyledButton> ("SYNC", Colours_OSD::accentSync,
                                                        osdLookAndFeel->jetbrainsMedium);
     tempoSyncButton->setAlwaysActive (true);
+    tempoSyncButton->setClickingTogglesState (false);  // Issue E15b: timer drives visual state
     addAndMakeVisible (*tempoSyncButton);
-    tempoSyncAttach = std::make_unique<ButtonAttachment> (processorRef.apvts, "tempoSync", *tempoSyncButton);
+
+    // Issue E15b: Manual gesture brackets instead of ButtonAttachment (prevents double-undo)
+    tempoSyncButton->onClick = [this]
+    {
+        auto* syncParam = processorRef.apvts.getParameter ("tempoSync");
+        if (syncParam != nullptr)
+        {
+            syncParam->beginChangeGesture();
+            float current = processorRef.apvts.getRawParameterValue ("tempoSync")->load();
+            syncParam->setValueNotifyingHost (current < 0.5f ? 1.0f : 0.0f);
+            syncParam->endChangeGesture();
+            processorRef.notifyHostStateChanged();
+            processorRef.captureUndoState ("Toggle Tempo Sync");
+        }
+    };
 
     auto updateSyncUI = [this] {
-        bool isSynced = tempoSyncButton->getToggleState();
+        bool isSynced = processorRef.apvts.getRawParameterValue ("tempoSync")->load() > 0.5f;
         delayTimeSlider.setVisible (!isSynced);
         noteDivisionSlider.setVisible (isSynced);
         syncModeBox.setVisible (false);  // hidden — replaced by toggle buttons
@@ -2267,7 +2284,9 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         noteDivisionSlider.setColour (juce::Slider::thumbColourId, knobCol);
     };
 
-    tempoSyncButton->onStateChange = updateSyncUI;
+    // Issue E15b: call once to initialize UI, then timer drives updates
+    updateSyncUI();
+    tempoSyncUpdateUI = updateSyncUI;  // store for timer-driven refresh
 
     // v0.7: Dotted/Triplet toggle buttons (mutually exclusive, radio-style)
     syncDottedButton = std::make_unique<StyledButton> ("", Colours_OSD::accentSync,
@@ -2407,16 +2426,22 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         objTrajectoryDirBox.setSelectedId (1, juce::sendNotificationSync);
         objTrajectoryFwdButton->setToggleState (true, juce::dontSendNotification);
         objTrajectoryRevButton->setToggleState (false, juce::dontSendNotification);
+        processorRef.captureUndoState ("Change Trajectory Direction");
     };
     objTrajectoryRevButton->onClick = [this] {
         objTrajectoryDirBox.setSelectedId (2, juce::sendNotificationSync);
         objTrajectoryRevButton->setToggleState (true, juce::dontSendNotification);
         objTrajectoryFwdButton->setToggleState (false, juce::dontSendNotification);
+        processorRef.captureUndoState ("Change Trajectory Direction");
     };
     objTrajectoryDirBox.onChange = [this] {
         int sel = objTrajectoryDirBox.getSelectedId();  // 1=Forward, 2=Reverse
         if (objTrajectoryFwdButton) objTrajectoryFwdButton->setToggleState (sel == 1, juce::dontSendNotification);
         if (objTrajectoryRevButton) objTrajectoryRevButton->setToggleState (sel == 2, juce::dontSendNotification);
+    };
+
+    objTrajectoryBox.onChange = [this] {
+        processorRef.captureUndoState ("Change Trajectory Shape");
     };
 
     styleSlider (objTrajectorySpeedSlider, *osdLookAndFeel, juce::Slider::RotaryVerticalDrag);
@@ -2713,6 +2738,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
             int cur = objInputChannelBox.getSelectedId();
             int next = (cur >= 3) ? 1 : cur + 1;
             objInputChannelBox.setSelectedId (next, juce::sendNotificationSync);
+            processorRef.captureUndoState ("Change Input Channel");
         };
     }
 
@@ -3530,6 +3556,17 @@ void OpenSpatialDelayEditor::timerCallback()
         {
             bool airActive = processorRef.apvts.getRawParameterValue ("airAbsorption")->load() > 0.5f;
             airAbsorptionButton->setToggleState (airActive, juce::dontSendNotification);
+        }
+
+        // Issue E15b: Sync tempoSync button visual state + UI (no ButtonAttachment)
+        if (tempoSyncButton && tempoSyncUpdateUI)
+        {
+            bool synced = processorRef.apvts.getRawParameterValue ("tempoSync")->load() > 0.5f;
+            if (tempoSyncButton->getToggleState() != synced)
+            {
+                tempoSyncButton->setToggleState (synced, juce::dontSendNotification);
+                tempoSyncUpdateUI();
+            }
         }
 
         // Always update graph with live values — dimming handles on/off visual

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -2422,17 +2422,34 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
     objTrajectoryDirBox.addItem ("Forward", 1);
     objTrajectoryDirBox.addItem ("Reverse", 2);
     addChildComponent (objTrajectoryDirBox);  // invisible
+    // Issue #182: Use manual gesture brackets (like Dotted/Triplet) instead of
+    // setSelectedId() which relies on ComboBoxAttachment auto-gestures that don't
+    // create proper undo entries in Ableton.
     objTrajectoryFwdButton->onClick = [this] {
-        objTrajectoryDirBox.setSelectedId (1, juce::sendNotificationSync);
+        auto prefix = "object" + juce::String (currentObjectIndex + 1) + "_";
+        if (auto* param = processorRef.apvts.getParameter (prefix + "trajectoryDirection"))
+        {
+            param->beginChangeGesture();
+            param->setValueNotifyingHost (param->convertTo0to1 (0.0f));  // 0 = Forward
+            param->endChangeGesture();
+            processorRef.notifyHostStateChanged();
+            processorRef.captureUndoState ("Change Trajectory Direction");
+        }
         objTrajectoryFwdButton->setToggleState (true, juce::dontSendNotification);
         objTrajectoryRevButton->setToggleState (false, juce::dontSendNotification);
-        processorRef.captureUndoState ("Change Trajectory Direction");
     };
     objTrajectoryRevButton->onClick = [this] {
-        objTrajectoryDirBox.setSelectedId (2, juce::sendNotificationSync);
+        auto prefix = "object" + juce::String (currentObjectIndex + 1) + "_";
+        if (auto* param = processorRef.apvts.getParameter (prefix + "trajectoryDirection"))
+        {
+            param->beginChangeGesture();
+            param->setValueNotifyingHost (param->convertTo0to1 (1.0f));  // 1 = Reverse
+            param->endChangeGesture();
+            processorRef.notifyHostStateChanged();
+            processorRef.captureUndoState ("Change Trajectory Direction");
+        }
         objTrajectoryRevButton->setToggleState (true, juce::dontSendNotification);
         objTrajectoryFwdButton->setToggleState (false, juce::dontSendNotification);
-        processorRef.captureUndoState ("Change Trajectory Direction");
     };
     objTrajectoryDirBox.onChange = [this] {
         int sel = objTrajectoryDirBox.getSelectedId();  // 1=Forward, 2=Reverse
@@ -2440,7 +2457,10 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         if (objTrajectoryRevButton) objTrajectoryRevButton->setToggleState (sel == 2, juce::dontSendNotification);
     };
 
+    // Issue #182: Add notifyHostStateChanged() so the host creates a separate
+    // undo entry for trajectory shape changes (ComboBoxAttachment handles gestures).
     objTrajectoryBox.onChange = [this] {
+        processorRef.notifyHostStateChanged();
         processorRef.captureUndoState ("Change Trajectory Shape");
     };
 
@@ -2734,11 +2754,21 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         };
 
         // Cycle on click: L+R (1) → L (2) → R (3) → L+R (1)
+        // Issue #182: Use manual gesture brackets (like Dotted/Triplet) instead of
+        // setSelectedId() which relies on ComboBoxAttachment auto-gestures that don't
+        // create proper undo entries in Ableton.
         objInputChannelButton->onClick = [this] {
-            int cur = objInputChannelBox.getSelectedId();
-            int next = (cur >= 3) ? 1 : cur + 1;
-            objInputChannelBox.setSelectedId (next, juce::sendNotificationSync);
-            processorRef.captureUndoState ("Change Input Channel");
+            auto prefix = "object" + juce::String (currentObjectIndex + 1) + "_";
+            if (auto* param = processorRef.apvts.getParameter (prefix + "inputChannel"))
+            {
+                int cur = objInputChannelBox.getSelectedId();  // 1-based
+                int next = (cur >= 3) ? 1 : cur + 1;
+                param->beginChangeGesture();
+                param->setValueNotifyingHost (param->convertTo0to1 (static_cast<float> (next - 1)));
+                param->endChangeGesture();
+                processorRef.notifyHostStateChanged();
+                processorRef.captureUndoState ("Change Input Channel");
+            }
         };
     }
 
@@ -2853,14 +2883,14 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
     undoButton->setTooltip ("Undo");
     undoButton->setColour (juce::TextButton::buttonColourId, Colours_OSD::bgRecessed);
     undoButton->setColour (juce::TextButton::textColourOffId, Colours_OSD::textSecondary);
-    undoButton->onClick = [this] { processorRef.performInternalUndo(); updateUndoButtons(); };
+    undoButton->onClick = [this] { processorRef.performInternalUndo(); updatePresetButtonText(); updateUndoButtons(); };
     addAndMakeVisible (*undoButton);
 
     redoButton = std::make_unique<juce::TextButton> (juce::CharPointer_UTF8 ("\xe2\x86\xaa"));  // arrow right hook
     redoButton->setTooltip ("Redo");
     redoButton->setColour (juce::TextButton::buttonColourId, Colours_OSD::bgRecessed);
     redoButton->setColour (juce::TextButton::textColourOffId, Colours_OSD::textSecondary);
-    redoButton->onClick = [this] { processorRef.performInternalRedo(); updateUndoButtons(); };
+    redoButton->onClick = [this] { processorRef.performInternalRedo(); updatePresetButtonText(); updateUndoButtons(); };
     addAndMakeVisible (*redoButton);
 
     selectObject (0);
@@ -2911,12 +2941,14 @@ bool OpenSpatialDelayEditor::keyPressed (const juce::KeyPress& key)
     if (key == juce::KeyPress ('z', juce::ModifierKeys::commandModifier, 0))
     {
         processorRef.performInternalUndo();
+        updatePresetButtonText();
         updateUndoButtons();
         return true;
     }
     if (key == juce::KeyPress ('z', juce::ModifierKeys::commandModifier | juce::ModifierKeys::shiftModifier, 0))
     {
         processorRef.performInternalRedo();
+        updatePresetButtonText();
         updateUndoButtons();
         return true;
     }
@@ -3529,6 +3561,9 @@ void OpenSpatialDelayEditor::timerCallback()
     }
 
     // v0.9: Sync preset name button text from processor
+    // Issue #182: Also force sync after host state restore (Undo/Redo)
+    if (processorRef.stateJustRestored.exchange (false, std::memory_order_relaxed))
+        updatePresetButtonText();
     {
         int idx = processorRef.getCurrentPresetIndex();
         auto names = processorRef.getPresetNames();

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -2131,8 +2131,11 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         wobbleAmountAttach = std::make_unique<SliderAttachment> (processorRef.apvts, "wobbleAmount", wobbleAmountSlider);
         wobbleAmountSlider.onDragStart = [this] { lastSliderDragStartTime = juce::Time::getMillisecondCounterHiRes(); };
         wobbleAmountSlider.onDragEnd = [this] {
-            if (juce::Time::getMillisecondCounterHiRes() - lastSliderDragStartTime > 100.0)
+            if (juce::Time::getMillisecondCounterHiRes() - lastSliderDragStartTime > 20.0)
+            {
                 processorRef.notifyHostStateChanged();
+                processorRef.captureUndoState ("Adjust wobbleAmount");
+            }
         };
 
         styleSlider (wobbleMorphSlider, *osdLookAndFeel, juce::Slider::RotaryVerticalDrag);
@@ -2142,8 +2145,11 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         wobbleMorphAttach = std::make_unique<SliderAttachment> (processorRef.apvts, "wobbleMorph", wobbleMorphSlider);
         wobbleMorphSlider.onDragStart = [this] { lastSliderDragStartTime = juce::Time::getMillisecondCounterHiRes(); };
         wobbleMorphSlider.onDragEnd = [this] {
-            if (juce::Time::getMillisecondCounterHiRes() - lastSliderDragStartTime > 100.0)
+            if (juce::Time::getMillisecondCounterHiRes() - lastSliderDragStartTime > 20.0)
+            {
                 processorRef.notifyHostStateChanged();
+                processorRef.captureUndoState ("Adjust wobbleMorph");
+            }
         };
 
         // MOD section — rose/pink accent (using Colours_OSD::accentRose)
@@ -2457,11 +2463,19 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         if (objTrajectoryRevButton) objTrajectoryRevButton->setToggleState (sel == 2, juce::dontSendNotification);
     };
 
-    // Issue #182: Add notifyHostStateChanged() so the host creates a separate
-    // undo entry for trajectory shape changes (ComboBoxAttachment handles gestures).
+    // Issue #182: Use manual gesture brackets (like Direction/InputChannel) instead of
+    // ComboBoxAttachment auto-gestures that Ableton ignores.
     objTrajectoryBox.onChange = [this] {
-        processorRef.notifyHostStateChanged();
-        processorRef.captureUndoState ("Change Trajectory Shape");
+        auto prefix = "object" + juce::String (currentObjectIndex + 1) + "_";
+        if (auto* param = processorRef.apvts.getParameter (prefix + "trajectoryShape"))
+        {
+            int selectedIdx = objTrajectoryBox.getSelectedId() - 1;  // ComboBox 1-based -> 0-based
+            param->beginChangeGesture();
+            param->setValueNotifyingHost (param->convertTo0to1 (static_cast<float> (selectedIdx)));
+            param->endChangeGesture();
+            processorRef.notifyHostStateChanged();
+            processorRef.captureUndoState ("Change Trajectory Shape");
+        }
     };
 
     styleSlider (objTrajectorySpeedSlider, *osdLookAndFeel, juce::Slider::RotaryVerticalDrag);
@@ -3088,7 +3102,12 @@ void OpenSpatialDelayEditor::selectObject (int index)
         s->onDragStart = makeDragStart();
         s->onDragEnd   = makeDragEnd ("perObject");
     }
-    objTrajectoryAttach      = std::make_unique<ComboBoxAttachment> (processorRef.apvts, prefix + "trajectoryShape", objTrajectoryBox);
+    // Issue #182: Manual sync replaces ComboBoxAttachment (auto-gestures fail in Ableton)
+    {
+        auto* raw = processorRef.apvts.getRawParameterValue (prefix + "trajectoryShape");
+        if (raw)
+            objTrajectoryBox.setSelectedId (static_cast<int> (raw->load()) + 1, juce::dontSendNotification);
+    }
     objTrajectorySpeedAttach = std::make_unique<SliderAttachment>   (processorRef.apvts, prefix + "trajectorySpeed", objTrajectorySpeedSlider);
     objTrajectoryDirAttach   = std::make_unique<ComboBoxAttachment> (processorRef.apvts, prefix + "trajectoryDirection", objTrajectoryDirBox);
 
@@ -3377,6 +3396,9 @@ void OpenSpatialDelayEditor::timerCallback()
         bool hasTraj = (trajShape > 0);  // 0 = None
         if (objTrajectoryFwdButton) objTrajectoryFwdButton->setVisible (hasTraj);
         if (objTrajectoryRevButton) objTrajectoryRevButton->setVisible (hasTraj);
+        // Issue #182: Sync ComboBox from APVTS (no ComboBoxAttachment)
+        if (objTrajectoryBox.getSelectedId() != trajShape + 1)
+            objTrajectoryBox.setSelectedId (trajShape + 1, juce::dontSendNotification);
     }
 
     // v0.8: MOD enable/disable — dim wobble knobs + labels when disabled

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1405,6 +1405,8 @@ static void styleSlider (juce::Slider& slider, juce::LookAndFeel& lf,
     slider.setColour (juce::Slider::textBoxTextColourId, Colours_OSD::textSecondary);
     slider.setColour (juce::Slider::textBoxOutlineColourId, juce::Colours::transparentBlack);
     slider.setColour (juce::Slider::textBoxBackgroundColourId, juce::Colours::transparentBlack);
+    // Disable mouse wheel parameter adjustment on all sliders.
+    slider.setScrollWheelEnabled (false);
 }
 
 static void styleLabel (juce::Label& label, const juce::String& text, OSDLookAndFeel* lf = nullptr)
@@ -1618,15 +1620,16 @@ void FilterGraphComponent::mouseDown (const juce::MouseEvent& e)
 
     // Issue E15: Signal drag start for gesture wrapping (undo grouping)
     if (currentDrag != None && onFilterDragStarted)
-        onFilterDragStarted();
+        onFilterDragStarted (currentDrag == HP);
 }
 
 void FilterGraphComponent::mouseDrag (const juce::MouseEvent& e)
 {
     if (currentDrag == None) return;
 
-    // Horizontal: frequency
-    float freq = xToFreq (static_cast<float> (e.x));
+    // Horizontal: frequency — clamp to component bounds so handles can't go off-screen (issue #195)
+    float clampedX = juce::jlimit (0.0f, static_cast<float> (getWidth()), static_cast<float> (e.x));
+    float freq = xToFreq (clampedX);
     if (currentDrag == HP)
         hpFreq = juce::jlimit (20.0f, 5000.0f, freq);
     else
@@ -1657,7 +1660,7 @@ void FilterGraphComponent::mouseUp (const juce::MouseEvent&)
 {
     // Issue E15: Signal drag end for gesture wrapping (undo grouping)
     if (currentDrag != None && onFilterDragEnded)
-        onFilterDragEnded();
+        onFilterDragEnded (currentDrag == HP);
     currentDrag = None;
 }
 
@@ -1982,6 +1985,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         for (auto* p : activeSpatialGestureParams)
             if (p != nullptr) p->endChangeGesture();
         activeSpatialGestureParams = { nullptr, nullptr };
+        processorRef.captureUndoState ("Move Object");
     };
     spatialMap.setProcessor (&processorRef);
 
@@ -2035,6 +2039,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         for (auto* param : activeGlobalGestureParams)
             param->endChangeGesture();
         activeGlobalGestureParams.clear();
+        processorRef.captureUndoState ("Adjust Global Tap");
     };
     globalTapDrawer.onGlobalDelta = [this] (int idx, float delta) {
         applyGlobalTapDelta (idx, delta);
@@ -2072,9 +2077,34 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
     addKnob (delayTimeSlider,  delayTimeLabel,  "TIME",     "delayTime",  delayTimeAttach);
     addKnob (noteDivisionSlider, delayTimeLabel, "TIME",    "noteDivision", noteDivisionAttach);
     addKnob (feedbackSlider,   feedbackLabel,   "FEEDBACK", "feedback",   feedbackAttach);
+
+    // Issue E15b: Force host state capture after APVTS slider drag gestures.
+    // Uses gesture duration to distinguish drags (>100ms, force capture) from
+    // mouse wheel ticks (<100ms, let host debounce/group naturally).
+    auto makeGestureEndHandler = [this] (const char* name) {
+        return [this, name] {
+            double elapsed = juce::Time::getMillisecondCounterHiRes() - lastSliderDragStartTime;
+            if (elapsed > 20.0)
+            {
+                processorRef.notifyHostStateChanged();
+                processorRef.captureUndoState (juce::String ("Adjust ") + name);
+            }
+        };
+    };
+    auto makeDragStartHandler = [this] { return [this] { lastSliderDragStartTime = juce::Time::getMillisecondCounterHiRes(); }; };
+    delayTimeSlider.onDragStart = makeDragStartHandler();
+    delayTimeSlider.onDragEnd   = makeGestureEndHandler ("delayTime");
+    feedbackSlider.onDragStart  = makeDragStartHandler();
+    feedbackSlider.onDragEnd    = makeGestureEndHandler ("feedback");
     addKnob (filterHPSlider,   filterHPLabel,   "HP",       "filterHP",   filterHPAttach);
     addKnob (filterLPSlider,   filterLPLabel,   "LP",       "filterLP",   filterLPAttach);
     addKnob (dryWetSlider,     dryWetLabel,     "DRY/WET",  "dryWet",     dryWetAttach);
+    dryWetSlider.onDragStart = makeDragStartHandler();
+    dryWetSlider.onDragEnd   = makeGestureEndHandler ("dryWet");
+    inputGainSlider.onDragStart  = makeDragStartHandler();
+    inputGainSlider.onDragEnd    = makeGestureEndHandler ("inputGain");
+    outputGainSlider.onDragStart = makeDragStartHandler();
+    outputGainSlider.onDragEnd   = makeGestureEndHandler ("outputGain");
     addKnob (outputGainSlider, outputGainLabel, "OUTPUT",   "outputGain", outputGainAttach);
 
     // Section-based knob accent colors (prototype v6: DELAY=stellar, TONE=no knobs, MIX=amber)
@@ -2097,12 +2127,22 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         styleLabel (wobbleAmountLabel, "AMOUNT", &*osdLookAndFeel);
         addAndMakeVisible (wobbleAmountLabel);
         wobbleAmountAttach = std::make_unique<SliderAttachment> (processorRef.apvts, "wobbleAmount", wobbleAmountSlider);
+        wobbleAmountSlider.onDragStart = [this] { lastSliderDragStartTime = juce::Time::getMillisecondCounterHiRes(); };
+        wobbleAmountSlider.onDragEnd = [this] {
+            if (juce::Time::getMillisecondCounterHiRes() - lastSliderDragStartTime > 100.0)
+                processorRef.notifyHostStateChanged();
+        };
 
         styleSlider (wobbleMorphSlider, *osdLookAndFeel, juce::Slider::RotaryVerticalDrag);
         addAndMakeVisible (wobbleMorphSlider);
         styleLabel (wobbleMorphLabel, "MORPH", &*osdLookAndFeel);
         addAndMakeVisible (wobbleMorphLabel);
         wobbleMorphAttach = std::make_unique<SliderAttachment> (processorRef.apvts, "wobbleMorph", wobbleMorphSlider);
+        wobbleMorphSlider.onDragStart = [this] { lastSliderDragStartTime = juce::Time::getMillisecondCounterHiRes(); };
+        wobbleMorphSlider.onDragEnd = [this] {
+            if (juce::Time::getMillisecondCounterHiRes() - lastSliderDragStartTime > 100.0)
+                processorRef.notifyHostStateChanged();
+        };
 
         // MOD section — rose/pink accent (using Colours_OSD::accentRose)
         wobbleAmountSlider.setColour (juce::Slider::thumbColourId, Colours_OSD::accentRose);
@@ -2181,6 +2221,10 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         outputFormatBox.onChange = [this] {
             processorRef.configOutputFormat.store (outputFormatBox.getSelectedItemIndex(), std::memory_order_relaxed);
             processorRef.markConfigStateDirty();
+            // Issue E15b: Activate layout immediately on user-driven format change
+            // instead of waiting for the next timer tick. This eliminates the one-tick
+            // race that corrupts undo state after format changes.
+            processorRef.requestOutputFormatChange (outputFormatBox.getSelectedItemIndex());
         };
     }
 
@@ -2249,6 +2293,8 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
             param->beginChangeGesture();
             param->setValueNotifyingHost (param->convertTo0to1 ((float) mode));
             param->endChangeGesture();
+            processorRef.notifyHostStateChanged();
+            processorRef.captureUndoState ("Change Sync Mode");
         }
         repaint();
     };
@@ -2263,6 +2309,8 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
             param->beginChangeGesture();
             param->setValueNotifyingHost (param->convertTo0to1 ((float) mode));
             param->endChangeGesture();
+            processorRef.notifyHostStateChanged();
+            processorRef.captureUndoState ("Change Sync Mode");
         }
         repaint();
     };
@@ -2425,11 +2473,25 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
     addAndMakeVisible (oscPortLabel);
 
     // --- v0.4: Global Air Absorption toggle (IndicatorToggle) ----------------
+    // Issue #182: Use manual onClick with gesture brackets (like FLT/MOD) instead
+    // of ButtonAttachment, which creates double undo entries.
     airAbsorptionButton = std::make_unique<IndicatorToggle> ("AIR", Colours_OSD::accentStellar,
                                                               osdLookAndFeel->jetbrainsMedium);
+    airAbsorptionButton->setClickingTogglesState (false);  // timer drives visual state
+    airAbsorptionButton->onClick = [this]
+    {
+        auto* airParam = processorRef.apvts.getParameter ("airAbsorption");
+        if (airParam != nullptr)
+        {
+            airParam->beginChangeGesture();
+            float current = processorRef.apvts.getRawParameterValue ("airAbsorption")->load();
+            airParam->setValueNotifyingHost (current < 0.5f ? 1.0f : 0.0f);
+            airParam->endChangeGesture();
+            processorRef.notifyHostStateChanged();
+            processorRef.captureUndoState ("Toggle Air Absorption");
+        }
+    };
     addAndMakeVisible (*airAbsorptionButton);
-    airAbsorptionAttach = std::make_unique<ButtonAttachment> (processorRef.apvts, "airAbsorption",
-                                                              *airAbsorptionButton);
 
     // --- v0.7: ADM-OSC Send toggle (IndicatorToggle) -------------------------
     oscSendToggleButton = std::make_unique<IndicatorToggle> ("SEND", Colours_OSD::accentGreen,
@@ -2528,6 +2590,8 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
             float current = processorRef.apvts.getRawParameterValue ("filterEnabled")->load();
             fltParam->setValueNotifyingHost (current < 0.5f ? 1.0f : 0.0f);
             fltParam->endChangeGesture();
+            processorRef.notifyHostStateChanged();
+            processorRef.captureUndoState ("Toggle Filter");
         }
     };
     addAndMakeVisible (*fltToggle);
@@ -2550,6 +2614,8 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
             float cur = processorRef.apvts.getRawParameterValue ("wobbleEnabled")->load();
             param->setValueNotifyingHost (cur > 0.5f ? 0.0f : 1.0f);
             param->endChangeGesture();
+            processorRef.notifyHostStateChanged();
+            processorRef.captureUndoState ("Toggle Modulation");
         }
     };
     addAndMakeVisible (*modToggle);
@@ -2579,10 +2645,13 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         repaint();  // update painted readout
     };
     // Issue E15: Gesture wrapping for filter graph drag (undo grouping)
-    filterGraph.onFilterDragStarted = [this] {
+    filterGraph.onFilterDragStarted = [this] (bool isHP) {
         activeFilterGestureParams.clear();
-        // Begin gestures on all 4 filter params — both freq and Q may change during a drag
-        for (const char* id : { "filterHP", "filterLP", "filterHPQ", "filterLPQ" })
+        // Issue E15b: Only begin gestures on the params that will actually change.
+        // Opening gestures on all 4 params causes the host to create per-parameter undo entries.
+        const char* ids[2] = { isHP ? "filterHP" : "filterLP",
+                               isHP ? "filterHPQ" : "filterLPQ" };
+        for (auto* id : ids)
         {
             if (auto* param = processorRef.apvts.getParameter (id))
             {
@@ -2591,10 +2660,12 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
             }
         }
     };
-    filterGraph.onFilterDragEnded = [this] {
+    filterGraph.onFilterDragEnded = [this] (bool /*isHP*/) {
         for (auto* param : activeFilterGestureParams)
             param->endChangeGesture();
         activeFilterGestureParams.clear();
+        processorRef.notifyHostStateChanged();
+        processorRef.captureUndoState ("Adjust Filter");
     };
 
     // --- v0.7: Per-object pitch shift knob (bottom panel) --------------------
@@ -2700,6 +2771,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         resetGlobalTapAPVTSParams();
         processorRef.loadPreviousPreset();
         updatePresetButtonText();
+        processorRef.captureUndoState ("Load Preset");
     };
 
     stylePresetButton (presetNextButton, ">");
@@ -2709,6 +2781,7 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         resetGlobalTapAPVTSParams();
         processorRef.loadNextPreset();
         updatePresetButtonText();
+        processorRef.captureUndoState ("Load Preset");
     };
 
     stylePresetButton (presetSaveButton, "Save");
@@ -2749,8 +2822,28 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
     smlButton->setButtonHeight (17);
     addAndMakeVisible (*smlButton);
 
+    // Issue E15b/182: Internal undo/redo buttons (FabFilter-style)
+    undoButton = std::make_unique<juce::TextButton> (juce::CharPointer_UTF8 ("\xe2\x86\xa9"));  // arrow left hook
+    undoButton->setTooltip ("Undo");
+    undoButton->setColour (juce::TextButton::buttonColourId, Colours_OSD::bgRecessed);
+    undoButton->setColour (juce::TextButton::textColourOffId, Colours_OSD::textSecondary);
+    undoButton->onClick = [this] { processorRef.performInternalUndo(); updateUndoButtons(); };
+    addAndMakeVisible (*undoButton);
+
+    redoButton = std::make_unique<juce::TextButton> (juce::CharPointer_UTF8 ("\xe2\x86\xaa"));  // arrow right hook
+    redoButton->setTooltip ("Redo");
+    redoButton->setColour (juce::TextButton::buttonColourId, Colours_OSD::bgRecessed);
+    redoButton->setColour (juce::TextButton::textColourOffId, Colours_OSD::textSecondary);
+    redoButton->onClick = [this] { processorRef.performInternalRedo(); updateUndoButtons(); };
+    addAndMakeVisible (*redoButton);
+
     selectObject (0);
     resized();  // re-layout now that all unique_ptr components are constructed
+
+    // Issue E15b/182: Capture initial state for undo baseline
+    processorRef.captureUndoState ("Initial State");
+    updateUndoButtons();
+
     startTimerHz (30);
 }
 
@@ -2768,6 +2861,40 @@ void OpenSpatialDelayEditor::visibilityChanged()
         startTimerHz (30);
     else
         startTimerHz (5);    // keep param sync alive, skip rendering
+}
+
+//==============================================================================
+// Issue E15b/182: Internal undo/redo support
+//==============================================================================
+void OpenSpatialDelayEditor::updateUndoButtons()
+{
+    if (undoButton)
+    {
+        undoButton->setEnabled (processorRef.pluginUndo.canUndo());
+        undoButton->setAlpha (processorRef.pluginUndo.canUndo() ? 1.0f : 0.3f);
+    }
+    if (redoButton)
+    {
+        redoButton->setEnabled (processorRef.pluginUndo.canRedo());
+        redoButton->setAlpha (processorRef.pluginUndo.canRedo() ? 1.0f : 0.3f);
+    }
+}
+
+bool OpenSpatialDelayEditor::keyPressed (const juce::KeyPress& key)
+{
+    if (key == juce::KeyPress ('z', juce::ModifierKeys::commandModifier, 0))
+    {
+        processorRef.performInternalUndo();
+        updateUndoButtons();
+        return true;
+    }
+    if (key == juce::KeyPress ('z', juce::ModifierKeys::commandModifier | juce::ModifierKeys::shiftModifier, 0))
+    {
+        processorRef.performInternalRedo();
+        updateUndoButtons();
+        return true;
+    }
+    return false;
 }
 
 //==============================================================================
@@ -2844,6 +2971,7 @@ void OpenSpatialDelayEditor::showPresetMenu()
                 resetGlobalTapAPVTSParams();
                 processorRef.loadPreset (result - 1);
                 updatePresetButtonText();
+                processorRef.captureUndoState ("Load Preset");
             }
         });
 }
@@ -2883,6 +3011,25 @@ void OpenSpatialDelayEditor::selectObject (int index)
     objDopplerAttach = std::make_unique<SliderAttachment> (processorRef.apvts, prefix + "dopplerAmount", objDopplerSlider);
     objPitchShiftAttach      = std::make_unique<SliderAttachment> (processorRef.apvts, prefix + "pitchShift", objPitchShiftSlider);
     objInputChannelAttach    = std::make_unique<ComboBoxAttachment> (processorRef.apvts, prefix + "inputChannel", objInputChannelBox);
+
+    // Issue E15b: Force host state capture after per-object slider drag gestures
+    auto makeDragStart = [this] { return [this] { lastSliderDragStartTime = juce::Time::getMillisecondCounterHiRes(); }; };
+    auto makeDragEnd = [this] (const char* name) {
+        return [this, name] {
+            double elapsed = juce::Time::getMillisecondCounterHiRes() - lastSliderDragStartTime;
+            if (elapsed > 20.0)
+            {
+                processorRef.notifyHostStateChanged();
+                processorRef.captureUndoState (juce::String ("Adjust ") + name);
+            }
+        };
+    };
+    for (auto* s : std::initializer_list<juce::Slider*> { &objAzimuthSlider, &objElevationSlider, &objDistanceSlider,
+                     &objDopplerSlider, &objPitchShiftSlider, &objTrajectorySpeedSlider })
+    {
+        s->onDragStart = makeDragStart();
+        s->onDragEnd   = makeDragEnd ("perObject");
+    }
     objTrajectoryAttach      = std::make_unique<ComboBoxAttachment> (processorRef.apvts, prefix + "trajectoryShape", objTrajectoryBox);
     objTrajectorySpeedAttach = std::make_unique<SliderAttachment>   (processorRef.apvts, prefix + "trajectorySpeed", objTrajectorySpeedSlider);
     objTrajectoryDirAttach   = std::make_unique<ComboBoxAttachment> (processorRef.apvts, prefix + "trajectoryDirection", objTrajectoryDirBox);
@@ -3237,8 +3384,13 @@ void OpenSpatialDelayEditor::timerCallback()
         }
     }
 
-    // Trigger layout recomputation if format changed
-    processorRef.requestOutputFormatChange (outputFormatBox.getSelectedItemIndex());
+    // Issue E15b: Only re-resolve the output format from the timer when the host
+    // changes the bus channel count (e.g., track routing change). User-driven format
+    // changes now call requestOutputFormatChange() directly from outputFormatBox.onChange.
+    // Polling every 30Hz tick created spurious layout activations after Undo/Redo that
+    // corrupted the host undo stack.
+    if (lastMaxBusChannels != processorRef.getMaxBusChannels())
+        processorRef.requestOutputFormatChange (outputFormatBox.getSelectedItemIndex());
 
     // v0.5: Context-sensitive header dropdowns based on output format
     int fmtIdx = static_cast<int> (processorRef.getActiveOutputFormat());
@@ -3324,13 +3476,16 @@ void OpenSpatialDelayEditor::timerCallback()
         {
             algoIdx = 7;  // Equal Power
             processorRef.configAlgorithm.store (algoIdx, std::memory_order_relaxed);
-            processorRef.markConfigStateDirty();
+            // Issue E15b: Do NOT call markConfigStateDirty() here — timer-driven
+            // algorithm corrections must be silent. User-initiated format changes
+            // already call markConfigStateDirty() from the combo box onChange handler.
+            // Calling it here creates spurious updateHostDisplay() notifications that
+            // corrupt the host undo stack after Undo/Redo operations.
         }
         else if (! isStereoVariant && algoIdx > 6)
         {
             algoIdx = 1;  // Constant Power (default for surround)
             processorRef.configAlgorithm.store (algoIdx, std::memory_order_relaxed);
-            processorRef.markConfigStateDirty();
         }
 
         // Sync combo selection from parameter (IDs are param index + 1)
@@ -3370,6 +3525,13 @@ void OpenSpatialDelayEditor::timerCallback()
         filterGraph.setEnabled (filterIsActive);
         if (fltToggle) fltToggle->setToggleState (filterIsActive, juce::dontSendNotification);
 
+        // Issue #182: Sync Air button visual state (no ButtonAttachment — manual sync)
+        if (airAbsorptionButton)
+        {
+            bool airActive = processorRef.apvts.getRawParameterValue ("airAbsorption")->load() > 0.5f;
+            airAbsorptionButton->setToggleState (airActive, juce::dontSendNotification);
+        }
+
         // Always update graph with live values — dimming handles on/off visual
         filterGraph.setFrequencies (hp, lp);
         filterGraph.setQ (hpq, lpq);
@@ -3390,6 +3552,9 @@ void OpenSpatialDelayEditor::timerCallback()
 
     // issue #164: Sync knobs from APVTS on host undo / external param change
     syncGlobalTapKnobsFromAPVTS();
+
+    // Issue E15b/182: Refresh undo/redo button state
+    updateUndoButtons();
 
     repaint();
 }
@@ -3671,6 +3836,13 @@ void OpenSpatialDelayEditor::resized()
     presetNextButton.setBounds (px, boxY, 22, boxH);
     px += 22 + 2;
     presetSaveButton.setBounds (px, boxY, 40, boxH);
+
+    // Issue E15b/182: Undo/Redo buttons in header (after preset save)
+    {
+        int undoX = px + 40 + 8;
+        if (undoButton)  undoButton->setBounds  (undoX, boxY, 22, boxH);
+        if (redoButton)  redoButton->setBounds  (undoX + 22, boxY, 22, boxH);
+    }
 
     // Title is painted directly in paint() — no setBounds needed
     // SML badge button (header, left-aligned)

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -2276,8 +2276,8 @@ OpenSpatialDelayEditor::OpenSpatialDelayEditor (OpenSpatialDelayProcessor& p)
         delayTimeSlider.setVisible (!isSynced);
         noteDivisionSlider.setVisible (isSynced);
         syncModeBox.setVisible (false);  // hidden — replaced by toggle buttons
-        syncDottedButton->setVisible (isSynced);
-        syncTripletButton->setVisible (isSynced);
+        if (syncDottedButton)  syncDottedButton->setVisible (isSynced);
+        if (syncTripletButton) syncTripletButton->setVisible (isSynced);
 
         // Toggle button text: "Sync" when synced, "Time" when free
         tempoSyncButton->setLabel (isSynced ? "SYNC" : "TIME");

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -651,7 +651,8 @@ private:
     int lastAlgoCategoryShown = -1;  // Track format category to avoid redundant combo rebuilds
     int lastMaxBusChannels    = -1;  // v0.7: Gate format availability re-check
     int lastOscPort           = -1;  // v0.7: Gate OSC port label sync
-    std::unique_ptr<ButtonAttachment> tempoSyncAttach;
+    // Issue E15b: tempoSync uses manual onClick (no ButtonAttachment — prevents double-undo)
+    std::function<void()> tempoSyncUpdateUI;  // stored lambda for timer-driven UI refresh
 
     // v0.4: Air Absorption uses manual onClick with gesture wrapping (issue #182)
 

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -278,8 +278,9 @@ public:
     std::function<void (float q)> onLPQChanged;
 
     // Callbacks: fired on filter handle drag start/end — used for gesture wrapping (issue E15)
-    std::function<void()> onFilterDragStarted;
-    std::function<void()> onFilterDragEnded;
+    // isHP = true when dragging the HP handle, false for LP
+    std::function<void (bool isHP)> onFilterDragStarted;
+    std::function<void (bool isHP)> onFilterDragEnded;
 
     /** Enable/disable the filter display (dims when off). */
     void setEnabled (bool enabled) { filterEnabled = enabled; repaint(); }
@@ -511,6 +512,7 @@ public:
 
     void paint (juce::Graphics&) override;
     void resized() override;
+    bool keyPressed (const juce::KeyPress& key) override;
 
     /** Sync all UI state from processor parameters (for screenshot tool).
         Normally the 30Hz timer handles this, but headless capture needs
@@ -651,8 +653,7 @@ private:
     int lastOscPort           = -1;  // v0.7: Gate OSC port label sync
     std::unique_ptr<ButtonAttachment> tempoSyncAttach;
 
-    // v0.4: Global DSP attachments
-    std::unique_ptr<ButtonAttachment> airAbsorptionAttach;
+    // v0.4: Air Absorption uses manual onClick with gesture wrapping (issue #182)
 
     // v0.8: Wobble modulation attachments
     std::unique_ptr<SliderAttachment> wobbleAmountAttach, wobbleMorphAttach;
@@ -697,6 +698,13 @@ private:
     std::vector<juce::RangedAudioParameter*> activeGlobalGestureParams;   // Global Tap Drawer drag
     std::array<juce::RangedAudioParameter*, 2> activeSpatialGestureParams { nullptr, nullptr }; // Spatial Map drag
     std::vector<juce::RangedAudioParameter*> activeFilterGestureParams;   // Filter Graph drag
+
+    // Issue E15b/182: Internal undo/redo buttons (FabFilter-style)
+    std::unique_ptr<juce::TextButton> undoButton, redoButton;
+    void updateUndoButtons();
+
+    // Track slider drag start time for gesture duration measurement (undo grouping)
+    double lastSliderDragStartTime = 0.0;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (OpenSpatialDelayEditor)
 };

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -6409,6 +6409,9 @@ void OpenSpatialDelayProcessor::setStateInformation (const void* data, int sizeI
     // Issue E15b/182: Consume dirty flag and clear restore guard
     configStateDirty.store (false, std::memory_order_relaxed);
     stateRestoreInProgress.store (false, std::memory_order_relaxed);
+
+    // Issue #182: Signal editor to sync preset name after host state restore (Undo/Redo)
+    stateJustRestored.store (true, std::memory_order_relaxed);
 }
 
 //==============================================================================

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -5721,6 +5721,13 @@ void OpenSpatialDelayProcessor::handleOSCPosition (int objIdx, float azDeg, floa
 //==============================================================================
 void OpenSpatialDelayProcessor::captureUndoState (const juce::String& name)
 {
+    // Issue #182: Suppress spurious captures during state restores (DAW undo,
+    // internal undo). replaceState() fires parameter listeners whose onChange
+    // callbacks would otherwise create ghost entries that wipe redo history.
+    if (internalUndoInProgress.load (std::memory_order_relaxed)
+        || stateRestoreInProgress.load (std::memory_order_relaxed))
+        return;
+
     pluginUndo.captureState (apvts, configAlgorithm, configHrtfProfile,
                              configOutputFormat, configInputFormat,
                              currentPresetIndex, name);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -5722,7 +5722,8 @@ void OpenSpatialDelayProcessor::handleOSCPosition (int objIdx, float azDeg, floa
 void OpenSpatialDelayProcessor::captureUndoState (const juce::String& name)
 {
     pluginUndo.captureState (apvts, configAlgorithm, configHrtfProfile,
-                             configOutputFormat, configInputFormat, name);
+                             configOutputFormat, configInputFormat,
+                             currentPresetIndex, name);
 }
 
 void OpenSpatialDelayProcessor::applyUndoState (const juce::ValueTree& state)
@@ -5740,6 +5741,9 @@ void OpenSpatialDelayProcessor::applyUndoState (const juce::ValueTree& state)
                               std::memory_order_relaxed);
     configInputFormat.store (static_cast<int> (state.getProperty ("_configInputFormat", configInputFormat.load())),
                              std::memory_order_relaxed);
+
+    // Restore preset index so UI label syncs via timer
+    currentPresetIndex = static_cast<int> (state.getProperty ("_presetIndex", currentPresetIndex));
 
     // Restore APVTS state (triggers parameter listeners but not gesture notifications)
     apvts.replaceState (state);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -5717,6 +5717,54 @@ void OpenSpatialDelayProcessor::handleOSCPosition (int objIdx, float azDeg, floa
 // #############################################################################
 
 //==============================================================================
+// Issue E15b/182: Plugin-internal undo/redo (FabFilter-style)
+//==============================================================================
+void OpenSpatialDelayProcessor::captureUndoState (const juce::String& name)
+{
+    pluginUndo.captureState (apvts, configAlgorithm, configHrtfProfile,
+                             configOutputFormat, configInputFormat, name);
+}
+
+void OpenSpatialDelayProcessor::applyUndoState (const juce::ValueTree& state)
+{
+    if (! state.isValid()) return;
+
+    internalUndoInProgress.store (true, std::memory_order_relaxed);
+
+    // Restore config atomics from snapshot properties
+    configAlgorithm.store (static_cast<int> (state.getProperty ("_configAlgorithm", configAlgorithm.load())),
+                           std::memory_order_relaxed);
+    configHrtfProfile.store (static_cast<int> (state.getProperty ("_configHrtfProfile", configHrtfProfile.load())),
+                             std::memory_order_relaxed);
+    configOutputFormat.store (static_cast<int> (state.getProperty ("_configOutputFormat", configOutputFormat.load())),
+                              std::memory_order_relaxed);
+    configInputFormat.store (static_cast<int> (state.getProperty ("_configInputFormat", configInputFormat.load())),
+                             std::memory_order_relaxed);
+
+    // Restore APVTS state (triggers parameter listeners but not gesture notifications)
+    apvts.replaceState (state);
+
+    internalUndoInProgress.store (false, std::memory_order_relaxed);
+
+    // Sync UI via config dirty flag
+    markConfigStateDirty();
+}
+
+void OpenSpatialDelayProcessor::performInternalUndo()
+{
+    auto state = pluginUndo.undo();
+    if (state.isValid())
+        applyUndoState (state);
+}
+
+void OpenSpatialDelayProcessor::performInternalRedo()
+{
+    auto state = pluginUndo.redo();
+    if (state.isValid())
+        applyUndoState (state);
+}
+
+//==============================================================================
 // State save / restore
 //==============================================================================
 void OpenSpatialDelayProcessor::getStateInformation (juce::MemoryBlock& destData)
@@ -5742,9 +5790,17 @@ void OpenSpatialDelayProcessor::getStateInformation (juce::MemoryBlock& destData
 
 void OpenSpatialDelayProcessor::setStateInformation (const void* data, int sizeInBytes)
 {
+    // Issue E15b/182: Suppress updateHostDisplay() during state restore (Undo/Redo).
+    // Timer-driven algorithm validation may fire between replaceState() and the next
+    // editor repaint, creating spurious undo points that corrupt the host undo stack.
+    stateRestoreInProgress.store (true, std::memory_order_relaxed);
+
     std::unique_ptr<juce::XmlElement> xmlState (getXmlFromBinary (data, sizeInBytes));
     if (xmlState == nullptr || ! xmlState->hasTagName (apvts.state.getType()))
+    {
+        stateRestoreInProgress.store (false, std::memory_order_relaxed);
         return;
+    }
 
     auto tree = juce::ValueTree::fromXml (*xmlState);
 
@@ -6345,6 +6401,10 @@ void OpenSpatialDelayProcessor::setStateInformation (const void* data, int sizeI
                 globalTapOffset[i].store (p->load(), std::memory_order_relaxed);
         }
     }
+
+    // Issue E15b/182: Consume dirty flag and clear restore guard
+    configStateDirty.store (false, std::memory_order_relaxed);
+    stateRestoreInProgress.store (false, std::memory_order_relaxed);
 }
 
 //==============================================================================

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -774,6 +774,10 @@ public:
     // that override parameter-level ones and cause multi-parameter undo grouping.
     void notifyHostStateChanged()
     {
+        // Issue #182: Suppress during state restores to prevent ghost undo entries
+        if (internalUndoInProgress.load (std::memory_order_relaxed)
+            || stateRestoreInProgress.load (std::memory_order_relaxed))
+            return;
         if (wrapperType != wrapperType_AudioUnit && wrapperType != wrapperType_AudioUnitv3)
             updateHostDisplay (ChangeDetails().withNonParameterStateChanged (true));
     }

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -538,6 +538,67 @@ private:
 };
 
 // #############################################################################
+// Issue E15b/182: Plugin-internal undo manager (FabFilter-style)
+// Captures full APVTS + config state at every gesture boundary.
+// Works for ALL params (including non-automatable), ALL formats, ALL DAWs.
+// #############################################################################
+class PluginUndoManager
+{
+public:
+    static constexpr int kMaxSteps = 50;
+
+    void captureState (juce::AudioProcessorValueTreeState& apvts,
+                       std::atomic<int>& configAlgorithm,
+                       std::atomic<int>& configHrtfProfile,
+                       std::atomic<int>& configOutputFormat,
+                       std::atomic<int>& configInputFormat,
+                       const juce::String& transactionName = {})
+    {
+        auto state = apvts.copyState();
+        state.setProperty ("_configAlgorithm",    configAlgorithm.load(),    nullptr);
+        state.setProperty ("_configHrtfProfile",  configHrtfProfile.load(),  nullptr);
+        state.setProperty ("_configOutputFormat", configOutputFormat.load(), nullptr);
+        state.setProperty ("_configInputFormat",  configInputFormat.load(),  nullptr);
+        state.setProperty ("_transactionName",    transactionName,           nullptr);
+
+        // Trim any redo history beyond the current position
+        while ((int) history.size() > currentIndex + 1)
+            history.pop_back();
+
+        history.push_back (state);
+
+        // Enforce max history size
+        if ((int) history.size() > kMaxSteps)
+            history.erase (history.begin());
+        else
+            currentIndex++;
+    }
+
+    bool canUndo() const { return currentIndex > 0; }
+    bool canRedo() const { return currentIndex < (int) history.size() - 1; }
+
+    juce::ValueTree undo()
+    {
+        if (! canUndo()) return {};
+        currentIndex--;
+        return history[(size_t) currentIndex].createCopy();
+    }
+
+    juce::ValueTree redo()
+    {
+        if (! canRedo()) return {};
+        currentIndex++;
+        return history[(size_t) currentIndex].createCopy();
+    }
+
+    void clear() { history.clear(); currentIndex = -1; }
+
+private:
+    std::vector<juce::ValueTree> history;
+    int currentIndex = -1;
+};
+
+// #############################################################################
 // PLUGIN-SPECIFIC — OpenSpatialDelay processor class
 // This class wires the reusable spatial framework (above) to the delay engine.
 // Other SML plugins would replace this class with their own DSP processor,
@@ -704,6 +765,31 @@ public:
     // Issue #122: Debounce updateHostDisplay — set by editor/OSC, flushed in timerCallback
     std::atomic<bool> configStateDirty { false };
     void markConfigStateDirty() { configStateDirty.store (true, std::memory_order_relaxed); }
+
+    // Issue E15b/182: AU-specific notification — VST3 uses setDirty, AU suppressed.
+    // AU undo is parameter-level (gesture brackets), not state-level.
+    // Calling nonParameterStateChanged for AU creates harmful full-state undo entries
+    // that override parameter-level ones and cause multi-parameter undo grouping.
+    void notifyHostStateChanged()
+    {
+        if (wrapperType != wrapperType_AudioUnit && wrapperType != wrapperType_AudioUnitv3)
+            updateHostDisplay (ChangeDetails().withNonParameterStateChanged (true));
+    }
+
+    // Issue E15b/182: Suppress updateHostDisplay() during host-initiated state restores
+    // (Undo/Redo). Without this, timer-driven config corrections trigger spurious
+    // updateHostDisplay() calls that create ghost undo points.
+    std::atomic<bool> stateRestoreInProgress { false };
+
+    // Issue E15b/182: Suppress host gesture notifications during internal undo/redo
+    std::atomic<bool> internalUndoInProgress { false };
+
+    // Issue E15b/182: Plugin-internal undo/redo stack (FabFilter-style)
+    PluginUndoManager pluginUndo;
+    void captureUndoState (const juce::String& name);
+    void performInternalUndo();
+    void performInternalRedo();
+    void applyUndoState (const juce::ValueTree& state);
 
     // v0.7: OSC Send accessors for editor
     bool isOscSendConnected() const { return oscSendConnected; }

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -783,6 +783,9 @@ public:
     // updateHostDisplay() calls that create ghost undo points.
     std::atomic<bool> stateRestoreInProgress { false };
 
+    // Issue #182: Flag set after setStateInformation() so editor can sync preset name
+    std::atomic<bool> stateJustRestored { false };
+
     // Issue E15b/182: Suppress host gesture notifications during internal undo/redo
     std::atomic<bool> internalUndoInProgress { false };
 

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -552,6 +552,7 @@ public:
                        std::atomic<int>& configHrtfProfile,
                        std::atomic<int>& configOutputFormat,
                        std::atomic<int>& configInputFormat,
+                       int presetIndex,
                        const juce::String& transactionName = {})
     {
         auto state = apvts.copyState();
@@ -559,6 +560,7 @@ public:
         state.setProperty ("_configHrtfProfile",  configHrtfProfile.load(),  nullptr);
         state.setProperty ("_configOutputFormat", configOutputFormat.load(), nullptr);
         state.setProperty ("_configInputFormat",  configInputFormat.load(),  nullptr);
+        state.setProperty ("_presetIndex",        presetIndex,              nullptr);
         state.setProperty ("_transactionName",    transactionName,           nullptr);
 
         // Trim any redo history beyond the current position

--- a/agent_docs/version_registry.md
+++ b/agent_docs/version_registry.md
@@ -34,7 +34,10 @@ Registry collapsed to v1.0.0 on 2026-04-02 after issue #77.
 | v1.0.31 | O131 | Issue #182 retry (failed — no undo stack, minimal fixes) | a73554f |
 | v1.0.32 | O132 | Issue #182: gesture hygiene + internal undo stack + v1.0.30 bug fixes | — |
 | v1.0.33 | O133 | Issue #182: ComboBox undo capture + tempoSync fix + preset name on undo | — |
+| v1.0.34 | O134 | Issue #182: manual gestures for trajectory/inputChannel + preset name sync | 76fd6cd |
+| v1.0.35 | O135 | (Same as v1.0.34, tested in Notion DB as v1.0.35) | — |
+| v1.0.36 | O136 | Issue #182: guard captureUndoState/notifyHostStateChanged + mod knobs + trajectory shape manual gestures | — |
 
 ## Next available
 
-**v1.0.34 / O134**
+**v1.0.37 / O137**

--- a/agent_docs/version_registry.md
+++ b/agent_docs/version_registry.md
@@ -31,7 +31,9 @@ Registry collapsed to v1.0.0 on 2026-04-02 after issue #77.
 | v1.0.20 | O120 | Default Input to Stereo on stereo tracks, disable on mono (issue #155) | 376b5fe |
 | v1.0.21–v1.0.29 | O121–O129 | Consumed by E15b double-undo investigation (issue #182) | various |
 | v1.0.30 | O130 | Current fix version for issue #182 | — |
+| v1.0.31 | O131 | Issue #182 retry (failed — no undo stack, minimal fixes) | a73554f |
+| v1.0.32 | O132 | Issue #182: gesture hygiene + internal undo stack + v1.0.30 bug fixes | — |
 
 ## Next available
 
-**v1.0.31 / O131**
+**v1.0.33 / O133**

--- a/agent_docs/version_registry.md
+++ b/agent_docs/version_registry.md
@@ -33,7 +33,8 @@ Registry collapsed to v1.0.0 on 2026-04-02 after issue #77.
 | v1.0.30 | O130 | Current fix version for issue #182 | — |
 | v1.0.31 | O131 | Issue #182 retry (failed — no undo stack, minimal fixes) | a73554f |
 | v1.0.32 | O132 | Issue #182: gesture hygiene + internal undo stack + v1.0.30 bug fixes | — |
+| v1.0.33 | O133 | Issue #182: ComboBox undo capture + tempoSync fix + preset name on undo | — |
 
 ## Next available
 
-**v1.0.33 / O133**
+**v1.0.34 / O134**


### PR DESCRIPTION
## Summary
- Guard `captureUndoState()` and `notifyHostStateChanged()` against spurious calls during state restores — fixes redo button regression and internal undo stack corruption
- Replace trajectory shape `ComboBoxAttachment` with manual gesture brackets — fixes trajectory undo in Ableton AU/VST3
- Add missing `captureUndoState()` to mod knob `onDragEnd` handlers — fixes mod knob double-undo
- Fix null pointer crash in `updateSyncUI` lambda during editor construction

## Test plan
- [x] All 293 unit tests pass
- [x] All 14 undo tests pass in Ableton (AU + VST3)
- [ ] REAPER testing (scheduled for tomorrow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)