### PR TITLE
docs(03.1): Phase 3.1 Release Readiness context

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,11 +3,11 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: executing
-stopped_at: "Phase 02 Plan 05 — Sender design pass mid-pivot. Site-side A2 CSS injection implemented (+184 lines in andrewrahman-com/components/DownloadForm.tsx, dirty working tree) but scope exceeds ideal. User direction (final this session): move bulk of styling to Sender account-level Brand Settings (applies to ALL forms + emails, minimises site coupling to Sender class names). Chrome confirmed open+logged-in at https://app.sender.net/forms/builder/bkRxov. Chrome drive helpers pre-written + verified at /tmp/osdchrome/{run.sh, click.sh, js.js}. Sender ToS fetched — zero free-tier branding clauses. `next dev` may still be running on :3000."
-last_updated: "2026-04-24T16:53:55.766Z"
+stopped_at: Phase 3.1 context gathered
+last_updated: "2026-04-25T09:11:25.139Z"
 last_activity: 2026-04-24 -- Phase --phase execution started
 progress:
-  total_phases: 5
+  total_phases: 6
   completed_phases: 2
   total_plans: 31
   completed_plans: 28
@@ -140,8 +140,8 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-04-24T16:45:00.000Z
-Stopped at: Phase 02 Plan 05 — Sender design pass mid-pivot. Site-side A2 CSS injection implemented (+184 lines in andrewrahman-com/components/DownloadForm.tsx, dirty working tree) but scope exceeds ideal. User direction (final this session): move bulk of styling to Sender account-level Brand Settings (applies to ALL forms + emails, minimises site coupling to Sender class names). Chrome confirmed open+logged-in at https://app.sender.net/forms/builder/bkRxov. Chrome drive helpers pre-written + verified at /tmp/osdchrome/{run.sh, click.sh, js.js}. Sender ToS fetched — zero free-tier branding clauses. `next dev` may still be running on :3000.
+Last session: --stopped-at
+Stopped at: Phase 3.1 context gathered
 Resume files:
 
   - PRIMARY: .planning/phases/02-email-capture-funding-infrastructure/02-05-SENDER-DESIGN-HANDOFF.md (paste-ready design tokens + full Chrome-drive walkthrough + post-dashboard cleanup plan)

