### PR TITLE
Docs: fold #198 and #196 fixes into v1.0.0 registry/history

### DIFF
--- a/agent_docs/version_registry.md
+++ b/agent_docs/version_registry.md
@@ -14,14 +14,16 @@ The `O10Z` code is a short identifier used in the plugin display name (e.g., O10
 
 | Version | Code | Description | Commit |
 |---------|------|-------------|--------|
-| v1.0.0 | O100 | **Release v1.0.0** — all fixes issues #76–#200 squashed into one commit | 768c248 |
+| v1.0.0 | O100 | **Release v1.0.0** — issues #76–#200 + Immersive HRTF bass-boost fix (#198) + filter graph UX overhaul (#196). Rebuilt 2026-04-17 at ff9ec24. | ff9ec24 |
 
 ## Post-release patches
 
-| Version | Code | Description | Commit |
-|---------|------|-------------|--------|
-| v1.0.1 | O101 | Fix Immersive HRTF bass boost — correct low-shelf filter profile index (issue #198) | 70cc5d8 |
-| v1.0.2 | O102 | Filter graph UX: EQ8-style log grid, dB labels, proportional scale, log Q drag (issue #196) | 82d9f6f |
+_None active._ Fixes previously labelled v1.0.1 (#198) and v1.0.2 (#196) were folded back into the v1.0.0 bundle on 2026-04-17; those bundles were removed from the local plugins folder. See history below.
+
+| Version | Code | Description | Commit | Status |
+|---------|------|-------------|--------|--------|
+| v1.0.1 | O101 | Fix Immersive HRTF bass boost — correct low-shelf filter profile index (issue #198) | 70cc5d8 | Merged into v1.0.0 (2026-04-17) |
+| v1.0.2 | O102 | Filter graph UX: EQ8-style log grid, dB labels, proportional scale, log Q drag (issue #196) | 82d9f6f | Merged into v1.0.0 (2026-04-17) |
 
 ## Next available
 

--- a/docs/VERSION_HISTORY.md
+++ b/docs/VERSION_HISTORY.md
@@ -715,3 +715,10 @@ After the v1.0 real-world testing release, the following features and fixes were
 - **23 output formats** (was 22 at baseline, added 9.1 Surround)
 - **8 spatialization algorithms** (was 7, added Constant Power as default)
 - **291 Catch2 tests, 110,205 assertions** (was 162/1,255 at baseline). Added pre-release coverage: stereo input routing (4), 9.1/SML 13.1 surround (7), HOA 4OA–6OA initialization and stress (5).
+
+### v1.0.0 Rebuild (2026-04-17)
+
+Local v1.0.0 plugin bundle rebuilt at commit `ff9ec24` to fold in two fixes that had been issued as separate versioned builds for testing. The v1.0.0 plugin identity (`O100`) and release tag (`768c248`) are unchanged; this is a local rebuild so the single installed bundle carries all fixes. v1.0.1 and v1.0.2 bundles removed from the local plugins folder.
+
+- **Immersive HRTF bass-boost fix (Issue #198):** Corrected low-shelf filter profile index for the Immersive HRTF preset (was formerly issued as v1.0.1/O101 at 70cc5d8).
+- **Filter graph UX overhaul (Issue #196):** EQ8-style logarithmic frequency grid, dB labels, proportional ±18 dB scale, extended Q range (0.1–8.0), off-screen curve clipping, and logarithmic Q drag for uniform feel across the full range (was formerly issued as v1.0.2/O102 at 82d9f6f).


### PR DESCRIPTION
## Summary
- Local `v1.0.0` plugin bundle rebuilt at `ff9ec24` so the single installed `O100` bundle now contains the Immersive HRTF bass-boost fix (#198) and the EQ8-style filter graph UX overhaul (#196).
- `agent_docs/version_registry.md` — v1.0.0 row updated to cite commit `ff9ec24`; v1.0.1/v1.0.2 rows moved to a "merged into v1.0.0 (2026-04-17)" status note; next available remains v1.0.3 / O103.
- `docs/VERSION_HISTORY.md` — added a **v1.0.0 Rebuild (2026-04-17)** section documenting the two folded-in fixes, with original interim commits (`70cc5d8`, `82d9f6f`) cited for traceability.
- GitHub release tag `768c248` is intentionally unchanged — only the local `O100` bundle was rebuilt.

## Test plan
- [x] `v1.0.0.component` + `v1.0.0.vst3` reinstalled, re-signed, validated (subtype=O100, arm64)
- [x] `v1.0.1` and `v1.0.2` component + vst3 bundles removed from `~/Library/Audio/Plug-Ins/`
- [ ] Open DAW, confirm single `OpenSpatialDelay v1.0.0` entry shows the corrected Immersive HRTF bass and the new filter graph UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)