### PR TITLE
Filter graph UX: EQ8-style overhaul (v1.0.2/O102)

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1499,17 +1499,14 @@ void FilterGraphComponent::paint (juce::Graphics& g)
     g.drawRoundedRectangle (bounds.reduced (0.5f), 4.0f, 1.0f);
 
     // --- dB-to-Y mapping (used by both grid lines and curve) ---
-    float plotTop = 2.0f;           // top of drawable area (peak headroom)
-    float plotBot = h + 20.0f;      // extend PAST bottom edge so curve disappears off-screen
-    float passbaseY = plotTop + (h - plotTop) * 0.25f;  // 0 dB line at 25% of visible height
-    float dbPerPixelAbove = 18.0f / (passbaseY - plotTop);    // 18 dB headroom above baseline
-    float dbPerPixelBelow = 48.0f / (plotBot - passbaseY);    // 48 dB rolloff — steeper visual slope
+    // Uniform ±18 dB scale with 0 dB centered — proportional like EQ8
+    float plotTop = 2.0f;
+    float plotBot = h - 2.0f;
+    float passbaseY = plotTop + (plotBot - plotTop) * 0.5f;   // 0 dB at vertical center
+    float dbPerPixel = 18.0f / (passbaseY - plotTop);         // 18 dB above and below
 
     auto dbToY = [&] (float dB) -> float {
-        if (dB >= 0.0f)
-            return juce::jlimit (plotTop, passbaseY, passbaseY - dB / dbPerPixelAbove);
-        else
-            return juce::jlimit (passbaseY, plotBot, passbaseY - dB / dbPerPixelBelow);
+        return juce::jlimit (plotTop, plotBot, passbaseY - dB / dbPerPixel);
     };
 
     // Vertical grid lines at key frequencies (Observatory v6)
@@ -1647,8 +1644,8 @@ void FilterGraphComponent::mouseDrag (const juce::MouseEvent& e)
 
     // Vertical: resonance Q (drag up = more Q, drag down = less)
     float dy = dragStartY - static_cast<float> (e.y);  // positive = dragged up
