### PR TITLE
docs: consolidate internal docs against v1.0.0 shipped code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Spatial delay plugin — each echo lives in 3D space. VST3 + AU, macOS + Windows
 ## What
 - `Source/` — plugin processor, editor, DSP (PluginProcessor.cpp is ~175KB)
 - `Tests/` — Catch2 test suite (162+ tests)
-- `HRTF/` — SOFA files for binaural rendering (6 profiles)
+- `HRTF/` — 5 SOFA files for binaural rendering (the plugin exposes 6 binauralization options: these 5 profiles + a CPU-lite Woodworth ITD/ILD fallback that uses no SOFA file)
 - `scripts/` — build_version.sh, install helpers
 - `docs/` — user manual, legal notices, assets
 - `fonts/` — DM Sans, JetBrains Mono, Roboto (SIL OFL / Apache 2.0)

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ OpenSpatialDelay is the first plugin in the **Spatial Media Library** — an ope
 - Feedback filters (low-pass + high-pass with resonance), soft clipper, output limiter
 
 **Animation & Control**
-- 14 trajectory shapes per tap — Orbit, Figure-8, Spiral, Heart, Helix, Bounce, and more
+- 13 trajectory shapes per tap — Orbit, Figure-8, Spiral, Heart, Helix, Bounce, and more (plus "None" to keep a tap static)
 - Forward/reverse trajectory direction
 - [ADM-OSC](https://adm-osc.music.columbia.edu/) receive and send for external position control, plus full OSC control of all parameters via custom `/osd/` namespace
 - Doppler effect with distance-based air absorption
 
 **Workflow**
-- 70 factory presets across 9 categories
-- User preset save/load with custom categories
+- 70 factory presets across 8 curated categories, plus a User category for your own saves
+- Save / load your own presets, including custom categories, from the plugin header
 - Spatial map with real-time trajectory visualization
 - Global tap controls — 6 offset knobs that adjust all enabled taps simultaneously, preserving spatial arrangements
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ OpenSpatialDelay is the first plugin in the **Spatial Media Library** — an ope
 - 23 output formats — Binaural, Stereo (5 mic simulation modes), 15 Surround (Quad through 9.1.6 Atmos + SpatialMediaLab 13.1), 6 Ambisonics (1st through 6th order)
 
 **Delay & Modulation**
-- Tempo-synced or free-running delay with cumulative pitch shifting across taps
-- Per-tap pitch shift that preserves timing, layered on top of global pitch
+- Tempo-synced or free-running delay with per-tap pitch shift, layered on top of a global tap-pitch offset
+- Per-tap pitch shift (±12 semitones) that preserves timing via phase-vocoder STFT
 - Wobble modulation — delay-time LFO with morphable waveform (sine → square)
 - Stereo input routing with per-tap L/R channel selection
 - Feedback filters (low-pass + high-pass with resonance), soft clipper, output limiter

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,9 +1,10 @@
-# Spatial Media Library — Project Specification
-## OpenSpatialDelay v0.1
+# OpenSpatialDelay — Project Specification
 
-**Document Version:** 1.1
-**Date:** 2026-03-03
+**Document Version:** 2.0
+**Date:** 2026-04-21 (consolidated against v1.0.0 shipped code)
 **Author:** Andrew Rahman (Product Vision) & Claude (Technical Architecture)
+
+> This document is the technical specification for OpenSpatialDelay v1.0.0. It was consolidated on 2026-04-21 to reflect the shipped codebase. Features deferred post-v1.0 are tracked as GitHub issues — see §12 — and have been removed from this document.
 
 ---
 
@@ -12,34 +13,34 @@
 1. [Executive Summary](#1-executive-summary)
 2. [Product Vision](#2-product-vision)
 3. [Technical Architecture](#3-technical-architecture)
-4. [v0.1 Feature Specification — OpenSpatialDelay (Binaural)](#4-v01-feature-specification)
+4. [Feature Specification (v1.0.0)](#4-feature-specification)
 5. [Signal Flow](#5-signal-flow)
 6. [Spatialization Engine](#6-spatialization-engine)
 7. [HRTF Implementation](#7-hrtf-implementation)
-8. [UI Design Specification](#8-ui-design-specification)
+8. [UI Design](#8-ui-design)
 9. [Preset System](#9-preset-system)
 10. [ADM-OSC Integration](#10-adm-osc-integration)
 11. [Build, CI/CD & Distribution](#11-build-cicd--distribution)
-12. [Versioned Roadmap](#12-versioned-roadmap)
-13. [Plugin Suite Roadmap](#13-plugin-suite-roadmap)
-14. [Appendices](#14-appendices)
+12. [Release History & Post-v1.0 Backlog](#12-release-history--post-v10-backlog)
+13. [Appendices](#13-appendices)
 
 ---
 
 ## 1. Executive Summary
 
-**Spatial Media Library** is an open-source suite of spatial audio VST3/AU plugins that share a common multi-algorithm spatialization engine. The first product, **OpenSpatialDelay**, is a spatial delay effect where each delay tap is positioned in 3D space and rendered to binaural headphones or discrete surround speakers (Quad through 9.1.6 Atmos). The output format is determined by the DAW's track I/O bus, independent from the spatialization algorithm. The plugin targets music producers, live sound engineers, post-production professionals, and installation/research users.
+**OpenSpatialDelay** is an open-source spatial delay effect where each delay tap is positioned in 3D space and rendered to binaural headphones, Ambisonics, or discrete surround speakers (Quad through 9.1.6 Atmos). The output format is determined by the DAW's track I/O bus, independent from the spatialization algorithm. The plugin targets music producers, live sound engineers, post-production professionals, and installation/research users.
 
 **Key differentiators:**
 - User-selectable spatialization algorithm — 7 options (Ambisonics, ConstantPower, DBAP, KNN, MDAP, VBAP, VBIP)
 - 6 binauralization options: 5 curated HRTF profiles from academically validated, freely licensed databases + 1 CPU-lite option (Woodworth ITD+ILD approximation, not an HRTF)
-- Up to 12 manually placeable delay taps with preset trajectory system
-- Cumulative pitch shifting across taps
-- ADM-OSC integration for interoperability with spatial audio ecosystems (by v1.0)
+- Up to 12 manually placeable delay taps, each with its own pitch shift, Doppler, and animated trajectory
+- 14 trajectory shapes for per-tap animation (Orbit, Figure-8, Spiral, Helix, Heart, Bounce, etc.)
+- ADM-OSC receive + send for interoperability with spatial audio renderers, plus an `/osd/` namespace for full parameter control
+- Stereo input with per-tap L / R / L+R channel selection
 - Open-source, licensed under GPL-3.0
 - macOS (Apple Silicon) + Windows (x64), VST3 + AU
 
-**Target delivery:** Usable v0.1 by end of March 2026.
+**Release status:** v1.0.0 shipped 2026-04-17. See §12 for history and the post-v1.0 backlog (all tracked as GitHub issues).
 
 ---
 
@@ -77,81 +78,57 @@ A spatial delay plugin where each repeat occurs at a different, definable positi
 ## 3. Technical Architecture
 
 ### 3.1 Framework & Language
-- **Framework:** JUCE 8 (C++17, targeting C++20 features where beneficial)
+- **Framework:** JUCE 8.0.3 (C++17)
 - **Build system:** CMake 3.22+
-- **Spatial audio HRTF parsing:** libmysofa (LGPL 2.1+ — compatible with open-source distribution)
-- **OSC transport (v0.3+):** JUCE `juce_osc` module (built-in `OSCSender` / `OSCReceiver` classes over UDP) — no external dependencies required
+- **Spatial audio HRTF parsing:** libmysofa v1.3.2 (BSD-3-Clause — compatible with GPL-3.0 distribution)
+- **OSC transport:** JUCE `juce_osc` module (built-in `OSCSender` / `OSCReceiver` over UDP) — no external dependencies required
 
 ### 3.2 Module Architecture
 
-The codebase is organized into a shared core library and per-plugin modules:
+The v1.0 codebase is a single-plugin flat layout. All DSP, UI, and integration code lives in `Source/`. There is no `SpatialMediaLab/Core/` shared library in v1.0 — that remains the long-term ambition for the plugin suite and is tracked in issue [#221](https://github.com/Spatial-Media-Lab/OpenSpatialDelay/issues/221).
 
 ```
-SpatialMediaLab/
-|-- Core/                          # Shared spatial engine (used by ALL plugins)
-|   |-- SpatialEngine/
-|   |   |-- SpatializationAlgorithm.h      # Abstract base class
-|   |   |-- VBAPPanner.h / .cpp            # Vector Base Amplitude Panning
-|   |   |-- VBIPPanner.h / .cpp            # Vector Base Intensity Panning
-|   |   |-- AmbisonicEncoder.h / .cpp      # HOA Ambisonics encoding
-|   |   |-- KNNPanner.h / .cpp             # K-Nearest Neighbor panning
-|   |   |-- DBAPPanner.h / .cpp            # Distance-Based Amplitude Panning
-|   |   |-- SpeakerLayout.h / .cpp         # Speaker configuration definitions
-|   |   |-- BinauralRenderer.h / .cpp      # HRTF convolution engine
-|   |   |-- HRTFManager.h / .cpp           # SOFA/HRTF loading & management
-|   |   `-- SourcePosition.h               # 3D position (azimuth, elevation, distance)
-|   |-- DSP/
-|   |   |-- PitchShifter.h / .cpp          # Granular or FFT pitch shifting
-|   |   |-- SmoothParameter.h / .cpp       # Lock-free parameter smoothing
-|   |   `-- InterpolatedDelay.h / .cpp     # Fractional delay line
-|   |-- Preset/
-|   |   |-- PresetManager.h / .cpp         # Load/save/factory presets
-|   |   `-- TrajectoryEngine.h / .cpp      # Spatial trajectory definitions
-|   |-- OSC/                                       # (v0.3+)
-|   |   |-- ADMOSCSender.h / .cpp          # Send tap positions as ADM-OSC objects
-|   |   |-- ADMOSCReceiver.h / .cpp        # Receive positions from external controllers
-|   |   `-- ADMOSCConfig.h / .cpp          # IP/port/rate configuration
-|   `-- UI/
-|       |-- SpatialMapComponent.h / .cpp   # 2D top-down visualizer (shared)
-|       |-- LookAndFeel_SML.h / .cpp       # Shared visual theme
-|       `-- CommonControls.h / .cpp        # Knobs, sliders, buttons
-|
-|-- Plugins/
-|   |-- OpenSpatialDelay/
-|   |   |-- PluginProcessor.h / .cpp       # Delay-specific audio processing
-|   |   |-- PluginEditor.h / .cpp          # Delay-specific UI
-|   |   |-- DelayLine.h / .cpp             # Multi-tap delay engine
-|   |   `-- TapManager.h / .cpp            # Per-tap state management
-|   |-- OpenSpatialReverb/                 # (Future)
-|   |-- OpenSpatialGranular/               # (Future)
-|   |-- OpenSpatialPanner/                 # (Future)
-|   `-- OpenSpatialChorus/                 # (Future)
-|
-|-- Resources/
-|   |-- HRTF/                              # Bundled HRTF SOFA files
-|   |   |-- MIT_KEMAR.sofa
-|   |   |-- SADIE_II_D2_KU100.sofa
-|   |   |-- CIPIC_Subject003.sofa
-|   |   |-- HUTUBS_PP2.sofa
-|   |   `-- Bernschuetz_KU100_Full2Deg.sofa
-|   |-- Presets/                           # Factory presets (JSON)
-|   `-- Fonts/                             # UI fonts
-|
-|-- Tests/
-|   |-- SpatialEngineTests.cpp
-|   |-- DelayLineTests.cpp
-|   |-- HRTFTests.cpp
-|   `-- analyze_spatial.py                 # Phase alignment validation
-|
-`-- CMakeLists.txt                         # Top-level build configuration
-```
+OpenSpatialDelay/
+|-- Source/                        # Plugin implementation (flat)
+|   |-- PluginProcessor.h / .cpp       # ~175KB — DSP engine, APVTS, spatialization, HRTF,
+|   |                                  # delay taps, feedback, OSC, preset state
+|   |-- PluginEditor.h / .cpp          # UI, Colours_OSD palette, spatial map, controls
+|   |-- PhaseVocoderPitchShifter.h     # STFT pitch shifter (2048 FFT, 4x overlap, ±12 st)
+|   |-- TrajectoryEngine.h / .cpp      # 14 trajectory shapes for animated taps
+|   |-- FilterBank.h / .cpp            # Feedback-path LP + HP biquads with resonance
+|   |-- DopplerVelocity.h / .cpp       # Per-tap Doppler pitch from position velocity
+|   |-- PresetData.h / .cpp            # 70 factory presets (C++ static structs)
+|   |-- SharedFFTCache.h               # Global vDSP FFT setup reuse (multi-instance)
+|-- HRTF/                          # 5 embedded SOFA files
+|   |-- bernschuetz_ku100.sofa             # CC BY 3.0
+|   |-- cipic_subject_003.sofa             # Public Domain
+|   |-- hutubs_pp2.sofa                    # CC BY 4.0
+|   |-- mit_kemar_large_pinna.sofa         # MIT license
+|   `-- sadie_d2_ku100.sofa                # Apache 2.0
+|-- fonts/                         # Embedded UI fonts
+|   |-- DM_Sans-*.ttf                      # SIL OFL 1.1 (Regular, Medium, SemiBold, Bold)
+|   |-- JetBrains_Mono-*.ttf               # SIL OFL 1.1 (Regular, Medium, Bold)
+|   `-- Roboto-Medium.ttf                  # Apache 2.0
+|-- Tests/                         # Catch2 suite
+|   |-- DSPUnitTests.cpp
+|   |-- IntegrationTests.cpp
+|   |-- SurroundOutputTests.cpp
+|   |-- ConvolverGlitchTests.cpp
+|   |-- OscTests.cpp
+|   |-- ParameterCountTests.cpp
+|   |-- PreReleaseTests.cpp
+|   `-- TrajectoryTests.cpp
+|-- JUCE/                          # JUCE 8.0.3 (git submodule)
+|-- scripts/                       # build_version.sh, install helpers, video tooling
+|-- docs/                          # User manual PDF, legal notices, version history
+`-- CMakeLists.txt                 # juce_add_plugin target; PLUGIN_CODE Os10
 
 ### 3.3 Core Design Principles
 
-1. **Lock-free audio processing:** The `processBlock` callback must never allocate memory, acquire locks, or perform I/O. All parameter changes use `std::atomic` or lock-free FIFOs.
-2. **SIMD optimization:** Use JUCE's `FloatVectorOperations` (which maps to ARM NEON on Apple Silicon and SSE/AVX on x64) for all bulk channel operations — gain scaling, buffer copying, accumulation.
-3. **Algorithm abstraction:** All spatialization algorithms inherit from `SpatializationAlgorithm` and implement a common interface (`computeGains(SourcePosition, SpeakerLayout) -> float[]`), enabling runtime algorithm switching without architectural changes.
-4. **Shared core, independent plugins:** Each plugin in the suite links against the same `SpatialMediaLab_Core` static library. Plugin-specific DSP lives in the plugin module only.
+1. **Lock-free audio processing:** The `processBlock` callback never allocates, acquires locks, or performs I/O. Parameter changes flow via `std::atomic` loads from APVTS or lock-free FIFOs.
+2. **SIMD optimization:** JUCE's `FloatVectorOperations` (ARM NEON on Apple Silicon, SSE/AVX on x64) handles bulk channel operations — gain scaling, buffer copies, accumulation.
+3. **Algorithm abstraction:** All 7 spatialization algorithms inherit from a common interface (`computeGains(SourcePosition, SpeakerLayout) → float[]`), enabling runtime algorithm switching.
+4. **Shared FFT setup:** Multi-instance plugin scenarios share a global vDSP FFT setup via `SharedFFTCache` to avoid per-instance allocation spikes.
 
 ### 3.4 I/O Architecture
 
@@ -159,41 +136,44 @@ SpatialMediaLab/
 
 #### 3.4.1 Input Format
 
-| Format | Channels | Behavior | Version |
-|--------|----------|----------|---------|
-| Mono | 1 | Direct pass-through to delay engine | v0.1+ |
-| Stereo | 2 | L+R summed to mono internally (`(L+R)*0.5`) | v0.2+ |
-
-Independent L/R delay processing is deferred to v1.0.
+| Format | Channels | Behavior |
+|--------|----------|----------|
+| Mono | 1 | Direct pass-through to the delay engine |
+| Stereo | 2 | Independent L and R delay lines; each tap chooses L, R, or L+R via the per-tap `inputChannel` parameter |
 
 #### 3.4.2 Output Format
 
 The plugin auto-detects the output format from the host's track channel count. All speaker positions follow ITU-R BS.775 (ear-level) and BS.2051 (height) standards. Convention: 0° = front, positive azimuth = left.
 
-| Output Format | Channels | Speaker Layout | LFE | Version |
-|---------------|----------|----------------|-----|---------|
-| Binaural (Stereo) | 2 | Virtual speakers → HRTF renderer | No | v0.1+ |
-| Quadraphonic | 4 | L(30°), R(-30°), Ls(110°), Rs(-110°) | No | v0.2 |
-| 5.1 Surround | 6 | L, R, C, Ls, Rs + LFE (ch3) | Yes | v0.2 |
-| 7.1 Surround | 8 | L, R, C, Lss(90°), Rss(-90°), Lsr(135°), Rsr(-135°) + LFE | Yes | v0.2 |
-| 7.1.4 (Atmos bed) | 12 | 7.1 ear-level + Tfl, Tfr, Trl, Trr at 45° elevation + LFE | Yes | v0.2 |
-| 9.1.6 (Atmos full) | 16 | 9.1 ear-level + Tfl, Tfr, Tsl, Tsr, Trl, Trr at 45° elevation + LFE | Yes | v0.2 |
+| Output Format | Channels | Speaker Layout | LFE |
+|---------------|----------|----------------|-----|
+| Stereo (Binaural or encoded) | 2 | Binaural HRTF renderer (default), or one of: Equal Power, Stereo VBAP, XY, MS, Blumlein (selectable when bus is stereo) | No |
+| Quadraphonic | 4 | L(30°), R(-30°), Ls(110°), Rs(-110°) | No |
+| 5.1 Surround | 6 | L, R, C, Ls, Rs + LFE (ch3) | Yes |
+| 7.1 Surround | 8 | L, R, C, Lss(90°), Rss(-90°), Lsr(135°), Rsr(-135°) + LFE | Yes |
+| 7.1.4 (Atmos bed) | 12 | 7.1 ear-level + Tfl, Tfr, Trl, Trr at 45° elevation + LFE | Yes |
+| 9.1.6 (Atmos full) | 16 | 9.1 ear-level + Tfl, Tfr, Tsl, Tsr, Trl, Trr at 45° elevation + LFE | Yes |
+| Ambisonics (HOA) | 4 / 9 / 16 / 25 / 36 / 49 | 1st through 6th order spherical harmonic channels | No |
 
 **Algorithm × Output Format compatibility:**
 
-| Algorithm | Binaural (2ch) | Discrete Surround (4–16ch) |
-|-----------|----------------|---------------------------|
-| Direct Binaural | Yes | No (auto-disabled on surround tracks) |
-| VBAP | Yes (via 16 virtual speakers) | Yes (2D for flat layouts, 3D for height) |
-| Ambisonics (HOA) | Yes (SH → binaural decode) | Yes (SH → Tikhonov-regularized speaker decode) |
-| VBIP | Yes (via virtual speakers) | Yes (intensity-weighted VBAP) |
-| KNN | Yes (via virtual speakers) | Yes (K-nearest neighbor) |
+| Algorithm | Binaural (2ch) | Discrete Surround (4–16ch) | Ambisonics |
+|-----------|----------------|----------------------------|------------|
+| VBAP | Yes (via virtual speaker layout) | Yes (2D pair-wise, 3D triplet-wise for height) | Via SH encode |
+| VBIP | Yes (via virtual speakers) | Yes (intensity-weighted VBAP) | Via SH encode |
+| KNN | Yes (via virtual speakers) | Yes (k-nearest-neighbor interpolation) | Via SH encode |
+| Ambisonics (HOA) | Yes (SH → binaural decode) | Yes (SH → Tikhonov-regularized speaker decode) | Native |
+| DBAP | Yes (via virtual speakers) | Yes (no sweet-spot assumption) | Via SH encode |
+| MDAP | Yes (via virtual speakers) | Yes (multi-direction amplitude panning) | Via SH encode |
+| ConstantPower | Yes (stereo path) | Limited (pair-wise constant-power between two nearest speakers) | Via SH encode |
+
+A dedicated Direct Binaural rendering path (`renderDirectBinauralHRTF`) is used for stereo/binaural output regardless of algorithm selection — each tap is convolved with the HRTF for its position directly, without going through a virtual speaker intermediary.
 
 **Rendering paths:**
-- **Binaural:** VBAP/VBIP/KNN algorithms route through a 16-speaker virtual layout, rendered to L/R via the selected HRTF profile (ITD+ILD model). Ambisonics encodes to SH and decodes to binaural via SH weights. Direct Binaural bypasses virtual speakers entirely.
-- **Discrete Surround:** Algorithms compute gains directly for the physical speaker layout defined by the active output format. LFE is generated from a mono sum of all spatialized object signals, filtered at 120 Hz (2nd-order Butterworth LP) and attenuated by −10 dB. Dry signal is routed to L and R channels only (channels 0–1), not distributed to all speakers.
-
-**Future extension:** Stereo encoding variants (Stereo VBAP, XY, MS, Blumlein) could be added as distinct 2-channel output modes, distinguished from Binaural by a user-facing dropdown that appears only when the DAW bus is stereo. Not currently planned.
+- **Binaural (2ch, default for stereo bus):** Each active tap is convolved with the selected HRTF profile for its azimuth/elevation via a partitioned FFT convolver. Dry signal follows a stereo path with 2048-sample PDC to match the phase-vocoder latency.
+- **Stereo encoded (2ch, opt-in):** Taps are routed through one of 5 stereo encoding modes (Equal Power, Stereo VBAP, XY, MS, Blumlein) when the user selects a stereo mode instead of Binaural.
+- **Discrete Surround (4–16ch):** Algorithms compute gains directly for the physical speaker layout. LFE is derived from a mono sum of spatialized objects (120 Hz 2nd-order Butterworth LP, −10 dB). Dry signal is routed to L/R only.
+- **Ambisonics (4–49ch):** Tap positions are encoded into spherical harmonics up to 6th order. No speaker decode occurs inside the plugin — the Ambisonics bus is the output.
 
 #### 3.4.3 Bus Layout Negotiation
 
@@ -203,61 +183,103 @@ The plugin queries the host via JUCE's `BusesLayout` system:
 - **Supported outputs:** Stereo, Quadraphonic, 5.1, 7.1, 7.1.4, 9.1.6
 - **Internal bus:** Up to 16 discrete output channels. Actual channel count determined by the track the plugin is placed on.
 - **Detection flow:** `prepareToPlay()` calls `detectOutputFormat(getTotalNumOutputChannels())` → `activateLayout(format)`, which configures the `SpeakerLayout` struct, computes the Ambisonics decode matrix (Tikhonov-regularized pseudo-inverse), and builds VBAP triplets for height layouts.
-- **UI adaptation:** The editor reads `getActiveOutputFormat()` each timer tick. On surround tracks, Direct Binaural is disabled (auto-switches to VBAP) and the HRTF Profile dropdown is hidden.
+- **UI adaptation:** The editor polls the active output format each timer tick. On stereo bus (binaural), the HRTF profile selector is visible and the output-format dropdown exposes the stereo-encoding modes (Equal Power, Stereo VBAP, XY, MS, Blumlein). On surround or Ambisonics buses, the HRTF selector is hidden and the algorithm selector drives all output channels.
 
 ---
 
-## 4. v0.1 Feature Specification
+## 4. Feature Specification
 
-### 4.1 Delay Engine
+Ranges and defaults are sourced from `Source/PluginProcessor.cpp::createParameterLayout`. The plugin exposes **143 APVTS parameters** total (23 global + 10 per-tap × 12 taps) — verified by `Tests/ParameterCountTests.cpp`.
+
+### 4.1 Global Parameters (23)
+
+**Delay**
 
 | Parameter | Range | Default | Notes |
-|-----------|-------|---------|-------|
-| Delay Time | 1 ms — 2000 ms | 500 ms | Per tap; also expressible as tempo-synced note value |
-| Tempo Sync | On/Off | Off | When On, delay time snaps to note divisions |
-| Note Divisions | 1/1, 1/2, 1/4, 1/8, 1/16 (straight, dotted, triplet) | 1/4 | Only active when Tempo Sync is On |
-| Feedback | 0% — 100% | 30% | Global; feeds output back through the spatial trajectory |
-| Filter (Low-Pass) | 200 Hz — 20 kHz | 20 kHz | Global; applied to feedback path |
-| Filter (High-Pass) | 20 Hz — 5 kHz | 20 Hz | Global; applied to feedback path |
-| Pitch Shift | -12 st — +12 st | 0 st | Global; cumulative per tap (Tap N = N * shift amount) |
-| Dry/Wet | 0% — 100% | 50% | Blend control |
-| Input Gain | -inf — +12 dB | 0 dB | Pre-processing level |
-| Output Gain | -inf — +12 dB | 0 dB | Post-processing level |
+|---|---|---|---|
+| Delay Time | 1 – 2000 ms | 500 ms | Master free-run delay time. Overridden by sync division when tempo sync is on. |
+| Tempo Sync | On/Off | Off | When on, delay time snaps to a note division. |
+| Note Division | 0.5 – 32 sixteenths (continuous float) | 4.0 (1/4) | Active only when Tempo Sync is on. |
+| Sync Mode | Straight / Dotted / Triplet | Straight | Modifier for note division. |
+| Feedback | 0 – 100% | 30% | Feedback into the pre-spatial mono feedback path. |
+| Dry/Wet | 0 – 100% | 50% | Equal-power (cos/sin) crossfade at the post-render stage. |
 
-### 4.2 Tap System
+**Feedback filter**
+
+| Parameter | Range | Default | Notes |
+|---|---|---|---|
+| Filter On | On/Off | On | Master bypass for the feedback-path filter bank. |
+| Filter HP Frequency | 20 – 5000 Hz | 50 Hz | High-pass biquad on the feedback path. |
+| Filter HP Q | 0.1 – 4.0 | 0.707 | HP resonance. |
+| Filter LP Frequency | 200 – 20000 Hz | 5000 Hz | Low-pass biquad on the feedback path. |
+| Filter LP Q | 0.1 – 4.0 | 0.707 | LP resonance. |
+
+**Modulation & air**
+
+| Parameter | Range | Default | Notes |
+|---|---|---|---|
+| Wobble On | On/Off | Off | Master bypass for delay-time wobble modulation. |
+| Wobble Amount | 0 – 100% | 0% | Depth of wobble on delay time. |
+| Wobble Morph | 0 – 100% | 0% | Morphs the LFO waveform from sine (0%) to square (100%). |
+| Air Absorption | On/Off | On | Enables distance-driven high-frequency attenuation. |
+
+**I/O gain**
+
+| Parameter | Range | Default | Notes |
+|---|---|---|---|
+| Input Gain | −100 dB – +40 dB | 0 dB | Applied before the delay engine. |
+| Output Gain | −100 dB – +12 dB | 0 dB | Applied after dry/wet mix. |
+
+**Global tap offsets** (additive on top of each enabled tap's own value)
+
+| Parameter | Range | Default | Notes |
+|---|---|---|---|
+| Global Tap Azimuth | −180° – +180° | 0° | Rotates all taps by a common offset. |
+| Global Tap Elevation | −90° – +90° | 0° | Tilts all taps by a common offset. |
+| Global Tap Distance | 0.0 – 1.0 | 0.0 | Pushes all taps radially outward. |
+| Global Tap Pitch | −12 st – +12 st | 0 st | Shifts every tap's pitch by a common offset. |
+| Global Tap Doppler | 0.0 – 1.0 | 0.0 | Scales every tap's Doppler amount. |
+| Global Tap Speed | 0.0 – 1.0 | 0.0 | Scales every tap's trajectory speed. |
+
+### 4.2 Per-Tap Parameters (10 × 12 taps = 120)
+
+The plugin has 12 delay taps. Each tap has 10 APVTS parameters:
+
+| Parameter | Range | Notes |
+|---|---|---|
+| On | On/Off | Whether the tap contributes to the output. |
+| Azimuth | −180° – +180° | 0° = front, positive = left. |
+| Elevation | −90° – +90° | Polar elevation. |
+| Distance | 0.0 – 1.0 | Normalized; drives distance attenuation + air absorption. |
+| Doppler Amount | 0.0 – 1.0 | Per-tap Doppler pitch from position velocity. |
+| Pitch Shift | −12 st – +12 st | Per-tap phase-vocoder pitch shift, additive with Global Tap Pitch. |
+| Trajectory Shape | 14 options: None, Orbit, Circle, Line, Bounce, Cross, Figure-8, Heart, Helix, Infinity, Random, Spiral, Square, Triangle | Animated trajectory. |
+| Trajectory Speed | 0.0 – 1.0 | Rate (multiplied by Global Tap Speed). |
+| Trajectory Direction | Forward / Reverse | Trajectory animation direction. |
+| Input Channel | L+R / L / R | Which input channel feeds this tap's delay line. |
+
+### 4.3 Spatial Rendering
 
 | Feature | Specification |
-|---------|--------------|
-| Maximum taps | 12 |
-| Positioning | Manual placement on 2D top-down map |
-| Position parameters | Azimuth (-180 to +180 deg), Elevation (-90 to +90 deg), Distance (0.0 to 1.0 normalized) |
-| Tap activation | Each tap can be enabled/disabled individually |
-| Tap delay time | Each tap has its own delay time (ms or synced note value) |
-| Static positions (v0.1) | Taps remain fixed during playback |
-| Animated trajectories | Planned for future version (with optional Doppler effect) |
-
-### 4.3 Spatial Rendering (v0.1 Binaural, v0.2+ Multi-Format)
-
-| Feature | Specification |
-|---------|--------------|
-| Output format | Binaural stereo (v0.1+), Quad/5.1/7.1/7.1.4/9.1.6 surround (v0.2+) — see Section 3.4.2 |
-| Spatialization algorithm | User-selectable: 7 options — Ambisonics, ConstantPower, DBAP, KNN, MDAP, VBAP, VBIP (binaural routing is a separate render path, not an algorithm choice) |
-| HRTF profiles | 5 built-in options (see Section 7) — binaural output only |
-| HRTF convolution | Partitioned FFT convolution for low-latency, artifact-free rendering |
-| Distance attenuation | Inverse distance law applied automatically (no user control in v0.1) |
-| Distance filtering | High-frequency rolloff proportional to distance (air absorption model) |
-| LFE generation | 120 Hz LP (2nd-order Butterworth), −10 dB — surround formats with LFE only |
+|---|---|
+| Output formats | Stereo (binaural + 5 encoded stereo modes), Quad, 5.1, 7.1, 7.1.4, 9.1.6, plus 1st–6th order Ambisonics. See §3.4.2. |
+| Spatialization algorithm | User-selectable: Ambisonics, ConstantPower, DBAP, KNN, MDAP, VBAP, VBIP (7 options). |
+| Binauralization options | 6 total — 5 HRTF profiles (Immersive, Natural, Precise, Spatial, Studio Reference) plus 1 CPU-lite "Simple (Low CPU)" Woodworth ITD+ILD option (not an HRTF). |
+| HRTF convolution | Partitioned FFT convolution with spectral-envelope EMA smoothing (magnitude + phase per bin) to prevent phase-misalignment comb filtering. |
+| Distance attenuation | Inverse-distance law applied automatically. |
+| Air absorption | High-frequency roll-off proportional to distance; toggleable via the Air Absorption global. |
+| LFE generation | 120 Hz 2nd-order Butterworth LP, −10 dB, derived from a mono sum of spatialized signals; applied on surround formats that carry LFE. |
 
 ### 4.4 DAW Integration
 
 | Feature | Specification |
-|---------|--------------|
-| Plugin formats | VST3, AU (macOS only) |
-| Sample rates | 44.1 kHz, 48 kHz, 88.2 kHz, 96 kHz (received from host DAW via `prepareToPlay`; no hardcoded sample rates) |
-| Buffer sizes | 64 — 4096 samples |
-| Parameter automation | All global parameters automatable via host |
-| State save/restore | Full state serialization (preset + tap positions + all parameters) |
-| Tempo sync | Reads BPM from host transport |
+|---|---|
+| Plugin formats | VST3 (macOS + Windows), AU (macOS only) |
+| Sample rates | Whatever the host reports via `prepareToPlay`; no hardcoded rates. Verified in tests at 44.1, 48, 88.2, 96 kHz. |
+| Buffer sizes | 64 – 4096 samples |
+| Parameter automation | All 143 APVTS parameters are host-automatable. A subset of 64 is marked as automation-discoverable for Ableton auto-populate. |
+| State save/restore | Full APVTS state + preset metadata. |
+| Tempo sync | Reads BPM and transport position from host. |
 
 ---
 
@@ -297,7 +319,7 @@ The plugin queries the host via JUCE's `BusesLayout` system:
           |      v                 v                 v
           |  +---+---+        +---+---+        +---+---+
           |  | Pitch |        | Pitch |        | Pitch |
-          |  |+1*P st|        |+2*P st|        |+N*P st|  (cumulative)
+          |  | P_1   |        | P_2   |        | P_N   |  (per-tap value + global offset)
           |  +---+---+        +---+---+        +---+---+
           |      |                 |                 |
           |      |  (each tap's mono signal + 3D position)
@@ -305,21 +327,21 @@ The plugin queries the host via JUCE's `BusesLayout` system:
           |      v                 v                 v
           |  +---+-----------------+-----------------+---+
           |  |     SPATIALIZATION ALGORITHM (per tap)     |
-          |  |  User-selectable: VBAP, Ambisonics, or    |
-          |  |  Direct Binaural (see Section 6)           |
+          |  |  User-selectable (7 options): Ambisonics, |
+          |  |  ConstantPower, DBAP, KNN, MDAP, VBAP,    |
+          |  |  VBIP (see §6.2)                           |
           |  |                                            |
           |  |  Input:  tap mono + position (az, el, dst) |
-          |  |  Output: speaker gains[] for virtual layout|
+          |  |  Output: speaker gains[] or SH coefficients|
           |  +---+-----------------+-----------------+---+
           |      |                 |                 |
           |      v                 v                 v
           |  +---+-----------------+-----------------+---+
-          |  |       BINAURAL RENDERER (shared)          |
-          |  |  Renders virtual speaker signals to L/R   |
-          |  |  via HRTF profile (ITD+ILD or convolution)|
-          |  |                                           |
-          |  |  For Direct Binaural: position → L/R      |
-          |  |  For VBAP/Ambi: speakers → binaural → L/R |
+          |  |        OUTPUT RENDERER (by bus)           |
+          |  |  Binaural (2ch): per-tap HRTF convolution |
+          |  |  Stereo encoded: 5 mic-sim modes          |
+          |  |  Surround: gains → physical speakers + LFE|
+          |  |  Ambisonics: SH coefficients → N channels |
           |  +---+-----------------------------+---------+
           |      |                             |
           |      v                             v
@@ -352,8 +374,8 @@ The plugin queries the host via JUCE's `BusesLayout` system:
                  |
                  v
              +---+---+
-             | Pitch |    Apply full round-trip shift: N * P
-             |N*P st |
+             | Pitch |    Feedback-path pitch shifter
+             | P_fb  |
              +---+---+
                  |
                  v
@@ -377,37 +399,33 @@ The plugin queries the host via JUCE's `BusesLayout` system:
 
 ### Spatial Ping-Pong Concept
 
-This delay works like a traditional ping-pong delay, but instead of bouncing between just Left and Right, the signal "travels" through N spatial positions in 3D space. Each tap is a sequential station along one shared delay chain. The signal enters the delay line, appears at Tap 1's spatial position after 1× base delay, at Tap 2's position after 2× base delay, and so on. When it reaches the last tap (Tap N), the feedback path reads that signal, filters and pitch-shifts it by the cumulative amount (N × P), and feeds it back to the delay input — completing the round trip so the whole spatial sequence repeats.
+This delay works like a traditional ping-pong delay, but instead of bouncing between just Left and Right, the signal "travels" through up to 12 spatial positions in 3D space. Each tap is a sequential station along one shared delay chain. The signal enters the delay line, appears at Tap 1's spatial position after 1× base delay, at Tap 2's position after 2× base delay, and so on. When it reaches the last enabled tap, the feedback path reads that signal, filters and pitch-shifts it, and feeds it back to the delay input — completing the round trip so the whole spatial sequence repeats. Each tap applies its own per-tap pitch value (plus the Global Tap Pitch offset); pitch is **not** multiplied by tap index.
 
 ### Two-Stage Spatialization Architecture
 
 The rendering of each tap to the output is a **two-stage process** designed for modularity across the entire Spatial Media Library plugin suite:
 
-**Stage A — Spatialization Algorithm (pluggable, user-selectable):**
-Each tap's mono signal and 3D position are fed into the selected algorithm, which computes gain coefficients for the active speaker layout:
-- **Direct Binaural:** Bypasses virtual speakers entirely. Source position maps directly to binaural L/R gains. Only available on stereo (binaural) tracks.
-- **VBAP:** Triangulates the source position against the speaker layout. Pair-wise (2D) for flat layouts, triplet-wise (3D) for height layouts.
-- **Ambisonics (HOA):** Encodes the source into 3rd-order spherical harmonics, then decodes to the speaker layout via Tikhonov-regularized pseudo-inverse matrix.
-- **VBIP:** Intensity-weighted VBAP — squares gains for better energy preservation with off-center sources.
-- **KNN:** K-nearest-neighbor interpolation against the speaker layout positions.
-
-All algorithms implement the shared `SpatializationAlgorithm` interface (see Section 6.1) and operate on whatever `SpeakerLayout` is active — virtual (for binaural) or physical (for surround). Future algorithms (DBAP) can be added without changing the delay engine.
+**Stage A — Spatialization Algorithm (user-selectable, 7 options):**
+Each tap's mono signal and 3D position are fed into the selected algorithm, which computes gain coefficients for the active speaker layout. See §6.2 for the full list.
 
 **Stage B — Output Renderer (output-format-dependent):**
-The renderer is determined by the DAW's track I/O bus (see Section 3.4.2):
-- **Binaural (2ch):** Virtual speaker contributions are rendered to headphone L/R using the selected HRTF profile (ITD+ILD model). Ambisonics decodes directly to binaural via SH weights.
-- **Discrete Surround (4–16ch):** Algorithm gains are routed directly to the physical output channels defined by the active `SpeakerLayout`. LFE is derived from a mono sum of all spatialized signals (120 Hz LP, −10 dB). Dry signal is routed to L/R only.
+Determined by the DAW's track I/O bus (see §3.4.2):
+- **Stereo / Binaural (2ch):** `renderDirectBinauralHRTF` convolves each tap with the HRTF for its position. This path bypasses the virtual speaker array entirely. Stereo-encoded modes (Equal Power, Stereo VBAP, XY, MS, Blumlein) are an alternative when the user selects one instead of Binaural.
+- **Discrete Surround (4–16ch):** Algorithm gains are routed to the physical output channels defined by the active `SpeakerLayout`. LFE is derived from a mono sum of spatialized signals (120 Hz LP, −10 dB). Dry signal is routed to L/R only.
+- **Ambisonics (4–49ch):** Tap positions are encoded into 1st–6th order spherical harmonics with no speaker decode inside the plugin.
 
-The algorithm stage is fully reusable across all output formats.
+The algorithm stage is reusable across all output formats. Binaural output always uses direct per-tap HRTF convolution — it is not a Stage A algorithm choice.
 
 ### Feedback Path
 
 **Critical: the feedback path is MONO and pre-spatial.** Spatialization is applied only in the output rendering path. The feedback loop stays in the mono domain, reading from a single point at the end of the tap chain. This ensures clean, stable feedback without spatial rendering artifacts accumulating in the loop.
 
-### Implementation Notes
+### Implementation Notes (v1.0.0)
 
-- **v0.1:** All three algorithm options use the same simplified binaural renderer (`computeBinauralGains()` — Woodworth ITD + broadband ILD). HRTF convolution (partitioned FFT) is a future priority.
-- **v0.2:** Adds discrete surround output (Quad through 9.1.6), VBIP and KNN algorithms, 2D/3D VBAP, Ambisonics decode to arbitrary speaker layouts, and LFE generation. All five algorithms are fully implemented for both binaural and surround paths.
+- **Binaural path:** `renderDirectBinauralHRTF()` convolves each tap with the selected HRTF profile for its position via partitioned FFT convolution. The 16-speaker virtual layout is used only for surround algorithm gains, not for binaural routing.
+- **All 7 algorithms shipped:** Ambisonics, ConstantPower, DBAP, KNN, MDAP, VBAP, VBIP — all concrete classes wired in `PluginProcessor.cpp`.
+- **Dry path latency compensation:** Dry signal flows through a stereo `dryDelayLineL/R` sized to `PhaseVocoderPitchShifter::kFFTSize` (2048) samples, matching the phase vocoder's report to `setLatencySamples`. Changing FFT size or overlap requires updating both paths together.
+- **Shared FFT:** Global vDSP FFT setup is reused across instances via `SharedFFTCache` to avoid multi-instance allocation spikes.
 
 ---
 
@@ -434,52 +452,62 @@ public:
 };
 ```
 
-### 6.2 Algorithms to Implement
+### 6.2 Algorithms Shipped in v1.0.0
 
-| Algorithm | Academic Reference | Priority | Notes |
-|-----------|--------------------|----------|-------|
-| **VBAP** | Pulkki, "Virtual Sound Source Positioning Using Vector Base Amplitude Panning," JAES 1997 | v0.1 | Industry standard. Triangulation-based. Pair-wise (2D) or triplet-wise (3D). |
-| **Ambisonics (HOA)** | Daniel, "Representation de champs acoustiques," PhD Thesis, 2000 | v0.1 | Encode to spherical harmonics, decode to any speaker layout. Up to 7th order (64 channels). |
-| **Direct HRTF** | N/A (convolution-based) | v0.1 | For binaural: skip speaker panning, convolve source directly with HRTF at the tap's position. Most accurate for headphone rendering. |
-| **KNN** | Based on nearest-neighbor interpolation of HRTF measurements | v0.2 | Use K nearest measured HRTF positions and interpolate. |
-| **VBIP** | Intensity-weighted variant of VBAP | v0.2 | Better energy preservation than VBAP for off-center sources. |
-| **DBAP** | Lossius, Baltazar, de la Hogue, "DBAP — Distance-Based Amplitude Panning," ICMC 2009 | v0.3 | No sweet spot assumption. Ideal for installations with irregular layouts. |
+All seven algorithms below are concrete classes in `Source/PluginProcessor.cpp` and wired into the `algorithms[]` dispatch table.
 
-### 6.3 Binaural Rendering (v0.1)
+| Algorithm | Academic Reference | Notes |
+|-----------|--------------------|-------|
+| **VBAP** | Pulkki, "Virtual Sound Source Positioning Using Vector Base Amplitude Panning," JAES 1997 | Pair-wise (2D) for flat layouts, triplet-wise (3D) for height layouts. |
+| **VBIP** | Intensity-weighted variant of VBAP | Squared gains, renormalized. Better energy preservation for off-centre sources. |
+| **Ambisonics (HOA)** | Daniel, "Représentation de champs acoustiques," PhD Thesis, 2000 | Encode to spherical harmonics (1st–6th order), decode to speaker layout via Tikhonov-regularized pseudo-inverse. |
+| **KNN** | Nearest-neighbor interpolation over the speaker layout | Use k nearest speaker positions and interpolate. |
+| **DBAP** | Lossius, Baltazar, de la Hogue, ICMC 2009 | No sweet-spot assumption; suited to irregular layouts. |
+| **MDAP** | Pulkki, "Multiple-Direction Amplitude Panning," AES 1999 | Spreads energy across multiple directions around the source; softer than VBAP for moving sources. |
+| **ConstantPower** | Standard equal-power pan law | Pair-wise constant-power panning between the two nearest speakers. |
 
-For v0.1 (binaural output), the rendering path is:
+A dedicated **Direct Binaural** render path (`renderDirectBinauralHRTF`) convolves each tap with the selected HRTF for its exact position — this is always used for the stereo/binaural output bus, independent of the algorithm selection.
 
-1. For each active tap, look up the nearest HRTF pair (left ear IR, right ear IR) for the tap's azimuth/elevation.
-2. Convolve the tap's delayed+pitched audio with the left-ear and right-ear impulse responses.
-3. Apply distance attenuation (inverse distance law) and air absorption (6 dB/doubling distance high-shelf filter).
-4. Sum all tap contributions into the stereo binaural output.
+### 6.3 Binaural Rendering (v1.0.0)
 
-**HRTF interpolation:** For positions between measured HRTF directions, use spherical linear interpolation (SLERP) between the nearest 3 measured positions (triangulated on the measurement sphere).
+For stereo/binaural output, `renderDirectBinauralHRTF()` executes a 3-pass architecture:
 
-**Convolution strategy:** Partitioned overlap-save FFT convolution with partition size matching the host buffer size for zero-latency operation.
+1. **Pass 1 — Per-sample delay engine → per-source mono accumulation.** Each active tap reads its delayed signal, applies per-tap pitch shift (phase-vocoder STFT), Doppler, and distance attenuation.
+2. **Pass 2 — Per-block HRTF convolution via `BinauralRenderer::renderSourceBuffers()`.** Each tap's mono signal is convolved with the HRTF for its current azimuth/elevation. Partitioned overlap-save FFT convolution with the partition size matched to the host buffer.
+3. **Pass 3 — Per-sample dry/wet mix + output gain.** Equal-power (cos/sin) crossfade between the stereo dry path (latency-compensated to match the phase vocoder's 2048-sample delay) and the wet sum.
+
+**HRTF lookup:** For positions between measured HRTF directions, `libmysofa`'s KD-tree lookup returns the nearest measured position. HRIR updates at block boundaries with ~1° threshold for realtime-safe position-driven reloading.
+
+**Spectral envelope smoothing:** The `PartitionedConvolver` applies EMA smoothing to magnitude and phase separately per frequency bin, avoiding comb filtering that would result from phase-misaligned time-domain IR blending.
+
+**ITD handling:** SOFA files that bake ITD into the HRIR waveform (e.g. MIT KEMAR) use an onset-detection-driven ITD delay line that is effectively a pass-through; other profiles use the explicit delay values in the SOFA file.
+
+See `agent_docs/architecture.md` for deeper implementation detail.
 
 ---
 
 ## 7. HRTF Implementation
 
-### 7.1 Selected HRTF Profiles
+### 7.1 Binauralization Options
 
-Five individual HRTF profiles, each selected for its distinct sonic character and free, redistribution-compatible license:
+The plugin exposes 6 binauralization options in the HRTF profile selector. Index 0 is a CPU-lite analytical model (no SOFA file); indices 1–5 are measured HRTFs loaded from SOFA files embedded in the plugin binary. Index order matches `hrtfProfileNames[]` in `Source/PluginProcessor.cpp`.
 
-| # | User-Facing Label | Source Database | Measurement ID | Head Type | License |
-|---|------------------|-----------------|----------------|-----------|---------|
-| 1 | **Studio Reference** | MIT KEMAR | Large pinna (DB-065) | KEMAR dummy head | MIT-style permissive |
-| 2 | **Immersive** | SADIE II (York) | Subject D2 | Neumann KU100 dummy | Apache 2.0 |
-| 3 | **Natural** | CIPIC (UC Davis) | Subject 003 | Human | Public domain |
-| 4 | **Precise** | HUTUBS (TU Berlin) | Subject PP2 | Human | CC BY 4.0 |
-| 5 | **Spatial** | Bernschuetz (TH Koeln) | HRIR_FULL2DEG | Neumann KU100 dummy | CC BY 3.0 |
+| Index | User-Facing Label | Source | Head Type | License |
+|---|---|---|---|---|
+| 0 | **Simple (Low CPU)** | Woodworth ITD + broadband ILD model — analytical, no SOFA file | — | — |
+| 1 | **Immersive** | SADIE II (York), Subject D2 | Neumann KU100 dummy | Apache 2.0 |
+| 2 | **Natural** | CIPIC (UC Davis), Subject 003 | Human | Public Domain |
+| 3 | **Precise** | HUTUBS (TU Berlin), Subject PP2 | Human | CC BY 4.0 |
+| 4 | **Spatial** | Bernschütz (TH Köln), HRIR_FULL2DEG | Neumann KU100 dummy | CC BY 3.0 |
+| 5 | **Studio Reference** | MIT KEMAR, large pinna (DB-065) | KEMAR dummy head | MIT |
 
 **Profile character descriptions (for UI tooltips):**
-1. **Studio Reference** — The most widely used reference HRTF in spatial audio. Neutral, predictable imaging. Best starting point.
-2. **Immersive** — Rich spatial image with strong elevation cues. Adopted by Google for VR audio. Slightly warmer tonality.
-3. **Natural** — Measured from a human subject. Most transparent lateral imaging for users with average head geometry.
-4. **Precise** — Cross-validated with numerical simulation. Excellent phase accuracy. Analytically wide image.
-5. **Spatial** — Ultra-high-resolution measurement (2-degree grid). Smoothest spatial transitions. No interpolation artifacts.
+- **Simple (Low CPU)** — Analytical ITD + ILD. Lowest CPU cost. Not an HRTF — no pinna / torso cues.
+- **Immersive** — Rich spatial image with strong elevation cues. Slightly warmer tonality.
+- **Natural** — Measured from a human subject. Transparent lateral imaging for average head geometry.
+- **Precise** — Cross-validated with numerical simulation. Strong phase accuracy. Analytically wide image.
+- **Spatial** — Ultra-high-resolution 2° grid. Smoothest spatial transitions.
+- **Studio Reference** — The most widely used reference HRTF in spatial audio. Neutral, predictable imaging.
 
 ### 7.2 HRTF File Format & Loading
 
@@ -488,158 +516,95 @@ Five individual HRTF profiles, each selected for its distinct sonic character an
 - **Bundle strategy:** All 5 SOFA files are embedded in the plugin binary as binary resources via JUCE's `BinaryData` system. No external file dependencies.
 - **Memory footprint:** Estimated 5-15 MB total for all 5 profiles (depending on spatial resolution). Only the active profile is loaded into the convolution engine at runtime.
 
-### 7.3 Future HRTF Features (Post-v0.1)
-- Custom SOFA file import (user loads their own HRTF)
-- Companion iPhone app for HRTF personalization via ear scanning (LiDAR + photogrammetry)
+### 7.3 Post-v1.0 HRTF Backlog
+
+Tracked as GitHub issues — not in scope for this specification:
+
+- Custom SOFA file import — issue [#218](https://github.com/Spatial-Media-Lab/OpenSpatialDelay/issues/218)
+- Companion iPhone app for HRTF personalization via LiDAR ear scanning — issue [#220](https://github.com/Spatial-Media-Lab/OpenSpatialDelay/issues/220)
 
 ---
 
-## 8. UI Design Specification
+## 8. UI Design
 
-### 8.1 Design Language
+The canonical visual reference for the shipped UI is the annotated user manual at `docs/OpenSpatialDelay_Manual_v1.0.pdf`. This section describes the structural contract only; colour and typography values are sourced from code.
 
-Inspired by Sound Particles inDelay (functional layout) and SnappySnap (aesthetic):
+### 8.1 Design Tokens
 
-- **Background:** Deep dark charcoal/near-black (#0A0A14)
-- **Primary accent:** Neon cyan (#00D4FF)
-- **Secondary accent:** Electric purple (#8B5CF6)
-- **Active elements:** Warm amber/gold (#F59E0B)
-- **Text:** Off-white (#E2E8F0) on dark backgrounds
-- **Panels:** Subtle glassmorphism with 1px border (#1E293B), slight background blur
-- **Corner radius:** 8-12px on panels
-- **Typography:** Clean sans-serif (Inter or system font)
-- **Tap indicators:** Colored circles on the spatial map, one distinct color per tap
+**Window:** 820 × 580 px, resizable. Implementation in `Source/PluginEditor.h/.cpp`.
 
-### 8.2 Layout (Approximate 800x500px Window)
+**Typography** (embedded via `BinaryData`, declared in `CMakeLists.txt`):
 
-```
-+------------------------------------------------------------------+
-|  OpenSpatialDelay                    [Preset: v] [<] [>] [Save]  |
-+------------------------------------------------------------------+
-|                                                                    |
-|  +--------------------------------------------+  +-------------+ |
-|  |                                            |  | ALGORITHM   | |
-|  |          2D SPATIAL MAP                    |  | [VBAP    v] | |
-|  |          (Top-Down View)                   |  |             | |
-|  |                                            |  | HRTF        | |
-|  |     Listener (center dot)                  |  | [Studio  v] | |
-|  |     Taps (colored circles 1-12)            |  |             | |
-|  |     Azimuth ring markings                  |  | DELAY TIME  | |
-|  |     Distance rings                         |  | [500 ms   ] | |
-|  |                                            |  | [Sync: Off] | |
-|  |                                            |  |             | |
-|  +--------------------------------------------+  | FEEDBACK    | |
-|                                                   | [###  30%]  | |
-|  +--------------------------------------------+  |             | |
-|  | TAP TIMELINE                               |  | FILTER      | |
-|  | [1][2][3][4][5][6][7][8][9][10][11][12]     |  | HP [20 Hz ] | |
-|  | Time: |====o==========| 500ms              |  | LP [20 kHz] | |
-|  | Az:   |========o======| +45 deg            |  |             | |
-|  | El:   |=====o=========| +10 deg            |  | PITCH       | |
-|  | Dist: |==o============| 0.3                |  | [+0 st    ] | |
-|  +--------------------------------------------+  |             | |
-|                                                   | DRY/WET     | |
-|  +---+  +---+  +---+                             | [###  50%]  | |
-|  |IN |  |OUT|  |D/W|                              |             | |
-|  | 0 |  | 0 |  |50%|                              | [IN] [OUT]  | |
-|  |dB |  |dB |  |   |                              | 0dB   0dB   | |
-|  +---+  +---+  +---+                             +-------------+ |
-+------------------------------------------------------------------+
-```
+| Family | Weights | License |
+|---|---|---|
+| DM Sans | Regular, Medium, SemiBold, Bold | SIL OFL 1.1 |
+| JetBrains Mono | Regular, Medium, Bold | SIL OFL 1.1 |
+| Roboto | Medium | Apache 2.0 |
 
-### 8.3 UI Components
+**Colour palette** (`Colours_OSD` namespace, `Source/PluginEditor.cpp`). Colours are near-black surfaces with six functional accents and 12 per-tap object colours.
 
-**Spatial Map (Main Area)**
-- 2D top-down circular view
-- Listener at center (fixed dot or head icon)
-- Concentric rings indicating distance (0.25, 0.5, 0.75, 1.0)
-- Azimuth markings at 0/90/180/270 degrees
-- Taps shown as numbered, color-coded draggable circles
-- Click to add tap, right-click to remove
-- Drag to reposition
+| Token | Value | Purpose |
+|---|---|---|
+| `bgVoid` | `#03060b` | Page background |
+| `bgPanel` | `#0a0d12` | Panel surface |
+| `bgHeader` | `#06090f` | Header bar |
+| `bgRecessed` | `#010205` | Recessed wells (filter graph, spatial map) |
+| `bgWell` | `#020307` | Slider / knob wells |
+| `borderSubtle` | `#252930` | Panel borders |
+| `borderDim` | `#171b20` | Divider lines |
+| `accentStellar` | `#80d8ff` | Delay section |
+| `accentViolet` | `#7457d1` | Tone / filter section |
+| `accentAmber` | `#f0a646` | Mix / output section |
+| `accentGreen` | `#3bce6c` | OSC section |
+| `accentRose` | `#e467a6` | Modulation section |
+| `accentSync` | `#e1c34b` | Tempo-sync indicator |
+| `textPrimary` | `#e1e5ea` | Primary text |
+| `textSecondary` | `#9fa5ae` | Secondary text |
 
-**Tap Timeline (Below Map)**
-- Horizontal strip showing all 12 tap slots
-- Selected tap is highlighted; its parameters appear below
-- Per-tap sliders: delay time, azimuth, elevation, distance
-- Tap enable/disable toggle per slot
+In addition, `Colours_OSD` defines 12 per-tap object colours (a red → rose spectrum) used across the spatial map, per-tap timeline, and tap-specific knobs.
 
-**Control Panel (Right Side)**
-- Algorithm selector dropdown (VBAP, HOA, Direct HRTF)
-- HRTF profile selector dropdown (5 profiles)
-- Global delay time (with tempo sync toggle + note division selector)
-- Global feedback knob
-- Global filter (HP + LP)
-- Global pitch shift
-- Dry/Wet knob
-- Input/Output gain knobs
+### 8.2 Layout Regions
 
-**Header Bar**
-- Plugin name and version
-- Preset browser (dropdown + prev/next + save button)
+Current (v1.0.0) editor structure:
+
+- **Header bar** — preset browser (dropdown + prev / next / save / menu), input format indicator, output format indicator, ADM-OSC status, plugin name/version.
+- **Spatial map (centre)** — 2D top-down view with listener at origin, 12 colour-coded draggable tap handles, distance rings, azimuth markings, and live trajectory-animation trails.
+- **Global Tap Drawer (left edge, collapsible)** — 6 offset knobs (Azimuth, Elevation, Distance, Pitch, Doppler, Speed) that adjust all enabled taps simultaneously while preserving their relative arrangement.
+- **Right panel** — algorithm selector, HRTF profile selector, filter section (HP + LP with Q, filter-graph visualization, Filter On bypass), wobble modulation section (amount + morph + on/off), OSC configuration (enable, send/receive toggles, IP/port), dry/wet, input / output gain.
+- **Bottom panel** — per-tap controls for the currently-selected tap: delay-tap index selector, on/off, azimuth, elevation, distance, doppler amount, pitch shift, trajectory shape + speed + direction, input channel.
+
+### 8.3 Interaction Patterns
+
+- Drag tap handles on the spatial map to reposition in azimuth/distance; double-click a handle to select.
+- Right-click any knob or slider for context menu (reset, enter value, link to MIDI, link to OSC).
+- Shift-drag on knobs for fine precision; double-click to reset.
+- Undo/redo via DAW standard shortcuts maps to internal APVTS undo stack; preset name updates on undo/redo.
 
 ---
 
 ## 9. Preset System
 
-### 9.1 Preset File Format
+### 9.1 Preset Format
 
-Presets are stored as JSON files:
+Factory presets are defined as C++ `static const` structs in `Source/PresetData.cpp` and compiled into the plugin binary. At plugin install time, a post-build script writes each factory preset to `~/Library/Audio/Presets/OpenSpatialDelay/<Category>/<Name>.json` (macOS) so users can see, copy, and edit them with any text editor.
 
-```json
-{
-    "name": "Orbital Spiral",
-    "version": "1.0",
-    "plugin": "OpenSpatialDelay",
-    "algorithm": "VBAP",
-    "hrtfProfile": 0,
-    "globalParams": {
-        "feedback": 0.35,
-        "filterHP": 80.0,
-        "filterLP": 12000.0,
-        "pitchShift": 2.0,
-        "dryWet": 0.5,
-        "inputGain": 0.0,
-        "outputGain": 0.0,
-        "tempoSync": false,
-        "delayTimeMs": 375.0,
-        "noteDivision": "1/4"
-    },
-    "taps": [
-        {
-            "index": 0,
-            "enabled": true,
-            "delayTimeMs": 250.0,
-            "azimuthDeg": -30.0,
-            "elevationDeg": 0.0,
-            "distance": 0.4
-        },
-        {
-            "index": 1,
-            "enabled": true,
-            "delayTimeMs": 500.0,
-            "azimuthDeg": 45.0,
-            "elevationDeg": 15.0,
-            "distance": 0.6
-        }
-    ]
-}
-```
+Preset JSON carries the full APVTS state (23 globals + 10 × 12 per-tap params) plus metadata (name, category, description, version). User-saved presets live in the same directory and are indistinguishable to the loader from factory presets.
 
-### 9.2 Factory Presets (v0.1)
+### 9.2 Factory Presets
 
-A minimal set shipping with the plugin:
+v1.0.0 ships **70 factory presets** across **9 categories**:
 
-| Preset Name | Description | Taps Used |
-|-------------|-------------|-----------|
-| **Default** | Single centered tap, 500ms, no pitch shift | 1 |
-| **Stereo Ping-Pong** | Two taps at -90 and +90 degrees, alternating | 2 |
-| **Circle (Quad)** | 4 taps at 0, 90, 180, 270 degrees equidistant | 4 |
-| **Surround 5.1** | 5 taps positioned at L, R, C, Ls, Rs | 5 |
-| **Surround 7.1** | 7 taps at standard 7.1 speaker positions | 7 |
-| **Atmos 7.1.4** | 11 taps at 7.1.4 speaker positions | 11 |
-| **Rising Spiral** | 8 taps spiraling outward with +2st pitch | 8 |
-| **Falling Cascade** | 6 taps descending in elevation with -1st pitch | 6 |
+| Category | Focus |
+|---|---|
+| Classic Delays | Familiar delay archetypes (ping-pong, slap, dotted eighth, etc.) |
+| Spatial Movement | Orbiting, spiralling, and trajectory-led presets |
+| Ambient + Texture | Long-tail, pad-friendly spatial washes |
+| Height + 3D | Presets exercising elevation and 3D spatial layouts |
+| Surround Production | Quad / 5.1 / 7.1 / 7.1.4 / 9.1.6 mix-ready configurations |
+| Wobble + Modulated | Tape-style and LFO-driven wobble presets |
+| Creative + Experimental | Non-standard designs (gated, chaotic, glitch) |
+| Rhythmic | Tempo-synced grooves and polymetric patterns |
+| User | Empty at ship; fills with user-saved presets |
 
 ---
 
@@ -651,7 +616,7 @@ A minimal set shipping with the plugin:
 
 By implementing ADM-OSC, OpenSpatialDelay (and all future Spatial Media Library plugins) can interoperate with the professional spatial audio ecosystem — sending tap positions to external renderers (L-ISA, SPAT Revolution, Dolby Atmos Renderer) and receiving position data from external controllers, consoles, or automation systems.
 
-**ADM-OSC is not required for v0.1.** It is targeted for **v0.3** (send) and **v1.0** (full send + receive), as it becomes critical once surround speaker output is implemented.
+**Status in v1.0.0:** Full send + receive are live. In addition to the ADM-OSC namespace, OSD exposes its own `/osd/` namespace for controlling every plugin parameter via OSC (both inbound and outbound).
 
 ### 10.2 ADM-OSC Message Specification
 
@@ -677,10 +642,17 @@ The plugin will implement the ADM-OSC v1.0 namespace. All messages use the form 
 
 #### Object Property Messages
 
-| OSC Address | Type | Range | Description |
-|-------------|------|-------|-------------|
-| `/adm/obj/N/gain` | float | 0 to 1 | Linear gain (1.0 = unity) |
-| `/adm/obj/N/w` | float | 0 to 1 | Width / extent of object |
+The ADM-OSC `/gain` and `/w` (width) property messages are defined by the spec but **not implemented in v1.0.0**. Tracked in issue [#222](https://github.com/Spatial-Media-Lab/OpenSpatialDelay/issues/222).
+
+#### `/osd/` Namespace (OSD-specific)
+
+In addition to ADM-OSC, OSD exposes all plugin parameters via an `/osd/` namespace — receive and send. Examples:
+
+- `/osd/obj/N/enabled`, `/osd/obj/N/pitch`, `/osd/obj/N/doppler`, `/osd/obj/N/trajectory`, `/osd/obj/N/speed`, `/osd/obj/N/direction`, `/osd/obj/N/input`
+- `/osd/obj/N/azim` / `/elev` / `/dist` / `/aed` / `/xyz` (aliases mirroring the ADM-OSC object position messages)
+- `/osd/global/delaytime`, `/osd/global/feedback`, `/osd/global/filterlp`, `/osd/global/filterhp`, `/osd/global/wobble`, `/osd/global/wobbleamount`, `/osd/global/wobblemorph`, `/osd/global/drywet`, `/osd/global/inputgain`, `/osd/global/outputgain`, `/osd/global/air`, `/osd/global/temposync`, `/osd/global/notedivision`, `/osd/global/syncmode`, `/osd/global/filterenabled`, `/osd/global/filterlpq`, `/osd/global/filterhpq`, `/osd/global/tapazimuth`, `/osd/global/tapelevation`, `/osd/global/tapdistance`, `/osd/global/tappitch`, `/osd/global/tapdoppler`, `/osd/global/tapspeed`
+
+All `/osd/` messages support both send and receive.
 
 #### Coordinate System
 
@@ -693,28 +665,17 @@ The plugin will implement the ADM-OSC v1.0 namespace. All messages use the form 
 | Parameter | Value | Notes |
 |-----------|-------|-------|
 | Protocol | UDP | Standard for real-time OSC |
-| Default send port | 4001 | ADM-OSC recommended default |
-| Default receive port | 4002 | For bidirectional communication |
-| Ports | User-configurable | Editable in plugin settings panel |
+| Default send port | 4003 | Editable in the plugin header |
+| Default receive port | 4002 | Editable in the plugin header |
 | IP address | User-configurable | Default: `127.0.0.1` (localhost) for same-machine use |
 
 ### 10.4 Behavioral Modes
 
-**Send Mode (v0.3):**
-The plugin transmits the spatial position of each active delay tap as an ADM-OSC object. When tap positions change (via user interaction, preset loading, or trajectory animation), the plugin sends updated position messages to the configured destination IP:port. This allows external renderers to mirror the spatial scene.
+**Send:** The plugin broadcasts the spatial position of each active delay tap as an ADM-OSC object (`/adm/obj/N/aed`) and mirrors plugin parameters on `/osd/global/...` and `/osd/obj/N/...`. Each tap maps to an ADM-OSC object (Tap 1 = `/adm/obj/1/...`, etc.). Updates are rate-limited to avoid UDP flooding.
 
-- Each tap maps to an ADM-OSC object: Tap 1 = `/adm/obj/1/...`, Tap 2 = `/adm/obj/2/...`, etc.
-- Position updates are sent at a configurable rate (default: 30 Hz) to avoid UDP flooding
-- Gain messages reflect per-tap level (accounting for distance attenuation)
+**Receive:** The plugin listens for ADM-OSC position messages and `/osd/` parameter messages and updates internal state via a lock-free FIFO to the audio thread. Enables external controllers (tablets, consoles, motion capture) to drive tap positions and any plugin parameter.
 
-**Receive Mode (v1.0):**
-The plugin listens for incoming ADM-OSC messages and updates tap positions accordingly. This enables:
-- External spatial controllers (tablets, consoles, motion capture) to drive tap positions
-- DAW-to-DAW spatial scene sharing
-- Live performance control from mixing consoles (DiGiCo, Lawo, etc.)
-
-**GET Requests (v1.0):**
-Per the ADM-OSC spec, sending a message without arguments acts as a GET request. The plugin will respond with the current value. Example: receiving `/adm/obj/4/xyz` (no args) triggers a reply of `/adm/obj/4/xyz -0.5 0.8 0.0`.
+Both send and receive can be independently enabled / disabled from the plugin header.
 
 ### 10.5 Implementation via JUCE
 
@@ -723,7 +684,7 @@ JUCE provides a native `juce_osc` module with `OSCSender` and `OSCReceiver` clas
 ```cpp
 // Sending tap position via ADM-OSC
 juce::OSCSender sender;
-sender.connect("127.0.0.1", 4001);
+sender.connect("127.0.0.1", 4003);
 
 // For each active tap, send its position
 for (int i = 0; i < numActiveTaps; ++i)
@@ -754,27 +715,14 @@ void oscMessageReceived(const juce::OSCMessage& message) override
 
 ### 10.6 UI Integration
 
-When ADM-OSC is enabled, the plugin settings panel will include:
+ADM-OSC and `/osd/` namespace configuration lives in the plugin header:
 
-```
-+------------------------------------------+
-| ADM-OSC Settings                         |
-|                                          |
-| [x] Enable ADM-OSC                       |
-|                                          |
-| Mode:  [Send ▼]  (Send / Receive / Both) |
-|                                          |
-| Send To:                                 |
-| IP:   [127.0.0.1    ]  Port: [4001]      |
-|                                          |
-| Receive On:                              |
-| Port: [4002]                             |
-|                                          |
-| Update Rate: [30 Hz ▼]                   |
-|                                          |
-| Status: ● Connected (sending)            |
-+------------------------------------------+
-```
+- **Enable** toggles for send and receive (independent).
+- **Send IP** and **Send Port** fields (default `127.0.0.1:4003`).
+- **Receive Port** field (default `4002`).
+- Status indicators for current send/receive state.
+
+See the user manual (`docs/OpenSpatialDelay_Manual_v1.0.pdf`) for annotated screenshots.
 
 ### 10.7 Compatible Software & Hardware
 
@@ -838,126 +786,55 @@ Jobs:
       - Package: .vst3 bundle
       - Upload artifacts
 
-  Release (on tag push):
-    - Download artifacts from both jobs
-    - Create GitHub Release with .zip archives for each platform
 ```
+
+A tag-push release job (automatic GitHub Release creation) is not part of v1.0.0 CI — releases are cut manually via `gh release create`. Automating this is tracked in issue [#223](https://github.com/Spatial-Media-Lab/OpenSpatialDelay/issues/223).
 
 ### 11.3 Distribution
 
-| Phase | Method |
-|-------|--------|
-| v0.x (current) | GitHub Releases — free, open-source |
-| v1.0+ (future) | Potential website with optional paid downloads |
-| Copy protection | None (honor system) for v0.x |
+| Channel | Method |
+|---|---|
+| Releases | [github.com/Spatial-Media-Lab/OpenSpatialDelay/releases](https://github.com/Spatial-Media-Lab/OpenSpatialDelay/releases) — free, open-source |
+| Copy protection | None (honour system) |
 
-### 11.4 Code Signing (Future)
+### 11.4 Code Signing
 
-- **macOS:** Apple Developer Program ($99/yr) for notarization. Not required for v0.1 (unsigned binaries can be opened via right-click > Open). Consider when distributing to non-technical users.
-- **Windows:** EV code signing certificate for SmartScreen trust. Not required for v0.1.
+Not shipping in v1.0.0. macOS binaries require the user to run `xattr -cr` after download; Windows binaries trigger SmartScreen. Both macOS notarization (Apple Developer Program) and Windows EV code signing are tracked in issue [#217](https://github.com/Spatial-Media-Lab/OpenSpatialDelay/issues/217). The SignPath workflow template in `.github/workflows/build-windows.yml` is present but commented out, ready to activate once the certificate is procured.
 
 ---
 
-## 12. Versioned Roadmap
+## 12. Release History & Post-v1.0 Backlog
 
-### Phase 1: v0.1 — Binaural Spatial Delay (Target: End of March 2026)
+### 12.1 Release History
 
-**Milestone: A working, installable plugin that a user can load in a DAW.**
+For the per-patch changelog, see [`docs/VERSION_HISTORY.md`](docs/VERSION_HISTORY.md). Summary of major milestones:
 
-| Week | Focus | Deliverables |
-|------|-------|-------------|
-| 1 (Mar 3-9) | Project scaffolding | CMake setup, JUCE project, module structure, CI pipeline, HRTF loading with libmysofa, basic delay line |
-| 2 (Mar 10-16) | Core DSP | Multi-tap delay engine (12 taps), HRTF convolution, binaural renderer, pitch shifter, feedback path with filters |
-| 3 (Mar 17-23) | UI + Integration | Spatial map component, tap timeline, control panel, parameter binding, preset save/load |
-| 4 (Mar 24-31) | Polish + Release | Factory presets, testing on macOS + Windows, bug fixes, GitHub Release |
+| Version | Released | Headline |
+|---|---|---|
+| v0.1 | 2026-03-31 | First installable plugin — binaural spatial delay, HRTF convolution, 12 taps, basic UI |
+| v0.2 | Q2 2026 | Surround output (Quad / 5.1 / 7.1 / 7.1.4 / 9.1.6), VBIP + KNN algorithms, Ambisonics decode, LFE, stereo input |
+| v0.3 | Q2 2026 | Direct binaural rendering path (per-tap HRTF lookup); virtual-speaker cleanup; DBAP |
+| v0.4 | Q3 2026 | Animated trajectories, trajectory presets, tempo-synced animation, Doppler, ADM-OSC Send |
+| v0.5 – v0.9 | Q3 2026 – Apr 2026 | Stereo encoding modes, MDAP + ConstantPower algorithms, Ambisonics 1st–6th order, wobble modulation, phase-vocoder pitch, Global Tap Offsets, 70 factory presets, user manual |
+| **v1.0.0** | **2026-04-17** | Public release under the Spatial Media Lab org; ADM-OSC Receive + full `/osd/` namespace; production documentation |
 
-### Phase 2: v0.2 — Surround Output + Enhanced Algorithms (Q2 2026) *(Implemented)*
+### 12.2 Post-v1.0 Backlog
 
-| Feature | Details | Status |
-|---------|---------|--------|
-| Binaural output | Stereo HRTF-based rendering (ITD+ILD model) | Carried from v0.1 |
-| Quadraphonic output | 4-channel speaker output (ITU-R BS.775) | Done |
-| 5.1 surround output | 6-channel speaker output + LFE | Done |
-| 7.1 surround output | 8-channel speaker output + LFE | Done |
-| 7.1.4 output (Atmos bed) | 12-channel with 4 height speakers + LFE | Done |
-| 9.1.6 output (Atmos full) | 16-channel with 6 height speakers + LFE | Done |
-| Dynamic channel detection | `detectOutputFormat()` maps DAW bus channel count to output format | Done |
-| LFE generation | 120 Hz Butterworth LP, −10 dB, from mono sum of spatialized signals | Done |
-| Context-sensitive UI | Direct Binaural disabled on surround tracks; HRTF dropdown hidden | Done |
-| VBIP algorithm | Intensity-weighted VBAP (squared gains, re-normalized) | Done |
-| KNN algorithm | K-nearest-neighbor speaker interpolation | Done |
-| 2D/3D VBAP | Pair-wise for flat layouts, triplet-wise for height layouts | Done |
-| Ambisonics surround decode | 3rd-order SH → Tikhonov-regularized pseudo-inverse decode matrix | Done |
-| Stereo input (summed to mono) | L+R × 0.5 internal mono conversion | Done |
+Features deferred past v1.0.0 are tracked as GitHub issues on the `Spatial-Media-Lab/OpenSpatialDelay` repo. They are **not** described in detail in this specification.
 
-### Phase 3: v0.3 — Direct Binaural Rendering + Architecture Refinement (Q2 2026)
-
-| Feature | Details |
-|---------|---------|
-| **Direct binaural rendering** | **Per-source HRTF convolution — each tap's 3D position (azimuth + elevation) maps directly to an HRTF lookup via SOFA file. No intermediate virtual speaker layout. Replaces the 16-speaker virtual array binaural path.** |
-| **Monitoring format removal** | **Eliminates the monitoring format dropdown entirely. Virtual speaker layouts are no longer needed for binaural output.** |
-| **Output-format-aware algorithm UI** | **Binaural (2ch): algorithm locked to "Direct Binaural", greyed out. Surround (>2ch): full algorithm menu (VBAP, VBIP, KNN, Ambisonics).** |
-| **Virtual speaker cleanup** | **Removes speaker convolver bank (speakerConvL/R[16]), SH convolver bank (shConvL/R[16]), renderSpeakerBuffers(), renderSHBuffers(), computeSHProjectedHRIRs(). Replaced by 12 per-source convolvers.** |
-| **Per-source HRIR update** | **Realtime-safe position-driven HRIR reloading at block boundaries via libmysofa KD-tree lookup + in-place FFT. ~1° threshold, <0.5% CPU typical.** |
-
-### Phase 4: v0.4 — Trajectories + ADM-OSC Send + Enhanced DSP (Q3 2026)
-
-| Feature | Details |
-|---------|---------|
-| Animated trajectories | Real-time tap movement during playback |
-| Trajectory presets | Spiral, bounce, orbit, random drift, figure-8 |
-| Tempo-synced trajectories | Movement speed locked to host BPM |
-| Doppler effect | Pitch shift proportional to tap velocity |
-| DBAP algorithm | Distance-based amplitude panning for installations |
-| **ADM-OSC Send** | **Transmit tap positions as ADM-OSC objects via UDP/OSC to external renderers (SPAT Revolution, L-ISA, etc.). Configurable destination IP/port, 30 Hz default update rate. Uses JUCE `juce_osc` module.** |
-
-### Phase 5: v1.0.0 — Production Release (Q1 2026, shipping week of 2026-04-10)
-
-| Feature | Status | Details |
-|---------|--------|---------|
-| Stereo input support | **Done** | Per-tap L+R/L/R input channel selection with dual delay lines |
-| Per-tap pitch shift | **Done** | ±24 semitone range via phase vocoder, additive to global pitch |
-| Global modulation (LFO) | **Done** | Wobble modulation with morphable waveform (sine → square) |
-| ADM-OSC Receive | **Done** | Incoming ADM-OSC messages control tap positions; OSC control of all parameters via `/osd/` namespace |
-| ADM-OSC Send | **Done** | Broadcast tap positions to external renderers (L-ISA, SPAT Revolution, Dolby Atmos Renderer) |
-| ADM-OSC Settings (header bar) | **Done** | Enable/disable, IP/port config, send/receive toggles in plugin header — uses ADM-OSC standards for object positions |
-| Expanded factory presets | **Done** | 70 factory presets across 9 categories |
-| User manual / documentation | **Done** | PDF manual with signal flow diagram, annotated screenshots, glossary, legal notices |
-| Custom SOFA import | **Deferred indefinitely** | User loads their own HRTF files |
-| AAX format | **Deferred post-v1.0** | Pro Tools compatibility |
-| Code signing | **Deferred post-v1.0** | macOS notarization + Windows EV certificate |
+| Issue | Title |
+|---|---|
+| [#217](https://github.com/Spatial-Media-Lab/OpenSpatialDelay/issues/217) | Code signing — macOS notarization + Windows EV certificate |
+| [#218](https://github.com/Spatial-Media-Lab/OpenSpatialDelay/issues/218) | Custom SOFA file import — user-loaded HRTF profiles |
+| [#219](https://github.com/Spatial-Media-Lab/OpenSpatialDelay/issues/219) | AAX plugin format — Pro Tools compatibility |
+| [#220](https://github.com/Spatial-Media-Lab/OpenSpatialDelay/issues/220) | Companion iPhone app for personalized HRTF via ear scanning |
+| [#221](https://github.com/Spatial-Media-Lab/OpenSpatialDelay/issues/221) | Spatial Media Library plugin suite — Reverb, Granular, Panner, Chorus (requires shared-core refactor) |
+| [#222](https://github.com/Spatial-Media-Lab/OpenSpatialDelay/issues/222) | ADM-OSC `/gain` and `/w` message support |
+| [#223](https://github.com/Spatial-Media-Lab/OpenSpatialDelay/issues/223) | Automated GitHub Release creation on tag push |
 
 ---
 
-## 13. Plugin Suite Roadmap
-
-All plugins share the `SpatialMediaLab/Core` engine and UI components.
-
-| Plugin | Description | Target |
-|--------|-------------|--------|
-| **OpenSpatialDelay** | Spatial delay with per-tap positioning | v0.1: Q1 2026 |
-| **OpenSpatialReverb** | Algorithmic reverb with spatial early reflections and diffuse tail positioning | 2027 |
-| **OpenSpatialGranular** | Granular synthesis/processing with grains positioned in 3D space (Sound Particles-inspired) | 2027 |
-| **OpenSpatialPanner** | Object-based spatial panner with energy distribution (Energy Panner-inspired). Trajectory automation, multi-source management | 2027 |
-| **OpenSpatialChorus** | Chorus/flanger with spatially distributed voices | 2027 |
-
-### Shared Core Components Across Suite
-
-| Component | Used By |
-|-----------|---------|
-| Spatialization algorithms (VBAP, HOA, DBAP, etc.) | All plugins |
-| Binaural renderer (HRTF convolution) | All plugins |
-| HRTF manager (SOFA loading, profile selection) | All plugins |
-| Speaker layout definitions | All plugins |
-| 2D spatial map UI component | All plugins |
-| Preset manager (JSON load/save) | All plugins |
-| Trajectory engine | Delay, Panner, Granular |
-| ADM-OSC transport (send/receive) | All plugins |
-| Look-and-feel / theme | All plugins |
-
----
-
-## 14. Appendices
+## 13. Appendices
 
 ### Appendix A: Academic References
 
@@ -982,97 +859,11 @@ All plugins share the `SpatialMediaLab/Core` engine and UI components.
 | HUTUBS PP2 | CC BY 4.0 | Yes (Brinkmann et al.) | Yes | Yes |
 | Bernschuetz KU100 | CC BY 3.0 | Yes (Bernschuetz) | Yes | Yes |
 
-### Appendix C: Docker Environment (Legacy Reference)
+### Appendix C: v1.0.0 Release Metadata
 
-The existing Docker environment (`Dockerfile`, `docker-compose.yml`, `setup-agent.sh`) was used for initial toolchain validation on ARM64/Linux. It successfully built a 64-channel test plugin but cannot produce macOS or Windows binaries. This environment is retained for reference but is **not part of the production build pipeline**. Native builds and GitHub Actions CI replace it going forward.
+v1.0.0 shipped on **2026-04-17** under the [`Spatial-Media-Lab/OpenSpatialDelay`](https://github.com/Spatial-Media-Lab/OpenSpatialDelay) organization, licensed GPL-3.0. The original v1.0.0 tag was re-cut from `768c248` to the post-#198 / post-#196 fix commit on 2026-04-17. The pre-retag commit is reachable at tag `v1.0.0-dev-baseline`. The archived personal repo at `AndrewRahman/OpenSpatialDelay` serves as a historical reference and URL redirect.
 
-### Appendix D: Existing Codebase Disposition
-
-The `Spatial64/` directory contains the proof-of-concept test plugin. Its code will **not be carried forward** directly. However, the following elements validated in that project inform the new architecture:
-
-| Validated Element | Carried Forward As |
-|-------------------|--------------------|
-| JUCE 8 CMake integration | Same pattern, expanded for multi-target builds |
-| 64-channel bus negotiation | Adapted for dynamic channel count |
-| `FloatVectorOperations` for SIMD | Core DSP pattern for all buffer operations |
-| Lock-free `processBlock` | Mandatory design constraint for all plugins |
-| `analyze_spatial.py` validation | Retained in test suite |
-
-### Appendix E: v1.0 Release & GitHub Migration Checklist
-
-This checklist covers the complete v1.0 release process, including freezing v0.9, migrating the repository to the Spatial Media Lab organization, and publishing the first public release.
-
-**Decisions finalized on 2026-03-18:**
-- **License:** GPL-3.0
-- **Repository:** Fresh repo under `github.com/Spatial-Media-Lab/OpenSpatialDelay` (not transfer)
-- **Git history:** Squash to single v1.0 commit for public repo; full dev history stays in archived private repo
-- **Downloads:** GitHub Releases page (not website)
-- **Visibility:** Public at v1.0 release
-
-#### Phase 1: Freeze v0.9
-
-Follow the Version Freeze SOP from CLAUDE.md:
-
-| Step | Action | Verify |
-|------|--------|--------|
-| 1 | Copy `Source/` files to `Archive/v0.9/` with version suffix | Files exist in archive |
-| 2 | `chmod a-w Archive/v0.9/*` | Files are read-only |
-| 3 | Build macOS Release: `cmake --build build --config Release` | AU + VST3 installed |
-| 4 | Copy built plugins to `Archive/v0.9/builds/` | Builds stored locally |
-| 5 | Update `PLUGIN_CODE` in CMakeLists.txt: `Osd9` → `Os10` | New plugin identity |
-| 6 | Update `docs/VERSION_HISTORY.md` and `CLAUDE.md` status section | Docs current |
-| 7 | Commit and push to `AndrewRahman/OpenSpatialDelay` | All changes on GitHub |
-| 8 | Wait for Windows CI: `gh run list --workflow=build-windows.yml --limit=1` | Build succeeds |
-| 9 | Download Windows VST3: `bash scripts/download_windows_build.sh` | Windows build in `build/windows/` |
-| 10 | Copy Windows build to `Archive/v0.9/builds/` | Both platforms archived |
-
-#### Phase 2: v1.0.0 Development
-
-v1.0.0 feature status:
-
-| Feature | Status | Notes |
-|---------|--------|-------|
-| Custom SOFA import | Deferred indefinitely | User loads own HRTF files — not shipping in v1.0.0 |
-| ADM-OSC Settings | Done | OSC enable/disable, IP/port in header bar; uses ADM-OSC for object positions |
-| AAX format | Deferred post-v1.0 | Pro Tools compatibility |
-| Code signing | Deferred post-v1.0 | macOS notarization + Windows EV cert |
-| User manual finalization | Done | PDF with glossary, signal flow diagram, annotated screenshots |
-
-#### Phase 3: GitHub Migration
-
-Execute when v1.0 is feature-complete and tested:
-
-| Step | Command | Verify |
-|------|---------|--------|
-| 1 | `gh auth refresh -h github.com -s admin:org,repo,delete_repo` | Auth succeeds |
-| 2 | `gh repo create Spatial-Media-Lab/OpenSpatialDelay --private --description "Spatial delay effect for 3D audio production — VST3 & AU" --homepage "https://spatialmedialab.org"` | Repo created |
-| 3 | `git remote rename origin personal` | Old remote preserved |
-| 4 | `git remote add origin https://github.com/Spatial-Media-Lab/OpenSpatialDelay.git` | New remote set |
-| 5 | `git push -u origin main` | Code pushed |
-| 6 | Verify CI triggers: `gh run list --repo Spatial-Media-Lab/OpenSpatialDelay --workflow=build-windows.yml --limit=1` | Windows build runs |
-| 7 | Verify download script: `bash scripts/download_windows_build.sh` | Downloads from new repo |
-| 8 | Update `CLAUDE.md` GitHub URL → `https://github.com/Spatial-Media-Lab/OpenSpatialDelay` | Reference updated |
-| 9 | Update `MEMORY.md` GitHub URL | Reference updated |
-
-#### Phase 4: Public Release
-
-| Step | Command / Action | Verify |
-|------|-----------------|--------|
-| 1 | Final macOS Release build + verify AU/VST3 install | Plugins work in Reaper |
-| 2 | Download final Windows build from CI | VST3 present |
-| 3 | Build final user manual PDF | PDF generated |
-| 4 | `gh repo edit Spatial-Media-Lab/OpenSpatialDelay --visibility public` | Repo is public |
-| 5 | `gh release create v1.0.0 --repo Spatial-Media-Lab/OpenSpatialDelay --title "v1.0.0" --notes "First public release"` | Release created |
-| 6 | Attach macOS + Windows builds to release | Both platforms downloadable |
-| 7 | Attach user manual PDF to release | Manual downloadable |
-| 8 | Verify LICENSE file visible at repo root | GPL-3.0 header |
-
-#### Phase 5: Archive Personal Repo
-
-| Step | Command | Verify |
-|------|---------|--------|
-| 1 | `gh repo edit AndrewRahman/OpenSpatialDelay --description "ARCHIVED — Moved to github.com/Spatial-Media-Lab/OpenSpatialDelay"` | Description updated |
-| 2 | Keep repo (do NOT delete) — serves as URL redirect and history archive | Accessible for reference |
+For version-by-version change history see [`docs/VERSION_HISTORY.md`](docs/VERSION_HISTORY.md). For the per-patch plugin-code registry used during active development see [`agent_docs/version_registry.md`](agent_docs/version_registry.md).
 
 ---
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -34,7 +34,8 @@
 - User-selectable spatialization algorithm — 7 options (Ambisonics, ConstantPower, DBAP, KNN, MDAP, VBAP, VBIP)
 - 6 binauralization options: 5 curated HRTF profiles from academically validated, freely licensed databases + 1 CPU-lite option (Woodworth ITD+ILD approximation, not an HRTF)
 - Up to 12 manually placeable delay taps, each with its own pitch shift, Doppler, and animated trajectory
-- 14 trajectory shapes for per-tap animation (Orbit, Figure-8, Spiral, Helix, Heart, Bounce, etc.)
+- 13 trajectory shapes for per-tap animation (Orbit, Figure-8, Spiral, Helix, Heart, Bounce, etc.), plus "None" for taps that stay fixed
+- 23 output formats (2 stereo, 15 surround, 6 Ambisonics orders)
 - ADM-OSC receive + send for interoperability with spatial audio renderers, plus an `/osd/` namespace for full parameter control
 - Stereo input with per-tap L / R / L+R channel selection
 - Open-source, licensed under GPL-3.0
@@ -94,7 +95,7 @@ OpenSpatialDelay/
 |   |                                  # delay taps, feedback, OSC, preset state
 |   |-- PluginEditor.h / .cpp          # UI, Colours_OSD palette, spatial map, controls
 |   |-- PhaseVocoderPitchShifter.h     # STFT pitch shifter (2048 FFT, 4x overlap, ±12 st)
-|   |-- TrajectoryEngine.h / .cpp      # 14 trajectory shapes for animated taps
+|   |-- TrajectoryEngine.h / .cpp      # 13 trajectory shapes for animated taps (+ "None" disabled state)
 |   |-- FilterBank.h / .cpp            # Feedback-path LP + HP biquads with resonance
 |   |-- DopplerVelocity.h / .cpp       # Per-tap Doppler pitch from position velocity
 |   |-- PresetData.h / .cpp            # 70 factory presets (C++ static structs)
@@ -143,17 +144,45 @@ OpenSpatialDelay/
 
 #### 3.4.2 Output Format
 
-The plugin auto-detects the output format from the host's track channel count. All speaker positions follow ITU-R BS.775 (ear-level) and BS.2051 (height) standards. Convention: 0° = front, positive azimuth = left.
+The plugin ships **23 output formats** (`NUM_OUTPUT_FORMATS` in `Source/PluginProcessor.h`). It auto-detects the active format from the host's track channel count and selects the matching entry from the `outputFormatRegistry`. All speaker positions follow ITU-R BS.775 (ear-level) and BS.2051 (height) standards. Convention: 0° = front, positive azimuth = left.
 
-| Output Format | Channels | Speaker Layout | LFE |
-|---------------|----------|----------------|-----|
-| Stereo (Binaural or encoded) | 2 | Binaural HRTF renderer (default), or one of: Equal Power, Stereo VBAP, XY, MS, Blumlein (selectable when bus is stereo) | No |
-| Quadraphonic | 4 | L(30°), R(-30°), Ls(110°), Rs(-110°) | No |
-| 5.1 Surround | 6 | L, R, C, Ls, Rs + LFE (ch3) | Yes |
-| 7.1 Surround | 8 | L, R, C, Lss(90°), Rss(-90°), Lsr(135°), Rsr(-135°) + LFE | Yes |
-| 7.1.4 (Atmos bed) | 12 | 7.1 ear-level + Tfl, Tfr, Trl, Trr at 45° elevation + LFE | Yes |
-| 9.1.6 (Atmos full) | 16 | 9.1 ear-level + Tfl, Tfr, Tsl, Tsr, Trl, Trr at 45° elevation + LFE | Yes |
-| Ambisonics (HOA) | 4 / 9 / 16 / 25 / 36 / 49 | 1st through 6th order spherical harmonic channels | No |
+**Stereo (2 formats)**
+
+| Output Format | Channels | Render Path |
+|---|---|---|
+| Binaural | 2 | HRTF convolution for each tap |
+| Stereo (encoded) | 2 | One of 5 mic-simulation modes (Equal Power, Stereo VBAP, XY, MS, Blumlein) selected via the algorithm parameter |
+
+**Surround (15 formats)**
+
+| Output Format | Channels | LFE | Height |
+|---|---|---|---|
+| Quadraphonic | 4 | No | No |
+| 5.0 Surround | 5 | No | No |
+| 5.1 Surround | 6 | Yes | No |
+| 7.0 Surround | 7 | No | No |
+| 7.1 Surround | 8 | Yes | No |
+| 9.1 Surround (ITU-R BS.2051 System H — ear-level) | 10 | Yes | No |
+| Octaphonic | 8 | No | No |
+| 5.1.2 | 8 | Yes | 2 |
+| 5.1.4 | 10 | Yes | 4 |
+| 7.1.2 | 10 | Yes | 2 |
+| 7.1.4 (Atmos bed) | 12 | Yes | 4 |
+| 7.1.6 | 14 | Yes | 6 |
+| 9.1.4 | 14 | Yes | 4 |
+| 9.1.6 (Atmos full) | 16 | Yes | 6 |
+| SML 13.1 (Spatial Media Lab Multi-Use Room) | 14 | Yes | 4 |
+
+**Ambisonics (6 formats, AmbiX ACN/SN3D)**
+
+| Output Format | Channels | Order |
+|---|---|---|
+| Ambisonics FOA | 4 | 1st |
+| Ambisonics SOA | 9 | 2nd |
+| Ambisonics HOA | 16 | 3rd |
+| Ambisonics 4OA | 25 | 4th |
+| Ambisonics 5OA | 36 | 5th |
+| Ambisonics 6OA | 49 | 6th |
 
 **Algorithm × Output Format compatibility:**
 
@@ -253,7 +282,7 @@ The plugin has 12 delay taps. Each tap has 10 APVTS parameters:
 | Distance | 0.0 – 1.0 | Normalized; drives distance attenuation + air absorption. |
 | Doppler Amount | 0.0 – 1.0 | Per-tap Doppler pitch from position velocity. |
 | Pitch Shift | −12 st – +12 st | Per-tap phase-vocoder pitch shift, additive with Global Tap Pitch. |
-| Trajectory Shape | 14 options: None, Orbit, Circle, Line, Bounce, Cross, Figure-8, Heart, Helix, Infinity, Random, Spiral, Square, Triangle | Animated trajectory. |
+| Trajectory Shape | None (disabled) + 13 shapes: Bounce, Circle, Cross, Figure-8, Heart, Helix, Infinity, Line, Orbit, Random, Spiral, Square, Triangle | "None" is the off state; selecting it disables trajectory animation for the tap. |
 | Trajectory Speed | 0.0 – 1.0 | Rate (multiplied by Global Tap Speed). |
 | Trajectory Direction | Forward / Reverse | Trajectory animation direction. |
 | Input Channel | L+R / L / R | Which input channel feeds this tap's delay line. |
@@ -262,7 +291,7 @@ The plugin has 12 delay taps. Each tap has 10 APVTS parameters:
 
 | Feature | Specification |
 |---|---|
-| Output formats | Stereo (binaural + 5 encoded stereo modes), Quad, 5.1, 7.1, 7.1.4, 9.1.6, plus 1st–6th order Ambisonics. See §3.4.2. |
+| Output formats | 23 total: 2 stereo (Binaural + encoded), 15 surround (Quad through 9.1.6 Atmos including the SML 13.1 layout), 6 Ambisonics (1st through 6th order). See §3.4.2. |
 | Spatialization algorithm | User-selectable: Ambisonics, ConstantPower, DBAP, KNN, MDAP, VBAP, VBIP (7 options). |
 | Binauralization options | 6 total — 5 HRTF profiles (Immersive, Natural, Precise, Spatial, Studio Reference) plus 1 CPU-lite "Simple (Low CPU)" Woodworth ITD+ILD option (not an HRTF). |
 | HRTF convolution | Partitioned FFT convolution with spectral-envelope EMA smoothing (magnitude + phase per bin) to prevent phase-misalignment comb filtering. |
@@ -592,7 +621,7 @@ Preset JSON carries the full APVTS state (23 globals + 10 × 12 per-tap params) 
 
 ### 9.2 Factory Presets
 
-v1.0.0 ships **70 factory presets** across **9 categories**:
+v1.0.0 ships **70 factory presets** across **8 curated categories**, plus a **User** category for user-created presets (empty at ship):
 
 | Category | Focus |
 |---|---|
@@ -604,7 +633,13 @@ v1.0.0 ships **70 factory presets** across **9 categories**:
 | Wobble + Modulated | Tape-style and LFO-driven wobble presets |
 | Creative + Experimental | Non-standard designs (gated, chaotic, glitch) |
 | Rhythmic | Tempo-synced grooves and polymetric patterns |
-| User | Empty at ship; fills with user-saved presets |
+| **User** (ships empty) | Users can save new presets from the plugin header preset menu at any time. User presets are saved as JSON under `~/Library/Audio/Presets/OpenSpatialDelay/User/` on macOS and are indistinguishable from factory presets to the loader. Users can also create their own custom categories. |
+
+### 9.3 User Preset Authoring
+
+- Save: header menu → **Save As** → name + category (pick an existing category or type a new one).
+- Delete / rename: edit the JSON file on disk, or use the header menu entries.
+- Share: user preset JSON files are plain text and portable between OSD installs.
 
 ---
 


### PR DESCRIPTION
## Summary

Parallel 4-agent audit of SPECIFICATION.md, CLAUDE.md, agent_docs/, and README.md against the v1.0.0 codebase, followed by ground-truth corrections and post-v1.0 feature extraction into tracked GitHub issues. Goal: one coherent source of truth before shipping goes wider.

## What changed

**SPECIFICATION.md** — 575 lines removed, 366 added (1079 → 889 lines). Rewrites applied to every section that had drifted:

- §1 executive summary updated to v1.0.0 actuals (23 output formats, 13 trajectory shapes, etc.)
- §3.2 replaced the aspirational \`SpatialMediaLab/Core/\` multi-plugin tree with the actual flat \`Source/\` layout
- §3.4.1 stereo-input row: removed \"summed to mono / independent L+R deferred to v1.0\"; stereo with per-tap channel selection is live
- §3.4.2 enumerated all 23 output formats (2 stereo / 15 surround / 6 Ambisonics) as three explicit tables
- §4.1 rewrote the global-parameter table to cover all 23 APVTS globals with correct ranges + defaults (HP 50 Hz, LP 5000 Hz, input gain max +40 dB, HP/LP Q, Filter On, Wobble On/Amount/Morph, Air Absorption, 6 Global Tap Offsets)
- §4.2 per-tap params: added Doppler, Pitch Shift, Trajectory Shape, Trajectory Speed/Direction, Input Channel (10 × 12 = 120 per-tap params)
- §5 signal flow: removed the incorrect \`N × P\` cumulative-pitch claim — each tap uses its own stored pitch; updated the ASCII diagram to name all 7 algorithms and the 4 output render paths
- §6.2 added MDAP + ConstantPower; removed \"Future\" tag on DBAP
- §7.1 HRTF profiles reordered to match code (index 0 Simple CPU-lite, 1 Immersive, 2 Natural, 3 Precise, 4 Spatial, 5 Studio Reference)
- §8 UI Design: replaced the wrong palette (\`#0A0A14\` etc.) and Inter font with actual \`Colours_OSD\` tokens and DM Sans / JetBrains Mono / Roboto; deleted the v0.1-era 800×500 ASCII layout mock
- §9 Preset System: replaced JSON-files-in-Resources description + 8-preset table with actual format (C++ static structs, JSON install) and **70 factory presets across 8 curated categories plus a User category for user-created presets** (added §9.3 User Preset Authoring)
- §10 ADM-OSC: removed \`/gain\` and \`/w\` rows (not implemented — tracked in #222); corrected send port to 4003; removed v0.3/v1.0 tags (both shipped); added \`/osd/\` namespace section with full address list
- §11.4 Code signing: replaced inline discussion with pointer to #217
- §12 \"Versioned Roadmap\" → \"Release History & Post-v1.0 Backlog\": collapsed per-phase roadmap tables into a release summary; post-v1.0 features tracked as #217–#223
- §13 \"Plugin Suite Roadmap\": deleted — tracked as #221
- §14 Appendices: kept A + B; replaced C (Docker legacy), D (Spatial64 POC), E (v1.0 release checklist) with a single Appendix C of v1.0.0 release metadata

**CLAUDE.md** — HRTF count clarified: \"6 profiles\" → \"5 SOFA files + Woodworth CPU-lite fallback (6 binauralization options total)\".

**README.md** — removed \"cumulative pitch shifting across taps\" (misleading v0.x phrasing); corrected to per-tap phase-vocoder shift. Trajectory count 14 → 13. Preset line mentions User category + custom categories.

## Post-v1.0 features filed as GitHub issues (and removed from docs)

- #217 Code signing (macOS notarization + Windows EV)
- #218 Custom SOFA file import
- #219 AAX plugin format
- #220 Companion iPhone HRTF-scanning app
- #221 Spatial Media Library plugin suite expansion
- #222 ADM-OSC \`/gain\` and \`/w\` support
- #223 Automated GitHub Release creation on tag push

## Test plan

Docs-only change. No build / test / runtime impact. Review for:

- [ ] SPECIFICATION.md now matches the v1.0.0 code
- [ ] CLAUDE.md / README.md consistent with SPECIFICATION.md
- [ ] Post-v1.0 items have GH issue coverage (#217–#223)
- [ ] Trajectory count reads as 13 shapes (with \"None\" as disabled state)
- [ ] Output formats enumerated to 23 total
- [ ] Preset section mentions both the 70 factory presets and user save/load

🤖 Generated with [Claude Code](https://claude.com/claude-code)