### PR TITLE
Fix Immersive HRTF bass boost (issue #198)

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1249,7 +1249,7 @@ void BinauralRenderer::setProfile (int profileIndex)
     // Design a low-shelf biquad filter to boost post-convolution output.
     // Applied per-source to the convolved signal — bass remains spatialized since
     // it amplifies whatever LF the HRTF captured at each direction.
-    lfShelfActive = (profileIndex == 1);  // Only MIT KEMAR needs compensation
+    lfShelfActive = (profileIndex == 5);  // Only MIT KEMAR needs compensation
     if (lfShelfActive)
     {
         // Low-shelf: +12 dB at 200 Hz, Q=0.7 (gentle slope)

--- a/agent_docs/version_registry.md
+++ b/agent_docs/version_registry.md
@@ -16,9 +16,15 @@ The `O10Z` code is a short identifier used in the plugin display name (e.g., O10
 |---------|------|-------------|--------|
 | v1.0.0 | O100 | **Release v1.0.0** — all fixes issues #76–#200 squashed into one commit | 768c248 |
 
+## Post-release patches
+
+| Version | Code | Description | Commit |
+|---------|------|-------------|--------|
+| v1.0.1 | O101 | Fix Immersive HRTF bass boost — correct low-shelf filter profile index (issue #198) | 70cc5d8 |
+
 ## Next available
 
-**v1.0.1 / O101** (use for any post-release patches)
+**v1.0.2 / O102** (use for any post-release patches)
 
 ## Archive — internal patch builds (v1.0.1–v1.0.36)
 


### PR DESCRIPTION
## Summary
- Fix profile index mismatch in low-shelf bass compensation filter
- Profile reordering (ec1d099) moved MIT KEMAR from index 1→5 but `lfShelfActive = (profileIndex == 1)` was not updated
- Result: Immersive (SADIE, index 1) got an unintended +12 dB bass boost; Studio Reference (KEMAR, index 5) lost its intended compensation
- One-line fix: `== 1` → `== 5`

## Test plan
- [x] A/B tested v1.0.1 (O101) vs v1.0.0 (O100) — Immersive bass boost gone, Studio Reference bass restored

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)