-    float qDelta = dy * 0.05f;  // sensitivity: 20px drag = 1.0 Q change
-    float newQ = juce::jlimit (0.5f, 8.0f, dragStartQ + qDelta);
+    float qDelta = dy * 0.075f;  // sensitivity: ~13px drag = 1.0 Q change (full range in graph height)
+    float newQ = juce::jlimit (0.1f, 8.0f, dragStartQ + qDelta);
 
     if (currentDrag == HP)
     {

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1662,10 +1662,9 @@ void FilterGraphComponent::mouseDrag (const juce::MouseEvent& e)
     else
         lpFreq = juce::jlimit (20.0f, 20000.0f, freq);
 
-    // Vertical: resonance Q (drag up = more Q, drag down = less)
+    // Vertical: resonance Q — logarithmic scaling for uniform feel across full range
     float dy = dragStartY - static_cast<float> (e.y);  // positive = dragged up
-    float qDelta = dy * 0.075f;  // sensitivity: ~13px drag = 1.0 Q change (full range in graph height)
-    float newQ = juce::jlimit (0.1f, 8.0f, dragStartQ + qDelta);
+    float newQ = juce::jlimit (0.1f, 8.0f, dragStartQ * std::exp (dy * 0.042f));
 
     if (currentDrag == HP)
     {

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1498,19 +1498,43 @@ void FilterGraphComponent::paint (juce::Graphics& g)
     g.setColour (Colours_OSD::borderDim);
     g.drawRoundedRectangle (bounds.reduced (0.5f), 4.0f, 1.0f);
 
-    // Grid lines at key frequencies (Observatory v6)
-    g.setColour (Colours_OSD::borderDim.withAlpha (alpha * 0.5f));
+    // --- dB-to-Y mapping (used by both grid lines and curve) ---
+    float plotTop = 2.0f;           // top of drawable area (peak headroom)
+    float plotBot = h + 20.0f;      // extend PAST bottom edge so curve disappears off-screen
+    float passbaseY = plotTop + (h - plotTop) * 0.25f;  // 0 dB line at 25% of visible height
+    float dbPerPixelAbove = 18.0f / (passbaseY - plotTop);    // 18 dB headroom above baseline
+    float dbPerPixelBelow = 48.0f / (plotBot - passbaseY);    // 48 dB rolloff — steeper visual slope
+
+    auto dbToY = [&] (float dB) -> float {
+        if (dB >= 0.0f)
+            return juce::jlimit (plotTop, passbaseY, passbaseY - dB / dbPerPixelAbove);
+        else
+            return juce::jlimit (passbaseY, plotBot, passbaseY - dB / dbPerPixelBelow);
+    };
+
+    // Vertical grid lines at key frequencies (Observatory v6)
+    g.setColour (Colours_OSD::borderDim.withAlpha (alpha * 0.7f));
     for (float freq : { 50.0f, 200.0f, 500.0f, 2000.0f, 5000.0f })
     {
         float x = freqToX (freq);
         g.drawVerticalLine (juce::roundToInt (x), bounds.getY() + 2, bounds.getBottom() - 2);
     }
-    // Primary grid lines (brighter)
-    g.setColour (Colours_OSD::borderDim.withAlpha (alpha * 0.8f));
+    // Primary vertical grid lines (brighter)
+    g.setColour (Colours_OSD::borderDim.withAlpha (alpha * 1.0f));
     for (float freq : { 100.0f, 1000.0f, 10000.0f })
     {
         float x = freqToX (freq);
         g.drawVerticalLine (juce::roundToInt (x), bounds.getY() + 2, bounds.getBottom() - 2);
+    }
+
+    // Horizontal dB grid lines (EQ8-style)
+    for (float dB : { -12.0f, -6.0f, 0.0f, 6.0f, 12.0f, 18.0f })
+    {
+        float y = dbToY (dB);
+        if (y < bounds.getY() + 2 || y > bounds.getBottom() - 12) continue;
+        float lineAlpha = (dB == 0.0f) ? 0.6f : 0.35f;
+        g.setColour (Colours_OSD::borderDim.withAlpha (alpha * lineAlpha));
+        g.drawHorizontalLine (juce::roundToInt (y), bounds.getX() + 2, bounds.getRight() - 2);
     }
 
     // Frequency labels — extended frequency marker set
@@ -1534,20 +1558,6 @@ void FilterGraphComponent::paint (juce::Graphics& g)
     }
 
     // --- Compute combined HP+LP magnitude response curve ---
-    // Layout: passband baseline in upper portion, peaks above, rolloff extends well past bottom
-    float plotTop = 2.0f;           // top of drawable area (peak headroom)
-    float plotBot = h + 20.0f;      // extend PAST bottom edge so curve disappears off-screen
-    float passbaseY = plotTop + (h - plotTop) * 0.25f;  // 0 dB line at 25% of visible height
-    float dbPerPixelAbove = 18.0f / (passbaseY - plotTop);    // 18 dB headroom above baseline
-    float dbPerPixelBelow = 48.0f / (plotBot - passbaseY);    // 48 dB rolloff — steeper visual slope
-
-    auto dbToY = [&] (float dB) -> float {
-        if (dB >= 0.0f)
-            return juce::jlimit (plotTop, passbaseY, passbaseY - dB / dbPerPixelAbove);
-        else
-            return juce::jlimit (passbaseY, plotBot, passbaseY - dB / dbPerPixelBelow);
-    };
-
     // Build the magnitude response path (2px steps for smoothness)
     juce::Path curve;
     bool started = false;
@@ -1631,9 +1641,9 @@ void FilterGraphComponent::mouseDrag (const juce::MouseEvent& e)
     float clampedX = juce::jlimit (0.0f, static_cast<float> (getWidth()), static_cast<float> (e.x));
     float freq = xToFreq (clampedX);
     if (currentDrag == HP)
-        hpFreq = juce::jlimit (20.0f, 5000.0f, freq);
+        hpFreq = juce::jlimit (20.0f, 20000.0f, freq);
     else
-        lpFreq = juce::jlimit (200.0f, 20000.0f, freq);
+        lpFreq = juce::jlimit (20.0f, 20000.0f, freq);
 
     // Vertical: resonance Q (drag up = more Q, drag down = less)
     float dy = dragStartY - static_cast<float> (e.y);  // positive = dragged up

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1501,22 +1501,36 @@ void FilterGraphComponent::paint (juce::Graphics& g)
     // --- dB-to-Y mapping (used by both grid lines and curve) ---
     // Uniform ±18 dB scale with 0 dB centered — proportional like EQ8
     float plotTop = 2.0f;
-    float plotBot = h - 2.0f;
-    float passbaseY = plotTop + (plotBot - plotTop) * 0.5f;   // 0 dB at vertical center
-    float dbPerPixel = 18.0f / (passbaseY - plotTop);         // 18 dB above and below
+    float plotVisBot = h - 2.0f;          // visible graph bottom (for grid line bounds)
+    float passbaseY = plotTop + (plotVisBot - plotTop) * 0.5f;  // 0 dB at vertical center
+    float dbPerPixel = 18.0f / (passbaseY - plotTop);           // 18 dB above and below
 
     auto dbToY = [&] (float dB) -> float {
-        return juce::jlimit (plotTop, plotBot, passbaseY - dB / dbPerPixel);
+        return std::max (plotTop, passbaseY - dB / dbPerPixel);  // clamp top only — curve clips off-screen at bottom
     };
 
-    // Vertical grid lines at key frequencies (Observatory v6)
-    g.setColour (Colours_OSD::borderDim.withAlpha (alpha * 0.7f));
-    for (float freq : { 50.0f, 200.0f, 500.0f, 2000.0f, 5000.0f })
+    // --- Logarithmic frequency grid (EQ8-style per-decade subdivisions) ---
+    // Tier 1: subdivision lines at every integer multiple per decade (faintest)
+    g.setColour (Colours_OSD::borderDim.withAlpha (alpha * 0.25f));
+    for (int decade : { 10, 100, 1000, 10000 })
+    {
+        for (int mult = 2; mult <= 9; ++mult)
+        {
+            float freq = static_cast<float> (decade * mult);
+            if (freq < 20.0f || freq > 20000.0f) continue;
+            if (mult == 5) continue;  // drawn brighter below
+            float x = freqToX (freq);
+            g.drawVerticalLine (juce::roundToInt (x), bounds.getY() + 2, bounds.getBottom() - 2);
+        }
+    }
+    // Tier 2: half-decade anchors — 50, 500, 5k (medium brightness)
+    g.setColour (Colours_OSD::borderDim.withAlpha (alpha * 0.5f));
+    for (float freq : { 50.0f, 500.0f, 5000.0f })
     {
         float x = freqToX (freq);
         g.drawVerticalLine (juce::roundToInt (x), bounds.getY() + 2, bounds.getBottom() - 2);
     }
-    // Primary vertical grid lines (brighter)
+    // Tier 3: decade markers — 100, 1k, 10k (brightest)
     g.setColour (Colours_OSD::borderDim.withAlpha (alpha * 1.0f));
     for (float freq : { 100.0f, 1000.0f, 10000.0f })
     {
@@ -1524,33 +1538,39 @@ void FilterGraphComponent::paint (juce::Graphics& g)
         g.drawVerticalLine (juce::roundToInt (x), bounds.getY() + 2, bounds.getBottom() - 2);
     }
 
-    // Horizontal dB grid lines (EQ8-style)
-    for (float dB : { -12.0f, -6.0f, 0.0f, 6.0f, 12.0f, 18.0f })
+    // --- Horizontal dB grid lines with labels (EQ8-style) ---
+    {
+        auto* lfPtr = dynamic_cast<OSDLookAndFeel*> (&getLookAndFeel());
+        if (lfPtr) g.setFont (makeFont (lfPtr->jetbrainsRegular, 7.0f));
+        else       g.setFont (juce::FontOptions (7.0f));
+    }
+    for (float dB : { -12.0f, -6.0f, 0.0f, 6.0f, 12.0f })
     {
         float y = dbToY (dB);
-        if (y < bounds.getY() + 2 || y > bounds.getBottom() - 12) continue;
-        float lineAlpha = (dB == 0.0f) ? 0.6f : 0.35f;
+        if (y < bounds.getY() + 2 || y > plotVisBot) continue;
+        float lineAlpha = (dB == 0.0f) ? 0.6f : 0.3f;
         g.setColour (Colours_OSD::borderDim.withAlpha (alpha * lineAlpha));
         g.drawHorizontalLine (juce::roundToInt (y), bounds.getX() + 2, bounds.getRight() - 2);
+        // dB label on left edge
+        juce::String label = (dB > 0.0f) ? ("+" + juce::String ((int) dB))
+                                          : juce::String ((int) dB);
+        g.setColour (Colours_OSD::textDim.withAlpha (alpha * 0.5f));
+        g.drawText (label, (int) bounds.getX() + 3, juce::roundToInt (y) - 5,
+                    22, 10, juce::Justification::left);
     }
 
-    // Frequency labels — extended frequency marker set
+    // Frequency labels at bottom — decade markers only (EQ8-style)
     {
         auto* lfPtr = dynamic_cast<OSDLookAndFeel*> (&getLookAndFeel());
         if (lfPtr) g.setFont (makeFont (lfPtr->jetbrainsRegular, 8.0f));
         else       g.setFont (juce::FontOptions (8.0f));
     }
-    struct FreqLabel { const char* text; float freq; bool primary; };
-    static constexpr FreqLabel freqLabels[] = {
-        {"50", 50.0f, false}, {"200", 200.0f, false}, {"500", 500.0f, false},
-        {"2k", 2000.0f, false}, {"5k", 5000.0f, false},
-        {"100", 100.0f, true}, {"1k", 1000.0f, true}, {"10k", 10000.0f, true}
-    };
-    for (auto& fl : freqLabels)
+    g.setColour (Colours_OSD::textDim.withAlpha (alpha * 0.7f));
+    for (auto& [text, freq] : std::initializer_list<std::pair<const char*, float>>{
+             {"100", 100.0f}, {"1k", 1000.0f}, {"10k", 10000.0f}})
     {
-        g.setColour (Colours_OSD::textDim.withAlpha (alpha * (fl.primary ? 0.7f : 0.5f)));
-        int lw = (std::strlen (fl.text) >= 3) ? 24 : 20;
-        g.drawText (fl.text, juce::roundToInt (freqToX (fl.freq)) - lw / 2,
+        int lw = (std::strlen (text) >= 3) ? 24 : 20;
+        g.drawText (text, juce::roundToInt (freqToX (freq)) - lw / 2,
                     juce::roundToInt (h) - 11, lw, 10, juce::Justification::centred);
     }
 
@@ -1576,10 +1596,10 @@ void FilterGraphComponent::paint (juce::Graphics& g)
         }
     }
 