--- a/.planning/phases/03.1-release-readiness/03.1-CONTEXT.md
+++ b/.planning/phases/03.1-release-readiness/03.1-CONTEXT.md
@@ -1,0 +1,118 @@
+# Phase 3.1: Release Readiness — Context
+
+**Gathered:** 2026-04-25
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Phase 3.1 prepares OpenSpatialDelay for public launch. Four work streams: (1) clean the SML GitHub repo of internal planning artifacts and make it public, (2) build release binaries for both macOS and Windows, (3) polish the site's primary CTAs for stronger visual hierarchy, and (4) tidy the planning state for the final push to Phase 5. This phase blocks Phase 5 (launch announcements).
+
+**Scope anchor:** repo-going-public gate + binary builds + CTA polish + planning hygiene.
+
+**Out of scope:** New site features, new plugin features, Sender.net form design work (that's Plan 02-05), Netlify migration (that's Plan 02-04), demo content (Phase 4).
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Repo cleanup (D-01 through D-03)
+
+- **D-01:** History rewrite using `git filter-repo` or BFG Repo-Cleaner to scrub `.planning/`, `.claude/`, `agent_docs/`, and `CLAUDE.md` from all commits in the SML repo. Force-push to main after rewrite. The repo is currently private with no external clones, so the destructive rewrite is safe.
+- **D-02:** Before executing the rewrite, Claude scans the repo for any additional non-source artifacts (build caches, session files, editor configs, etc.) and flags them for inclusion in the scrub list. The user approves the final list before the rewrite runs.
+- **D-03:** After the history rewrite, make the SML repo public. No download URLs need updating — plugin binaries are served through the site CDN (Netlify or Cloudflare), not GitHub Releases. GitHub is source code only.
+
+### Release binaries (D-04, D-05)
+
+- **D-04:** Two platform builds required before launch: **macOS arm64** (AU + VST3) and **Windows x64** (VST3 only).
+- **D-05:** macOS build is **arm64-only** — no universal binary. Intel Mac support is not a launch priority.
+
+### CTA visual polish (D-06)
+
+- **D-06:** Download and demo CTAs need stronger visual weight compared to Patreon. **Claude's discretion** — the planner/executor has creative freedom to propose and implement visual treatments within the existing design language and locked palette (primary cyan `#80d8ff`, secondary green `#3BCE6C`). Goal: the site's primary conversion actions (download + demo) should visually dominate over the secondary Patreon CTA.
+
+### Planning state cleanup (D-07 through D-09)
+
+- **D-07:** Trim `STATE.md` to current status only. The accumulated verbose session history (decision logs, session timestamps, blocker narratives) is moved to a separate `STATE-ARCHIVE.md` file — preserved but out of the active working document.
+- **D-08:** Archive completed phase directories (Phase 1, Phase 2) to an archive location. Keeps the active `.planning/phases/` directory focused on in-progress and upcoming work.
+- **D-09:** Update `ROADMAP.md` progress table and any stale status markers as part of the tidy.
+
+### Claude's Discretion
+
+- Specific visual treatment for CTA polish (D-06) — size, animation, spacing, contrast, or layout changes
+- Which additional non-source artifacts to flag during the repo scan (D-02)
+- Archive folder structure for completed phases (D-08)
+- How aggressively to trim STATE.md vs what to preserve (D-07)
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Repo cleanup
+- `.planning/ROADMAP.md` §Phase 03.1 — goal and dependency on Phase 3
+- `~/.claude/projects/.../memory/project_repo_migration.md` — repo cleanup scope: strip .planning/agent_docs, make public, build binaries
+- `~/.claude/projects/.../memory/feedback_download_distribution.md` — downloads via site CDN, NOT GitHub Releases
+
+### Release binaries
+- `agent_docs/version_registry.md` — current version registry, build naming rules
+- `scripts/build_version.sh` — build script for versioned plugins
+- `.planning/PROJECT.md` §Validated — platform targets (VST3+AU macOS, VST3 Windows)
+- `~/.claude/projects/.../memory/project_version_e15b.md` — v1.0.0 release state, squash commit 768c248
+- `~/.claude/projects/.../memory/project_build_system.md` — JUCE 8.0.3, CMake, Windows CI
+
+### CTA visual polish
+- `~/.claude/projects/.../memory/project_cta_polish.md` — Download+demo CTAs need stronger visual weight
+- `~/.claude/projects/.../memory/project_andrewrahman_site_cta_palette.md` — locked palette: cyan download, green Patreon
+- `.planning/phases/03-personal-website/03-CONTEXT.md` — Phase 3 site decisions (design tokens, section architecture)
+
+### Planning state
+- `.planning/STATE.md` — current state (to be trimmed)
+- `.planning/ROADMAP.md` — progress table (to be updated)
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `scripts/build_version.sh` — versioned build script for macOS (already used for v1.0.0 arm64 build)
+- Windows CI pipeline — referenced in `project_build_system.md` memory; cross-platform build infrastructure exists
+- Site section-component architecture (13 top-level components in `page.tsx`) — CTA polish targets existing components, no new sections needed
+
+### Established Patterns
+- Version registry in `agent_docs/version_registry.md` — all builds tracked with version/hash/format
+- `.gitignore` does NOT currently exclude `.planning/`, `.claude/`, or `agent_docs/` — these are tracked (169 files). The history rewrite removes them from all commits rather than just gitignoring going forward.
+- Git filter-repo is the modern replacement for BFG — preferred for path-based filtering
+
+### Integration Points
+- SML GitHub repo (`Spatial-Media-Lab/OpenSpatialDelay`) — currently private, target of the cleanup + public flip
+- `andrewrahman-com` site repo (sibling directory) — CTA polish changes land here
+- Netlify/Cloudflare CDN — binary hosting (no changes needed for repo cleanup)
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- User explicitly chose history rewrite over simple deletion — wants a clean public history with no trace of planning artifacts
+- User confirmed arm64-only for Mac (no universal binary) — "Most Mac users have M-series now, keeps it simple"
+- User wants STATE.md history preserved in a separate archive file, not deleted — values the record but wants it out of the active document
+- User correction (captured in feedback memory): downloads go through site CDN, never frame GitHub Releases as the download path
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+None — discussion stayed within phase scope.
+
+</deferred>
+
+---
+
+*Phase: 03.1-release-readiness*
+*Context gathered: 2026-04-25*