-    // Fill under curve
+    // Fill under curve (extend past bottom so fill clips at component edge)
     juce::Path fillPath (curve);
-    fillPath.lineTo (w, plotBot);
-    fillPath.lineTo (0.0f, plotBot);
+    fillPath.lineTo (w, h + 20.0f);
+    fillPath.lineTo (0.0f, h + 20.0f);
     fillPath.closeSubPath();
     g.setColour (Colours_OSD::accentViolet.withAlpha (0.10f * alpha));
     g.fillPath (fillPath);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -333,7 +333,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout
     // G8: High-Pass Resonance (was "HP Resonance")
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("filterHPQ", 8), "High-Pass Resonance",
-        juce::NormalisableRange<float> (0.5f, 8.0f, 0.01f, 0.4f), 0.707f,
+        juce::NormalisableRange<float> (0.1f, 8.0f, 0.01f, 0.4f), 0.707f,
         juce::AudioParameterFloatAttributes().withStringFromValueFunction (
             [](float value, int) { return juce::String (value, 2); })));
 
@@ -348,7 +348,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout
     // G10: Low-Pass Resonance (was "LP Resonance")
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("filterLPQ", 10), "Low-Pass Resonance",
-        juce::NormalisableRange<float> (0.5f, 8.0f, 0.01f, 0.4f), 0.707f,
+        juce::NormalisableRange<float> (0.1f, 8.0f, 0.01f, 0.4f), 0.707f,
         juce::AudioParameterFloatAttributes().withStringFromValueFunction (
             [](float value, int) { return juce::String (value, 2); })));
 

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -325,7 +325,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout
     // G7: High-Pass Frequency (was "High-Pass Filter" — HP grouped before LP)
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("filterHP", 7), "High-Pass Frequency",
-        juce::NormalisableRange<float> (20.0f, 5000.0f, 1.0f, 0.3f), 50.0f,
+        juce::NormalisableRange<float> (20.0f, 20000.0f, 1.0f, 0.3f), 50.0f,
         juce::AudioParameterFloatAttributes()
             .withStringFromValueFunction (fmtFreq)
             .withValueFromStringFunction (parseFreq)));
@@ -340,7 +340,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout
     // G9: Low-Pass Frequency (was "Low-Pass Filter")
     params.push_back (std::make_unique<juce::AudioParameterFloat> (
         juce::ParameterID ("filterLP", 9), "Low-Pass Frequency",
-        juce::NormalisableRange<float> (200.0f, 20000.0f, 1.0f, 0.3f), 5000.0f,
+        juce::NormalisableRange<float> (20.0f, 20000.0f, 1.0f, 0.3f), 5000.0f,
         juce::AudioParameterFloatAttributes()
             .withStringFromValueFunction (fmtFreq)
             .withValueFromStringFunction (parseFreq)));

--- a/agent_docs/version_registry.md
+++ b/agent_docs/version_registry.md
@@ -21,10 +21,11 @@ The `O10Z` code is a short identifier used in the plugin display name (e.g., O10
 | Version | Code | Description | Commit |
 |---------|------|-------------|--------|
 | v1.0.1 | O101 | Fix Immersive HRTF bass boost — correct low-shelf filter profile index (issue #198) | 70cc5d8 |
+| v1.0.2 | O102 | Filter graph UX: EQ8-style grid lines + extended nipple drag range (issue #196) | 14e8ac3 |
 
 ## Next available
 
-**v1.0.2 / O102** (use for any post-release patches)
+**v1.0.3 / O103** (use for any post-release patches)
 
 ## Archive — internal patch builds (v1.0.1–v1.0.36)
 

--- a/agent_docs/version_registry.md
+++ b/agent_docs/version_registry.md
@@ -21,7 +21,7 @@ The `O10Z` code is a short identifier used in the plugin display name (e.g., O10
 | Version | Code | Description | Commit |
 |---------|------|-------------|--------|
 | v1.0.1 | O101 | Fix Immersive HRTF bass boost — correct low-shelf filter profile index (issue #198) | 70cc5d8 |
-| v1.0.2 | O102 | Filter graph UX: EQ8-style log grid + dB labels + proportional scale + extended drag (issue #196) | e3a0519 |
+| v1.0.2 | O102 | Filter graph UX: EQ8-style log grid, dB labels, proportional scale, log Q drag (issue #196) | 82d9f6f |
 
 ## Next available
 

--- a/agent_docs/version_registry.md
+++ b/agent_docs/version_registry.md
@@ -21,7 +21,7 @@ The `O10Z` code is a short identifier used in the plugin display name (e.g., O10
 | Version | Code | Description | Commit |
 |---------|------|-------------|--------|
 | v1.0.1 | O101 | Fix Immersive HRTF bass boost — correct low-shelf filter profile index (issue #198) | 70cc5d8 |
-| v1.0.2 | O102 | Filter graph UX: EQ8-style grid lines + extended nipple drag range (issue #196) | 14e8ac3 |
+| v1.0.2 | O102 | Filter graph UX: EQ8-style grid lines, proportional ±18 dB scale, extended drag range (issue #196) | d00e8fa |
 
 ## Next available
 

--- a/agent_docs/version_registry.md
+++ b/agent_docs/version_registry.md
@@ -21,7 +21,7 @@ The `O10Z` code is a short identifier used in the plugin display name (e.g., O10
 | Version | Code | Description | Commit |
 |---------|------|-------------|--------|
 | v1.0.1 | O101 | Fix Immersive HRTF bass boost — correct low-shelf filter profile index (issue #198) | 70cc5d8 |
-| v1.0.2 | O102 | Filter graph UX: EQ8-style grid lines, proportional ±18 dB scale, extended drag range (issue #196) | d00e8fa |
+| v1.0.2 | O102 | Filter graph UX: EQ8-style log grid + dB labels + proportional scale + extended drag (issue #196) | e3a0519 |
 
 ## Next available
 


### PR DESCRIPTION
## Summary

Overhauls the TONE section filter graph to match Ableton EQ8's visual style and interaction model:

- **Extended drag ranges**: HP/LP frequency both span full 20–20kHz; Q range extended to 0.1–8.0 so nipples reach all graph edges
- **Proportional ±18 dB scale**: 0 dB centered at 50% height (was asymmetric +18/-48 that wasted 70% of vertical space)
- **EQ8-style logarithmic frequency grid**: Per-decade subdivision lines (20, 30…90, 200, 300…900, etc.) in 3-tier brightness hierarchy
- **Horizontal dB grid lines with labels**: +12, +6, 0, -6, -12 labeled on left edge
- **Logarithmic Q drag**: `Q *= exp(0.042 * dy)` — constant ~4.3%/px feel at all Q values, eliminating jumpiness at low Q
- **Clean edge clipping**: Filter curve extends off-screen at bottom instead of sitting as a visible line

## Test plan

- [x] All 293 tests pass
- [x] v1.0.2/O102 built, installed, signed (AU + VST3)
- [x] Verified in REAPER — nipple drag smooth at all Q values, full graph range usable
- [x] Existing presets load correctly (expanded ranges are backward-compatible)

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)