--- a/.planning/phases/03.1-release-readiness/03.1-DISCUSSION-LOG.md
+++ b/.planning/phases/03.1-release-readiness/03.1-DISCUSSION-LOG.md
@@ -1,0 +1,95 @@
+# Phase 3.1: Release Readiness - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-04-25
+**Phase:** 03.1-release-readiness
+**Areas discussed:** Repo cleanup strategy, CTA visual treatment, Release binary scope, Planning state tidy-up
+
+---
+
+## Repo Cleanup Strategy
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| New commit | Delete files in a single commit on main. Simple but leaves artifacts in git history. | |
+| History rewrite | Use git filter-repo or BFG to scrub paths from all past commits. Clean public history, destructive. | ✓ |
+| Fresh orphan branch | Create new branch with only clean files, force-push as new main. | |
+
+**User's choice:** History rewrite
+**Notes:** User also chose "Let Claude scan for other non-source artifacts and flag them before the rewrite." Follow-up about v1.0.0 tag/release revealed a repeated misunderstanding — downloads go through site CDN, not GitHub Releases. Correction recorded in feedback memory.
+
+---
+
+## CTA Visual Treatment
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Bigger + bolder | Increase button size, font weight, or padding | |
+| Animation/glow | Add subtle pulse, shimmer, or glow effect | |
+| Layout restructure | Rearrange hero section for more CTA prominence | |
+| Let Claude decide | Creative freedom within existing design language | ✓ |
+
+**User's choice:** Let Claude decide
+**Notes:** Planner has full creative freedom within locked palette (cyan download, green Patreon).
+
+---
+
+## Release Binary Scope
+
+### Platform builds
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| macOS only (arm64 + x86_64 universal) | Ship Mac first, add Windows later | |
+| macOS + Windows | Both platforms ready at launch | ✓ |
+| macOS arm64 only (current) | Don't rebuild, launch with what exists | |
+
+**User's choice:** macOS + Windows — both platforms at launch
+
+### macOS architecture
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Universal binary | arm64 + x86_64 in one file | |
+| arm64-only | Apple Silicon only | ✓ |
+
+**User's choice:** arm64-only — "Most Mac users have M-series now, keeps it simple"
+
+---
+
+## Planning State Tidy-up
+
+### Cleanup scope
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Trim STATE.md | Cut verbose session history to current status only | |
+| Archive completed phases | Move Phase 1/2 artifacts to archive folder | |
+| Full tidy | Both: trim STATE.md AND archive completed phases | ✓ |
+| Let Claude decide | Clean up whatever looks messy | |
+
+**User's choice:** Full tidy
+
+### STATE.md history disposition
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Deleted | All in git history if needed | |
+| Moved to separate file | Archive to STATE-ARCHIVE.md | ✓ |
+
+**User's choice:** Moved to STATE-ARCHIVE.md
+
+---
+
+## Claude's Discretion
+
+- CTA visual treatment approach (size, animation, spacing, contrast, layout)
+- Additional non-source artifacts to flag during repo scan
+- Archive folder structure for completed phases
+- STATE.md trimming aggressiveness
+
+## Deferred Ideas
+
+None — discussion stayed within phase scope.


### PR DESCRIPTION
## Summary
- Captured implementation decisions for Phase 3.1 (Release Readiness) via discuss-phase workflow
- 9 decisions across 4 areas: repo cleanup (history rewrite), release binaries (macOS arm64 + Windows x64), CTA visual polish, planning state tidy-up
- Updated STATE.md with session pointer

## Test plan
- [ ] Verify CONTEXT.md decisions are clear enough for downstream planning agents
- [ ] Verify DISCUSSION-LOG.md captures all alternatives considered

🤖 Generated with [Claude Code](https://claude.com/claude-code)